### PR TITLE
TTRC-193: Revert to production styling with RSS enrichment (v2)

### DIFF
--- a/public/story-styles.css
+++ b/public/story-styles.css
@@ -1,477 +1,55 @@
-/* Story View Styles - Matching prototype design with responsive grid and accessible components */
+/* Story View Styles - Production-style single-column layout with dark theme */
 
-/* Feed Container */
+/* Feed Container - Single column layout */
 .tt-feed {
-  max-width: 1400px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 24px;
 }
 
-/* Responsive Grid - 3 columns → 2 columns → 1 column */
+/* Single Column Grid */
 .tt-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 20px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-@media (max-width: 1200px) {
-  .tt-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
 @media (max-width: 768px) {
-  .tt-grid {
-    grid-template-columns: 1fr;
-  }
   .tt-feed {
     padding: 16px;
   }
-}
-
-/* Story Card */
-.tt-card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
-  padding: 16px;
-  transition: box-shadow 0.2s ease;
-}
-
-.tt-card:hover {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07);
-}
-
-/* Card Header (clickable area) */
-.tt-card-head {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  cursor: pointer;
-  user-select: none;
-}
-
-.tt-card-head:focus {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-/* QA FIX: Headlines clamped to 3 lines + word wrap for long text */
-.tt-card-headline h2 {
-  font-size: 20px;
-  font-weight: 800;
-  margin: 0;
-  line-height: 1.3;
-  color: #0f172a;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  word-break: break-word;
-}
-
-.tt-meta {
-  margin-top: 8px;
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  color: #475569;
-  font-size: 13px;
-  align-items: center;
-}
-
-/* Severity Badge - Spicy labels in UPPERCASE */
-.tt-badge {
-  display: inline-block;
-  color: #fff;
-  border-radius: 999px;
-  padding: 2px 10px;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.tt-status {
-  background: #f1f5f9;
-  color: #334155;
-  padding: 2px 8px;
-  border-radius: 6px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-/* Chevron Icon */
-.tt-chevron {
-  font-size: 24px;
-  color: #94a3b8;
-  transition: transform 0.2s ease;
-  line-height: 1;
-}
-
-.tt-chevron.rot {
-  transform: rotate(180deg);
-}
-
-/* Card Body (expandable content) */
-.tt-card-body {
-  max-height: 0;
-  overflow: hidden;
-  opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
-}
-
-.tt-card-body.open {
-  max-height: 2000px;
-  opacity: 1;
-  margin-top: 12px;
-}
-
-/* QA FIX: Spicy Summary with scroll for long content + word wrap */
-.tt-summary {
-  background: #f8f9fa;
-  border-left: 3px solid #e5e7eb;
-  padding: 12px;
-  border-radius: 8px;
-  color: #374151;
-  line-height: 1.6;
-  margin: 0;
-  white-space: pre-wrap;
-  max-height: 400px;
-  overflow-y: auto;
-  word-break: break-word;
-}
-
-/* Action Buttons */
-.tt-actions {
-  margin-top: 12px;
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.tt-btn {
-  padding: 8px 14px;
-  border: 1px solid #cbd5e1;
-  background: #fff;
-  color: #0f172a;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  text-decoration: none;
-  transition: all 0.2s ease;
-  display: inline-block;
-}
-
-.tt-btn:hover {
-  background: #f8fafc;
-  border-color: #94a3b8;
-}
-
-.tt-btn:focus {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
-}
-
-.tt-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  background: #e2e8f0;
-  color: #94a3b8;
-}
-
-.tt-btn-primary {
-  background: #0f172a;
-  color: #fff;
-  border-color: #0f172a;
-}
-
-.tt-btn-primary:hover {
-  background: #1e293b;
-}
-
-.tt-btn-primary:disabled {
-  background: #cbd5e1;
-  border-color: #cbd5e1;
-  color: #94a3b8;
-}
-
-/* Receipts Section */
-.tt-receipts {
-  margin-top: 12px;
-  font-size: 12px;
-  color: #64748b;
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  border-top: 1px solid #f1f5f9;
-  padding-top: 10px;
-  align-items: center;
-}
-
-.tt-receipts strong {
-  color: #334155;
-  font-weight: 600;
-}
-
-.tt-chip {
-  background: #f1f5f9;
-  color: #334155;
-  padding: 3px 9px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.tt-more {
-  color: #64748b;
-  font-style: italic;
-  font-size: 11px;
-}
-
-/* Modal Styles */
-.tt-modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 20px;
-}
-
-.tt-modal {
-  background: #fff;
-  width: 90%;
-  max-width: 600px;
-  max-height: 80vh;
-  overflow: auto;
-  border-radius: 12px;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2);
-}
-
-.tt-modal:focus {
-  outline: none;
-}
-
-/* QA FIX: Visible focus ring for modal elements */
-.tt-modal a:focus,
-.tt-modal button:focus {
-  outline: 2px solid #94a3b8;
-  outline-offset: 2px;
-}
-
-.tt-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  border-bottom: 1px solid #e5e7eb;
-  position: sticky;
-  top: 0;
-  background: #fff;
-  z-index: 10;
-}
-
-.tt-modal-title {
-  font-weight: 700;
-  font-size: 18px;
-  margin: 0;
-  color: #0f172a;
-}
-
-.tt-modal-close {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 0;
-  background: #f1f5f9;
-  cursor: pointer;
-  font-size: 24px;
-  line-height: 1;
-  color: #64748b;
-  transition: all 0.2s ease;
-}
-
-.tt-modal-close:hover {
-  background: #e2e8f0;
-  color: #334155;
-}
-
-.tt-modal-body {
-  padding: 16px;
-}
-
-.tt-modal-headline {
-  font-size: 14px;
-  font-weight: 600;
-  color: #0f172a;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid #e5e7eb;
-}
-
-.tt-source-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 0;
-  border-bottom: 1px solid #f1f5f9;
-}
-
-.tt-source-row:last-child {
-  border-bottom: none;
-}
-
-.tt-source-name {
-  font-weight: 700;
-  color: #0f172a;
-  font-size: 14px;
-}
-
-.tt-source-meta {
-  font-size: 12px;
-  color: #64748b;
-  margin-top: 2px;
-}
-
-.tt-source-title {
-  margin-top: 4px;
-  font-size: 13px;
-  color: #475569;
-  line-height: 1.4;
-}
-
-.tt-source-link {
-  color: #2563eb;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 14px;
-  white-space: nowrap;
-  flex-shrink: 0;
-  transition: color 0.2s ease;
-}
-
-.tt-source-link:hover {
-  color: #1d4ed8;
-  text-decoration: underline;
-}
-
-.tt-modal-note {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid #f1f5f9;
-  font-size: 12px;
-  color: #64748b;
-  font-style: italic;
-}
-
-/* Loading States */
-.tt-skeletons {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
-}
-
-@media (max-width: 1200px) {
-  .tt-skeletons {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .tt-grid {
+    gap: 16px;
   }
 }
 
-@media (max-width: 768px) {
-  .tt-skeletons {
-    grid-template-columns: 1fr;
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-.tt-skel {
-  height: 180px;
-  background: linear-gradient(90deg, #e5e7eb, #f1f5f9, #e5e7eb);
-  background-size: 200% 100%;
-  animation: tt-shimmer 1.5s infinite;
-  border-radius: 12px;
-}
-
-@keyframes tt-shimmer {
-  0% {
-    background-position: 200% 0;
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
   }
-  100% {
-    background-position: -200% 0;
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-/* Error State */
-.tt-error {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 12px;
-  border-radius: 8px;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
+/* Smooth transitions for filter changes */
+.filter-transition {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.tt-error .tt-btn {
-  background: #fff;
-  color: #991b1b;
-  border-color: #fca5a5;
-  padding: 6px 12px;
-  font-size: 13px;
-}
-
-.tt-error .tt-btn:hover {
-  background: #fef2f2;
-}
-
-/* Empty State */
-.tt-empty {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  padding: 48px 24px;
-  border-radius: 12px;
-  text-align: center;
-  color: #475569;
-}
-
-.tt-empty h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #0f172a;
-  margin: 0 0 8px 0;
-}
-
-.tt-empty p {
-  font-size: 14px;
-  margin: 0;
-}
-
-/* Load More Button Container */
-.tt-load-more {
-  display: flex;
-  justify-content: center;
-  margin: 24px 0;
-}
-
-.tt-load-more .tt-btn-primary {
-  padding: 10px 24px;
-  font-size: 15px;
-}
-
-/* End of Feed Message */
-.tt-end {
-  text-align: center;
-  color: #64748b;
-  font-size: 14px;
-  margin: 24px 0;
-  padding: 12px;
-}
+/* Cards now use Tailwind classes in story-card.js */
+/* Modal styles handled inline in component */


### PR DESCRIPTION
## Summary
Reverts TEST story cards to production-style single-column layout while displaying all RSS enrichment fields.

**Note:** This supersedes closed PR #8 (had merge conflict with PR #5). Same changes, clean merge from updated test branch.

## Changes
✅ **Production Styling Applied:**
- Single-column card layout (removed 3-column grid)
- Dark theme: `bg-gray-800/50` with blue accents
- Production-matching animations and hover states

✅ **All Enrichment Fields Displayed:**
- **Summary**: Fallback chain (spicy → neutral → headline → "No summary available")
- **Primary Actor**: Displayed in metadata line
- **Severity Badges**: Color-coded pills (red/orange/yellow/green)
- **Category**: Displayed with severity
- **Source Count**: Clickable to open sources modal
- **Updated Time**: Relative time ago with tooltip

✅ **Modal Enhancements:**
- Duplicate fetch prevention (guard check)
- Error state with retry button
- Empty state with informative message
- Dark themed to match cards

✅ **Skipped per PM Decision:**
- AI badge (removed from requirements in JIRA comments)

## Files Modified
- `public/story-card.js` - Complete rewrite with production component structure
- `public/story-styles.css` - Single-column layout + animations

## Testing
- [ ] Cards display in single column
- [ ] All enrichment fields visible (summary, actor, severity, category)
- [ ] Modal opens without duplicate fetches
- [ ] Error states show with retry functionality
- [ ] Dark theme matches production styling

## Related
- JIRA: TTRC-193
- Parent: TTRC-148 (Story Enrichment)
- Supersedes: PR #8 (closed due to merge conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>