### PR TITLE
fix: use correct GitHub secret names

### DIFF
--- a/.github/workflows/enrich-pardons.yml
+++ b/.github/workflows/enrich-pardons.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           # Use PROD secrets on main, TEST secrets on test
           SUPABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_URL || secrets.SUPABASE_TEST_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_TEST_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_SERVICE_KEY || secrets.SUPABASE_TEST_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RUN_ID: ${{ github.run_id }}
           INPUT_LIMIT: ${{ inputs.limit }}

--- a/.github/workflows/research-pardons.yml
+++ b/.github/workflows/research-pardons.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           # Use PROD secrets on main, TEST secrets on test
           SUPABASE_URL: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_URL || secrets.SUPABASE_TEST_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_TEST_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ github.ref == 'refs/heads/main' && secrets.SUPABASE_SERVICE_KEY || secrets.SUPABASE_TEST_SERVICE_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           RUN_ID: ${{ github.run_id }}
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,22 @@ WHERE day = CURRENT_DATE;
 
 **NEVER merge test→main. Always cherry-pick tested commits.**
 
+### GitHub Secrets (EXACT names)
+| Secret | Purpose |
+|--------|---------|
+| `SUPABASE_URL` | PROD Supabase URL |
+| `SUPABASE_SERVICE_KEY` | PROD service role key |
+| `SUPABASE_ANON_KEY` | PROD anon key |
+| `SUPABASE_TEST_URL` | TEST Supabase URL |
+| `SUPABASE_TEST_SERVICE_KEY` | TEST service role key |
+| `SUPABASE_TEST_ANON_KEY` | TEST anon key |
+| `OPENAI_API_KEY` | OpenAI (shared) |
+| `PERPLEXITY_API_KEY` | Perplexity (shared) |
+| `EDGE_CRON_TOKEN` | Edge function auth (TEST) |
+| `EDGE_CRON_TOKEN_PROD` | Edge function auth (PROD) |
+
+**Important:** Workflows use `SUPABASE_SERVICE_KEY` not `SUPABASE_SERVICE_ROLE_KEY`.
+
 ## Development Commands
 
 ### Local Development


### PR DESCRIPTION
Fix SUPABASE_SERVICE_KEY (not SUPABASE_SERVICE_ROLE_KEY) + document secrets in CLAUDE.md