### PR TITLE
fix(ci): add ENVIRONMENT/TARGET_ENV to daily/EO tracker workflows

### DIFF
--- a/.github/workflows/daily-tracker.yml
+++ b/.github/workflows/daily-tracker.yml
@@ -31,7 +31,17 @@ jobs:
           echo "environment=production" >> $GITHUB_OUTPUT
           echo "🚀 Using PRODUCTION environment"
         fi
-      
+
+    - name: Export env (prod|test)
+      run: |
+        if [ "${{ steps.env_detect.outputs.environment }}" = "production" ]; then
+          echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+          echo "TARGET_ENV=prod" >> $GITHUB_ENV
+        else
+          echo "ENVIRONMENT=test" >> $GITHUB_ENV
+          echo "TARGET_ENV=test" >> $GITHUB_ENV
+        fi
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/executive-orders-tracker.yml
+++ b/.github/workflows/executive-orders-tracker.yml
@@ -32,6 +32,16 @@ jobs:
           echo "🚀 Using PRODUCTION environment"
         fi
 
+    - name: Export env (prod|test)
+      run: |
+        if [ "${{ steps.env_detect.outputs.environment }}" = "production" ]; then
+          echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+          echo "TARGET_ENV=prod" >> $GITHUB_ENV
+        else
+          echo "ENVIRONMENT=test" >> $GITHUB_ENV
+          echo "TARGET_ENV=test" >> $GITHUB_ENV
+        fi
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Problem
Daily Tracker and EO Tracker failing since Jan 8 with:
```
Error: Missing TARGET_ENV or ENVIRONMENT (prod|test)
```

This is a regression from TTRC-362 PROD hardening (PR #31) which introduced `validateEnv()` requiring `ENVIRONMENT` or `TARGET_ENV`, but these two workflows weren't updated.

## Timeline
- **Jan 7 16:35:** Last successful runs (both workflows)
- **Jan 7 22:39:** PR #31 merged (TTRC-362 PROD hardening)  
- **Jan 8 14:31:** Daily Tracker failed
- **Jan 8 16:34:** EO Tracker failed

## Fix
Add "Export env (prod|test)" step after `env_detect` in both workflows:
- Sets both `ENVIRONMENT` and `TARGET_ENV` (validates with either)
- Uses `$GITHUB_ENV` (available to all subsequent steps, not just one)

## Verification
After merge, manually trigger both workflows:
```bash
gh workflow run "Daily Political Tracker" --ref main
gh workflow run "Track Executive Orders" --ref main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)