### PR TITLE
fix(eo-tracker): ADO-267 fix EO tracker crash on new orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ supabase/.temp/
 _ul*
 _UL*
 tmpclaude-*
+
+# Environment marker (should only exist on test branch, never main)
+TEST_BRANCH_MARKER.md

--- a/TEST_BRANCH_MARKER.md
+++ b/TEST_BRANCH_MARKER.md
@@ -1,6 +1,0 @@
-# TEST BRANCH MARKER
-
-This file indicates that this is the TEST branch.
-When this file exists, the system will use TEST database credentials.
-
-DO NOT commit this file to the main branch!

--- a/scripts/executive-orders-tracker-supabase.js
+++ b/scripts/executive-orders-tracker-supabase.js
@@ -47,11 +47,10 @@ async function generateAIAnalysis(title, orderNumber, abstract = '') {
             severity_rating: 'medium',
             policy_direction: 'modify',
             implementation_timeline: 'ongoing',
-            impact_areas: [],
-            full_text_available: true
+            impact_areas: []
         };
     }
-    
+
     try {
         const response = await fetch('https://api.openai.com/v1/chat/completions', {
             method: 'POST',
@@ -76,8 +75,7 @@ Provide a JSON response with these exact fields:
   "severity_rating": "low|medium|high based on scope and impact",
   "policy_direction": "expand|restrict|modify|create|eliminate",
   "implementation_timeline": "immediate|30_days|90_days|ongoing",
-  "impact_areas": ["list of policy areas affected like immigration, economy, healthcare, etc"],
-  "full_text_available": true
+  "impact_areas": ["list of policy areas affected like immigration, economy, healthcare, etc"]
 }
 
 Respond ONLY with valid JSON.`
@@ -95,8 +93,7 @@ Respond ONLY with valid JSON.`
                 severity_rating: 'medium',
                 policy_direction: 'modify',
                 implementation_timeline: 'ongoing',
-                impact_areas: [],
-                full_text_available: true
+                impact_areas: []
             };
         }
 
@@ -113,11 +110,10 @@ Respond ONLY with valid JSON.`
                 severity_rating: 'medium',
                 policy_direction: 'modify',
                 implementation_timeline: 'ongoing',
-                impact_areas: [],
-                full_text_available: true
+                impact_areas: []
             };
         }
-        
+
     } catch (error) {
         console.log(`   ⚠️ Error generating AI analysis: ${error.message}`);
         return {
@@ -125,8 +121,7 @@ Respond ONLY with valid JSON.`
             severity_rating: 'medium',
             policy_direction: 'modify',
             implementation_timeline: 'ongoing',
-            impact_areas: [],
-            full_text_available: true
+            impact_areas: []
         };
     }
 }
@@ -330,7 +325,6 @@ async function fetchFromFederalRegister() {
                     policy_direction: aiAnalysis ? aiAnalysis.policy_direction : 'modify',
                     implementation_timeline: aiAnalysis ? aiAnalysis.implementation_timeline : 'ongoing',
                     impact_areas: aiAnalysis ? aiAnalysis.impact_areas : [],
-                    full_text_available: aiAnalysis ? aiAnalysis.full_text_available : true,
                     type: 'executive_order',
                     legal_challenges: [],
                     related_orders: [],


### PR DESCRIPTION
## Summary
- **Remove TEST_BRANCH_MARKER.md from main** - File was causing PROD workflow to incorrectly use TEST database credentials
- **Add TEST_BRANCH_MARKER.md to .gitignore** - Prevents future accidental commits to main
- **Remove `full_text_available` field from EO script** - Field never existed in DB schema (latent bug since Aug 2025)

## Root Cause
EO tracker has been failing since Jan 13 when new Executive Orders (14372, 14373) were signed. Two bugs:

1. `TEST_BRANCH_MARKER.md` on main caused env detection to pick TEST DB for PROD runs
2. Script tried to save `full_text_available` field that doesn't exist in schema

Bug was dormant since Aug 2025 because no new EOs were issued - the save code path was never hit until Jan 13.

## Test plan
- [ ] Verify EO tracker workflow runs successfully after merge
- [ ] Confirm new EOs (14372, 14373) are saved to PROD database
- [ ] Verify TEST_BRANCH_MARKER.md no longer exists on main

## ADO
Fixes [ADO-267](https://dev.azure.com/AJWolfe92/TTracker/_workitems/edit/267)

🤖 Generated with [Claude Code](https://claude.ai/code)