### PR TITLE
fix: remove YAML-breaking backticks from AI review workflow

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -102,13 +102,8 @@ Repo context for relevance:
 - Security: never log secrets; SQL must be parameterized; RLS respected; idempotent jobs via (job_type,payload_hash) unique.
 - UX: keep dashboards responsive; avoid heavy client bundles.
 
-Output format (JSON in markdown code block):
-```json
-{
-  "BLOCKERS": [{"file": "path/to/file.js", "lines": "128-140", "type": "security|bug|perf", "why": "explanation", "patch": "suggested fix"}],
-  "NON_BLOCKING": [{"file": "path/to/file.js", "lines": "50-52", "type": "style|test", "why": "explanation", "patch": "suggested fix"}]
-}
-```
+Output format: Return JSON with two arrays - BLOCKERS and NON_BLOCKING.
+Each finding should have: file, lines, type, why, and patch fields.
 If nothing to report, return empty arrays for both sections.
 EOF
 


### PR DESCRIPTION
Fixes the YAML syntax error on line 106 that was preventing the AI code review workflow from running.

**Problem:** Triple backticks and curly braces in the heredoc were breaking YAML parsing.

**Solution:** Replaced the JSON example with a simple text description of the expected format.

**Impact:** Workflow will now validate and run on pull requests.

This needs to be merged ASAP so PR #5 can get its AI review.