### PR TITLE
ci: add Perplexity research workflow (ADO-253)

### DIFF
--- a/.github/workflows/research-pardons.yml
+++ b/.github/workflows/research-pardons.yml
@@ -23,6 +23,10 @@ on:
         required: false
         default: "false"
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: research-pardons-test
   cancel-in-progress: true
@@ -32,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/test'
     timeout-minutes: 10
+    environment:
+      name: test
 
     steps:
       - name: Checkout code
@@ -52,13 +58,22 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_TEST_SERVICE_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           RUN_ID: ${{ github.run_id }}
+        shell: bash
         run: |
-          ARGS="--limit=${{ inputs.limit }}"
-          if [ "${{ inputs.force }}" = "true" ]; then
-            ARGS="$ARGS --force"
+          set -Eeuo pipefail
+          LIMIT="${{ inputs.limit }}"
+          FORCE="${{ inputs.force }}"
+          # Validate numeric limit to avoid shell/arg injection
+          if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+            echo "Invalid limit: $LIMIT" >&2
+            exit 2
           fi
-          echo "Running: node scripts/enrichment/perplexity-research.js $ARGS"
-          node scripts/enrichment/perplexity-research.js $ARGS
+          ARGS=( "--limit=$LIMIT" )
+          if [[ "$FORCE" == "true" ]]; then
+            ARGS+=( "--force" )
+          fi
+          echo "Running: node scripts/enrichment/perplexity-research.js ${ARGS[*]}"
+          node scripts/enrichment/perplexity-research.js "${ARGS[@]}"
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/research-pardons.yml
+++ b/.github/workflows/research-pardons.yml
@@ -25,10 +25,10 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  actions: read
 
 concurrency:
-  group: research-pardons-test
+  group: research-pardons-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -63,6 +63,10 @@ jobs:
           set -Eeuo pipefail
           LIMIT="${{ inputs.limit }}"
           FORCE="${{ inputs.force }}"
+          # Default limit if not provided
+          if [[ -z "${LIMIT:-}" ]]; then
+            LIMIT="20"
+          fi
           # Validate numeric limit to avoid shell/arg injection
           if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
             echo "Invalid limit: $LIMIT" >&2

--- a/.github/workflows/research-pardons.yml
+++ b/.github/workflows/research-pardons.yml
@@ -28,7 +28,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: research-pardons-${{ github.ref }}
+  group: research-pardons-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -71,6 +71,12 @@ jobs:
           if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
             echo "Invalid limit: $LIMIT" >&2
             exit 2
+          fi
+          # Cap limit to avoid accidental high-cost runs (92 pardons total)
+          MAX_LIMIT=100
+          if (( LIMIT > MAX_LIMIT )); then
+            echo "Limit $LIMIT exceeds max $MAX_LIMIT; capping to $MAX_LIMIT." >&2
+            LIMIT="$MAX_LIMIT"
           fi
           ARGS=( "--limit=$LIMIT" )
           if [[ "$FORCE" == "true" ]]; then

--- a/.github/workflows/research-pardons.yml
+++ b/.github/workflows/research-pardons.yml
@@ -1,0 +1,69 @@
+# Research Pardons (Perplexity) - ADO-253
+#
+# Manual-only workflow (no cron) because:
+# - Cron runs from default branch (main), not test
+# - We want to control when research runs during testing
+#
+# Usage:
+#   gh workflow run "Research Pardons (Perplexity)" --ref test
+#   gh workflow run "Research Pardons (Perplexity)" --ref test -f limit=5
+#   gh workflow run "Research Pardons (Perplexity)" --ref test -f limit=92 -f force=true
+
+name: Research Pardons (Perplexity)
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Max pardons to research this run"
+        required: false
+        default: "20"
+      force:
+        description: "Force re-research even if already complete"
+        required: false
+        default: "false"
+
+concurrency:
+  group: research-pardons-test
+  cancel-in-progress: true
+
+jobs:
+  research:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/test'
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Research pardons
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_TEST_SERVICE_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          ARGS="--limit=${{ inputs.limit }}"
+          if [ "${{ inputs.force }}" = "true" ]; then
+            ARGS="$ARGS --force"
+          fi
+          echo "Running: node scripts/enrichment/perplexity-research.js $ARGS"
+          node scripts/enrichment/perplexity-research.js $ARGS
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: research-logs-${{ github.run_id }}
+          path: '*.log'
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds manual-only workflow for Perplexity pardon research
- Has branch guard: only runs when triggered with `--ref test`
- Required on main for `workflow_dispatch` to be discoverable

## Test plan
- [ ] AI code review passes
- [ ] Merge, then trigger with `gh workflow run "Research Pardons (Perplexity)" --ref test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)