### PR TITLE
fix(eo-tracker): ADO-267 add SERVICE_ROLE_KEY for write permissions

### DIFF
--- a/.github/workflows/executive-orders-tracker.yml
+++ b/.github/workflows/executive-orders-tracker.yml
@@ -55,6 +55,7 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         SUPABASE_URL: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_URL || secrets.SUPABASE_URL }}
         SUPABASE_ANON_KEY: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_ANON_KEY || secrets.SUPABASE_ANON_KEY }}
+        SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_SERVICE_KEY || secrets.SUPABASE_SERVICE_KEY }}
       run: node scripts/executive-orders-tracker-supabase.js
 
     - name: Commit any changes (minimal, since data is in Supabase)


### PR DESCRIPTION
## Summary
Adds `SUPABASE_SERVICE_ROLE_KEY` env var to EO tracker workflow for write permissions.

## Problem
Workflow was only passing `SUPABASE_ANON_KEY` which has read-only access due to RLS policies. Write operations failed with `permission denied for table executive_orders`.

## Fix
Added `SUPABASE_SERVICE_ROLE_KEY` env mapping so the config can use it for POST/PUT/PATCH/DELETE operations.

## ADO
Part of [ADO-267](https://dev.azure.com/AJWolfe92/TTracker/_workitems/edit/267)

🤖 Generated with [Claude Code](https://claude.ai/code)