### PR TITLE
fix: switch CDN from unpkg to jsdelivr for faster page loads

### DIFF
--- a/public/admin-supabase.html
+++ b/public/admin-supabase.html
@@ -11,9 +11,9 @@
     <script src="admin-config.js" onerror="console.warn('Admin config not found - using default config');"></script>
     
     <!-- React for better state management -->
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     
     <style>
         body {

--- a/public/admin.html
+++ b/public/admin.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TrumpyTracker Admin</title>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
     <style>
         body {
             margin: 0;

--- a/public/executive-orders.html
+++ b/public/executive-orders.html
@@ -12,12 +12,12 @@
   <!-- Theme CSS Variables -->
   <link rel="stylesheet" href="./themes.css">
 
-  <!-- React 18 CDN -->
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <!-- React 18 CDN (jsdelivr - more reliable than unpkg) -->
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
 
   <!-- Babel for JSX (dev mode) -->
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
 
   <!-- Prevent FOUC: Set theme immediately -->
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -12,12 +12,12 @@
   <!-- Theme CSS Variables -->
   <link rel="stylesheet" href="./themes.css">
 
-  <!-- React 18 CDN -->
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <!-- React 18 CDN (jsdelivr - more reliable than unpkg) -->
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
 
   <!-- Babel for JSX (dev mode) -->
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone/babel.min.js"></script>
 
   <!-- Prevent FOUC: Set theme immediately -->
   <script>

--- a/public/pardons.html
+++ b/public/pardons.html
@@ -12,13 +12,13 @@
   <!-- Theme CSS Variables -->
   <link rel="stylesheet" href="./themes.css">
 
-  <!-- React 18 CDN (pinned to exact version for security) -->
-  <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+  <!-- React 18 CDN (jsdelivr - more reliable than unpkg, pinned versions for security) -->
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18.3.1/umd/react.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
 
   <!-- Babel for JSX transformation (pinned version for security)
        Note: Required for type="text/babel" scripts. Future optimization: pre-compile JSX. -->
-  <script src="https://unpkg.com/@babel/standalone@7.24.0/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.24.0/babel.min.js"></script>
 
   <!-- Prevent FOUC: Set theme immediately -->
   <script>


### PR DESCRIPTION
## Summary
- Switch React, ReactDOM, and Babel CDN from unpkg.com to jsdelivr.net
- unpkg.com was experiencing 80+ second response times causing both TEST and PROD sites to hang on load
- jsdelivr has more reliable global CDN infrastructure

## Changes
- index.html
- executive-orders.html
- pardons.html (with pinned versions preserved)
- admin.html
- admin-supabase.html

## Test plan
- [x] Verified on TEST environment - page loads quickly now
- [x] Code review passed (feature-dev:code-reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)