### PR TITLE
feat: Admin Dashboard — Stories & Pardons CRUD + Re-Enrichment (ADO-333/335-339)

### DIFF
--- a/migrations/081_admin_content_history.sql
+++ b/migrations/081_admin_content_history.sql
@@ -1,0 +1,47 @@
+-- Migration: 081_admin_content_history.sql
+-- Purpose: Create admin schema and content_history table for undo support
+-- ADO: Feature 328, Story 337
+
+-- Create admin schema for admin-only tables
+CREATE SCHEMA IF NOT EXISTS admin;
+
+-- Content history table for tracking all field changes (enables undo)
+CREATE TABLE IF NOT EXISTS admin.content_history (
+  id BIGSERIAL PRIMARY KEY,
+  entity_type TEXT NOT NULL,        -- 'story', 'article', 'pardon', 'eo', 'feed', 'scotus'
+  entity_id TEXT NOT NULL,          -- ID as text (handles bigint and uuid)
+  field_name TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT,
+  changed_by TEXT,                  -- GitHub username or 'system'
+  changed_at TIMESTAMPTZ DEFAULT NOW(),
+  change_source TEXT DEFAULT 'admin' -- 'admin', 'pipeline', 'api', 'undo'
+);
+
+-- Index for quick lookups of entity history (most recent first)
+CREATE INDEX IF NOT EXISTS idx_content_history_entity
+ON admin.content_history(entity_type, entity_id, changed_at DESC);
+
+-- Index for cleanup job (90-day retention)
+CREATE INDEX IF NOT EXISTS idx_content_history_changed_at
+ON admin.content_history(changed_at DESC);
+
+-- Enable RLS - only service_role can access
+ALTER TABLE admin.content_history ENABLE ROW LEVEL SECURITY;
+
+-- Drop policy if exists (for idempotency)
+DROP POLICY IF EXISTS "Service role only" ON admin.content_history;
+
+-- Only service_role can access content history
+CREATE POLICY "Service role only" ON admin.content_history
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Grant access to service_role
+GRANT ALL ON admin.content_history TO service_role;
+GRANT USAGE ON SCHEMA admin TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE admin.content_history_id_seq TO service_role;
+
+COMMENT ON TABLE admin.content_history IS 'Tracks all field-level changes for undo support. Retained for 90 days.';
+COMMENT ON COLUMN admin.content_history.entity_type IS 'Type of entity: story, article, pardon, eo, feed, scotus';
+COMMENT ON COLUMN admin.content_history.entity_id IS 'ID of the entity (as text to handle various ID types)';
+COMMENT ON COLUMN admin.content_history.change_source IS 'Source of change: admin, pipeline, api, undo';

--- a/migrations/082_admin_action_log.sql
+++ b/migrations/082_admin_action_log.sql
@@ -1,0 +1,48 @@
+-- Migration: 082_admin_action_log.sql
+-- Purpose: Create action_log table for admin audit trail
+-- ADO: Feature 328, Story 337
+
+-- Action audit log - tracks all admin actions
+CREATE TABLE IF NOT EXISTS admin.action_log (
+  id BIGSERIAL PRIMARY KEY,
+  session_id UUID,                  -- Group related actions (optional)
+  user_id TEXT NOT NULL,            -- GitHub username
+  action TEXT NOT NULL,             -- 'create', 'update', 'delete', 're-enrich', 'bulk_update', 'undo'
+  entity_type TEXT NOT NULL,        -- 'story', 'article', 'pardon', 'eo', 'feed', 'scotus'
+  entity_id TEXT,                   -- Single entity
+  entity_ids TEXT[],                -- For bulk operations
+  details JSONB,                    -- Action-specific metadata
+  ip_address TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for user activity lookup
+CREATE INDEX IF NOT EXISTS idx_action_log_user
+ON admin.action_log(user_id, created_at DESC);
+
+-- Index for entity-specific activity
+CREATE INDEX IF NOT EXISTS idx_action_log_entity
+ON admin.action_log(entity_type, entity_id);
+
+-- Index for recent activity (cleanup job)
+CREATE INDEX IF NOT EXISTS idx_action_log_created
+ON admin.action_log(created_at DESC);
+
+-- Enable RLS - only service_role can access
+ALTER TABLE admin.action_log ENABLE ROW LEVEL SECURITY;
+
+-- Drop policy if exists (for idempotency)
+DROP POLICY IF EXISTS "Service role only" ON admin.action_log;
+
+-- Only service_role can access action log
+CREATE POLICY "Service role only" ON admin.action_log
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Grant access to service_role
+GRANT ALL ON admin.action_log TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE admin.action_log_id_seq TO service_role;
+
+COMMENT ON TABLE admin.action_log IS 'Audit log of all admin actions. Retained for 90 days.';
+COMMENT ON COLUMN admin.action_log.action IS 'Type of action: create, update, delete, re-enrich, bulk_update, undo';
+COMMENT ON COLUMN admin.action_log.details IS 'Action-specific metadata (e.g., estimated_cost for re-enrich)';

--- a/migrations/083_admin_rpc_functions.sql
+++ b/migrations/083_admin_rpc_functions.sql
@@ -1,0 +1,133 @@
+-- Migration: 083_admin_rpc_functions.sql
+-- Purpose: Create RPC functions for content history logging and undo
+-- ADO: Feature 328, Story 337
+
+-- Function to log a content change
+CREATE OR REPLACE FUNCTION log_content_change(
+  p_entity_type text,
+  p_entity_id text,
+  p_field_name text,
+  p_old_value text,
+  p_new_value text,
+  p_changed_by text,
+  p_change_source text DEFAULT 'admin'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO admin.content_history (
+    entity_type, entity_id, field_name,
+    old_value, new_value, changed_by, change_source
+  ) VALUES (
+    p_entity_type, p_entity_id, p_field_name,
+    p_old_value, p_new_value, p_changed_by, p_change_source
+  );
+END;
+$$;
+
+-- Function to undo the most recent change for an entity
+CREATE OR REPLACE FUNCTION undo_content_change(
+  p_entity_type text,
+  p_entity_id text,
+  p_changed_by text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_history admin.content_history%ROWTYPE;
+  v_table_name text;
+BEGIN
+  -- Get most recent change for this entity
+  SELECT * INTO v_history
+  FROM admin.content_history
+  WHERE entity_type = p_entity_type
+    AND entity_id = p_entity_id
+  ORDER BY changed_at DESC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No history found');
+  END IF;
+
+  -- Map entity type to table name
+  v_table_name := CASE p_entity_type
+    WHEN 'story' THEN 'stories'
+    WHEN 'pardon' THEN 'pardons'
+    WHEN 'scotus' THEN 'scotus_cases'
+    WHEN 'eo' THEN 'executive_orders'
+    WHEN 'feed' THEN 'feed_registry'
+    WHEN 'article' THEN 'articles'
+    ELSE NULL
+  END;
+
+  IF v_table_name IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unknown entity type');
+  END IF;
+
+  -- Execute the undo (articles use TEXT id, others use BIGINT)
+  IF p_entity_type = 'article' THEN
+    EXECUTE format(
+      'UPDATE %I SET %I = $1 WHERE id = $2',
+      v_table_name, v_history.field_name
+    ) USING v_history.old_value, p_entity_id;
+  ELSE
+    EXECUTE format(
+      'UPDATE %I SET %I = $1 WHERE id = $2',
+      v_table_name, v_history.field_name
+    ) USING v_history.old_value, p_entity_id::bigint;
+  END IF;
+
+  -- Log the undo as a new change (creates audit trail)
+  INSERT INTO admin.content_history (
+    entity_type, entity_id, field_name,
+    old_value, new_value, changed_by, change_source
+  ) VALUES (
+    p_entity_type, p_entity_id, v_history.field_name,
+    v_history.new_value, v_history.old_value, p_changed_by, 'undo'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'field', v_history.field_name,
+    'restored_value', v_history.old_value
+  );
+END;
+$$;
+
+-- Function to log an admin action (for audit trail)
+CREATE OR REPLACE FUNCTION log_admin_action(
+  p_user_id text,
+  p_action text,
+  p_entity_type text,
+  p_entity_id text DEFAULT NULL,
+  p_entity_ids text[] DEFAULT NULL,
+  p_details jsonb DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO admin.action_log (
+    user_id, action, entity_type, entity_id, entity_ids, details
+  ) VALUES (
+    p_user_id, p_action, p_entity_type, p_entity_id, p_entity_ids, p_details
+  );
+END;
+$$;
+
+-- Grant execute to authenticated role (functions use SECURITY DEFINER)
+GRANT EXECUTE ON FUNCTION log_content_change TO authenticated;
+GRANT EXECUTE ON FUNCTION undo_content_change TO authenticated;
+GRANT EXECUTE ON FUNCTION log_admin_action TO authenticated;
+
+-- Grant undo to anon role (admin.html uses anon key, admin password check is at edge function level)
+GRANT EXECUTE ON FUNCTION undo_content_change TO anon;
+
+COMMENT ON FUNCTION log_content_change IS 'Logs a field-level change for undo support';
+COMMENT ON FUNCTION undo_content_change IS 'Undoes the most recent change for an entity, returns the restored value';
+COMMENT ON FUNCTION log_admin_action IS 'Logs an admin action for audit trail';

--- a/public/admin.html
+++ b/public/admin.html
@@ -376,14 +376,14 @@
         }
         .stories-table th {
             text-align: left;
-            padding: 10px 12px;
+            padding: 10px 8px;
             color: #94a3b8;
             font-weight: 500;
             border-bottom: 1px solid #334155;
             white-space: nowrap;
         }
         .stories-table td {
-            padding: 12px;
+            padding: 10px 8px;
             border-bottom: 1px solid #1e293b;
             vertical-align: top;
         }
@@ -449,6 +449,305 @@
         .story-detail-content a { color: #3b82f6; text-decoration: none; }
         .story-detail-content a:hover { text-decoration: underline; }
 
+        /* Modal Styles */
+        .modal-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            padding: 20px;
+        }
+        .modal-content {
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 12px;
+            width: 100%;
+            max-width: 800px;
+            max-height: 90vh;
+            overflow-y: auto;
+        }
+        .modal-header {
+            padding: 20px;
+            border-bottom: 1px solid #334155;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .modal-title {
+            font-size: 18px;
+            font-weight: 600;
+            margin: 0;
+            color: #f8fafc;
+        }
+        .modal-close {
+            background: none;
+            border: none;
+            color: #94a3b8;
+            font-size: 24px;
+            cursor: pointer;
+            padding: 4px;
+            line-height: 1;
+        }
+        .modal-close:hover { color: #f8fafc; }
+        .modal-body { padding: 20px; }
+        .modal-footer {
+            padding: 16px 20px;
+            border-top: 1px solid #334155;
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+        .form-group {
+            margin-bottom: 16px;
+        }
+        .form-label {
+            display: block;
+            font-size: 13px;
+            color: #94a3b8;
+            margin-bottom: 6px;
+        }
+        .form-input, .form-select, .form-textarea {
+            width: 100%;
+            padding: 10px 12px;
+            background: #0f172a;
+            border: 1px solid #334155;
+            border-radius: 8px;
+            color: #e2e8f0;
+            font-size: 14px;
+        }
+        .form-input:focus, .form-select:focus, .form-textarea:focus {
+            outline: none;
+            border-color: #3b82f6;
+        }
+        .form-textarea {
+            resize: vertical;
+            min-height: 80px;
+        }
+        .form-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+        .btn-primary {
+            padding: 10px 20px;
+            background: #3b82f6;
+            border: none;
+            border-radius: 8px;
+            color: white;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .btn-primary:hover { background: #2563eb; }
+        .btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+        .btn-secondary {
+            padding: 10px 20px;
+            background: #334155;
+            border: none;
+            border-radius: 8px;
+            color: #e2e8f0;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .btn-secondary:hover { background: #475569; }
+
+        /* Toast Styles */
+        .toast-container {
+            position: fixed;
+            bottom: 24px;
+            right: 24px;
+            z-index: 1100;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .toast {
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 8px;
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            min-width: 280px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            animation: slideIn 0.3s ease;
+        }
+        @keyframes slideIn {
+            from { transform: translateX(100%); opacity: 0; }
+            to { transform: translateX(0); opacity: 1; }
+        }
+        .toast-success { border-left: 3px solid #4ade80; }
+        .toast-error { border-left: 3px solid #f87171; }
+        .toast-info { border-left: 3px solid #3b82f6; }
+        .toast-message { flex: 1; color: #e2e8f0; font-size: 14px; }
+        .toast-close {
+            background: none;
+            border: none;
+            color: #64748b;
+            cursor: pointer;
+            font-size: 18px;
+            padding: 0;
+            line-height: 1;
+        }
+        .toast-close:hover { color: #94a3b8; }
+
+        /* Undo Toast (special toast with countdown) */
+        .undo-toast {
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-left: 3px solid #3b82f6;
+            border-radius: 8px;
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            min-width: 320px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            animation: slideIn 0.3s ease;
+        }
+        .undo-toast-message {
+            flex: 1;
+            color: #e2e8f0;
+            font-size: 14px;
+        }
+        .undo-toast-btn {
+            padding: 6px 14px;
+            background: #3b82f6;
+            border: none;
+            border-radius: 6px;
+            color: white;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .undo-toast-btn:hover { background: #2563eb; }
+        .undo-toast-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+        .undo-countdown {
+            font-size: 11px;
+            color: #94a3b8;
+            min-width: 24px;
+            text-align: center;
+        }
+
+        /* Row Action Buttons */
+        .row-actions {
+            display: flex;
+            gap: 6px;
+            white-space: nowrap;
+        }
+        .btn-icon {
+            padding: 6px 10px;
+            background: #334155;
+            border: none;
+            border-radius: 6px;
+            color: #e2e8f0;
+            font-size: 12px;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .btn-icon:hover { background: #475569; }
+        .btn-icon:disabled { opacity: 0.5; cursor: not-allowed; }
+        .btn-icon.enriching {
+            background: #3b82f6;
+            color: white;
+        }
+        .btn-icon .spinner-sm {
+            width: 12px;
+            height: 12px;
+            border: 2px solid rgba(255,255,255,0.3);
+            border-top-color: white;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        /* Collapsible Form Sections */
+        .form-section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 0;
+            margin: 8px 0 12px;
+            border-bottom: 1px solid #334155;
+            cursor: pointer;
+            user-select: none;
+        }
+        .form-section-header:hover { color: #f8fafc; }
+        .form-section-header h4 {
+            margin: 0;
+            font-size: 14px;
+            font-weight: 600;
+            color: #94a3b8;
+        }
+        .form-section-header:hover h4 { color: #e2e8f0; }
+        .form-section-arrow {
+            font-size: 12px;
+            color: #64748b;
+            transition: transform 0.2s;
+        }
+        .form-section-arrow.open { transform: rotate(90deg); }
+
+        /* Checkbox row for multi-select */
+        .form-checkbox-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 6px;
+        }
+        .form-checkbox {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            background: #0f172a;
+            border: 1px solid #334155;
+            border-radius: 6px;
+            font-size: 13px;
+            color: #94a3b8;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .form-checkbox:hover { border-color: #3b82f6; color: #e2e8f0; }
+        .form-checkbox.checked {
+            background: rgba(59, 130, 246, 0.15);
+            border-color: #3b82f6;
+            color: #e2e8f0;
+        }
+        .form-checkbox input[type="checkbox"] {
+            accent-color: #3b82f6;
+            cursor: pointer;
+        }
+
+        /* JSON textarea error states */
+        .json-error {
+            border-color: #ef4444 !important;
+        }
+        .json-error:focus {
+            border-color: #ef4444 !important;
+            box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
+        }
+        .json-error-msg {
+            color: #fca5a5;
+            font-size: 12px;
+            margin-top: 4px;
+        }
+
         /* Responsive */
         @media (max-width: 900px) {
             .dashboard-grid { grid-template-columns: 1fr; }
@@ -479,6 +778,822 @@
         // Session storage key for admin password
         const AUTH_STORAGE_KEY = 'admin_password';
 
+        // Toast notification context and component
+        const ToastContext = React.createContext();
+
+        function ToastProvider({ children }) {
+            const [toasts, setToasts] = useState([]);
+
+            const addToast = useCallback((message, type = 'info', duration = 5000) => {
+                const id = Date.now();
+                setToasts(prev => [...prev, { id, message, type }]);
+                if (duration > 0) {
+                    setTimeout(() => {
+                        setToasts(prev => prev.filter(t => t.id !== id));
+                    }, duration);
+                }
+                return id;
+            }, []);
+
+            const removeToast = useCallback((id) => {
+                setToasts(prev => prev.filter(t => t.id !== id));
+            }, []);
+
+            return React.createElement(ToastContext.Provider, { value: { addToast, removeToast } },
+                children,
+                React.createElement('div', { className: 'toast-container' },
+                    toasts.map(toast =>
+                        React.createElement('div', { key: toast.id, className: `toast toast-${toast.type}` },
+                            React.createElement('span', { className: 'toast-message' }, toast.message),
+                            React.createElement('button', {
+                                className: 'toast-close',
+                                onClick: () => removeToast(toast.id)
+                            }, '×')
+                        )
+                    )
+                )
+            );
+        }
+
+        function useToast() {
+            return React.useContext(ToastContext);
+        }
+
+        // Undo Toast Component - special toast with 10-second countdown and Undo button
+        function UndoToast({ entityType, entityId, fieldName, oldValue, onUndo, onDismiss }) {
+            const [timeLeft, setTimeLeft] = React.useState(10);
+            const [undoing, setUndoing] = React.useState(false);
+
+            React.useEffect(() => {
+                const timer = setInterval(() => {
+                    setTimeLeft(t => {
+                        if (t <= 1) {
+                            onDismiss();
+                            return 0;
+                        }
+                        return t - 1;
+                    });
+                }, 1000);
+
+                return () => clearInterval(timer);
+            }, [onDismiss]);
+
+            const handleUndo = async () => {
+                setUndoing(true);
+                try {
+                    await onUndo();
+                    onDismiss();
+                } catch {
+                    setUndoing(false);
+                }
+            };
+
+            return React.createElement('div', { className: 'undo-toast' },
+                React.createElement('span', { className: 'undo-toast-message' },
+                    `Updated ${fieldName.replace(/_/g, ' ')}`
+                ),
+                React.createElement('button', {
+                    className: 'undo-toast-btn',
+                    onClick: handleUndo,
+                    disabled: undoing
+                },
+                    undoing ? 'Undoing...' : 'Undo',
+                    React.createElement('span', { className: 'undo-countdown' }, `(${timeLeft}s)`)
+                ),
+                React.createElement('button', {
+                    className: 'toast-close',
+                    onClick: onDismiss
+                }, '×')
+            );
+        }
+
+        // Category options for stories
+        const STORY_CATEGORIES = [
+            { value: 'corruption_scandals', label: 'Corruption & Scandals' },
+            { value: 'democracy_elections', label: 'Democracy & Elections' },
+            { value: 'policy_legislation', label: 'Policy & Legislation' },
+            { value: 'justice_legal', label: 'Justice & Legal' },
+            { value: 'executive_actions', label: 'Executive Actions' },
+            { value: 'foreign_policy', label: 'Foreign Policy' },
+            { value: 'corporate_financial', label: 'Corporate & Financial' },
+            { value: 'civil_liberties', label: 'Civil Liberties' },
+            { value: 'media_disinformation', label: 'Media & Disinformation' },
+            { value: 'epstein_associates', label: 'Epstein & Associates' },
+            { value: 'other', label: 'Other' }
+        ];
+
+        const ALARM_LEVEL_OPTIONS = [
+            { value: '5', label: 'Constitutional Dumpster Fire' },
+            { value: '4', label: 'Criminal Bullshit' },
+            { value: '3', label: 'The Deep Swamp' },
+            { value: '2', label: 'The Great Gaslight' },
+            { value: '1', label: 'Accidental Sanity' },
+            { value: '0', label: 'A Broken Clock Moment' }
+        ];
+        const ALARM_LEVEL_MAP = Object.fromEntries(ALARM_LEVEL_OPTIONS.map(o => [o.value, o.label]));
+
+        const STATUS_OPTIONS = [
+            { value: 'active', label: 'Active' },
+            { value: 'closed', label: 'Closed' },
+            { value: 'archived', label: 'Archived' }
+        ];
+
+        const LIFECYCLE_OPTIONS = [
+            { value: 'emerging', label: 'Emerging' },
+            { value: 'developing', label: 'Developing' },
+            { value: 'mature', label: 'Mature' }
+        ];
+
+        // Edit Story Modal Component
+        function EditStoryModal({ story, onClose, onSave, onShowUndo, onRefresh, supabase, password }) {
+            const [formData, setFormData] = useState({
+                primary_headline: story?.primary_headline || '',
+                primary_source: story?.primary_source || '',
+                primary_source_url: story?.primary_source_url || '',
+                primary_actor: story?.primary_actor || '',
+                status: story?.status || 'active',
+                alarm_level: story?.alarm_level ?? '',
+                category: story?.category || '',
+                summary_spicy: story?.summary_spicy || ''
+            });
+            const [saving, setSaving] = useState(false);
+            const [error, setError] = useState(null);
+            const [isConflict, setIsConflict] = useState(false);
+
+            // Capture original last_updated_at for optimistic locking
+            const originalLastUpdatedAt = story?.last_updated_at;
+
+            // Escape key closes modal
+            useEffect(() => {
+                const handler = (e) => { if (e.key === 'Escape') onClose(); };
+                document.addEventListener('keydown', handler);
+                return () => document.removeEventListener('keydown', handler);
+            }, [onClose]);
+
+            const handleChange = (field, value) => {
+                setFormData(prev => ({ ...prev, [field]: value }));
+            };
+
+            const handleSubmit = async (e) => {
+                e.preventDefault();
+                setSaving(true);
+                setError(null);
+
+                try {
+                    // Prepare update payload - only include changed fields
+                    const updates = {};
+                    if (formData.primary_headline !== story.primary_headline) updates.primary_headline = formData.primary_headline;
+                    if (formData.primary_source !== story.primary_source) updates.primary_source = formData.primary_source;
+                    if (formData.primary_source_url !== story.primary_source_url) updates.primary_source_url = formData.primary_source_url;
+                    if (formData.primary_actor !== story.primary_actor) updates.primary_actor = formData.primary_actor || null;
+                    if (formData.status !== story.status) updates.status = formData.status;
+                    const newAlarmLevelEdit = formData.alarm_level === '' ? null : parseInt(formData.alarm_level, 10);
+                    const oldAlarmLevelEdit = story.alarm_level ?? null;
+                    if (newAlarmLevelEdit !== oldAlarmLevelEdit) updates.alarm_level = newAlarmLevelEdit;
+                    if (formData.category !== story.category) updates.category = formData.category || null;
+
+                    if (formData.summary_spicy !== (story.summary_spicy || '')) updates.summary_spicy = formData.summary_spicy || null;
+
+                    if (Object.keys(updates).length === 0) {
+                        onClose();
+                        return;
+                    }
+
+                    // Update story via authenticated edge function with optimistic locking
+                    const { data, error: updateError } = await supabase.functions.invoke(
+                        'admin-update-story',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                story_id: story.id,
+                                updates,
+                                original_last_updated_at: originalLastUpdatedAt
+                            }
+                        }
+                    );
+
+                    if (updateError) {
+                        // Supabase-js wraps non-2xx as FunctionsHttpError — extract body for conflict check
+                        let body = data;
+                        try {
+                            if (!body && updateError.context) body = await updateError.context.json();
+                        } catch (_) {}
+
+                        if (body?.conflict) {
+                            setIsConflict(true);
+                            setError(body.error || 'Record was modified by another process. Close and refresh to get the latest data.');
+                            setSaving(false);
+                            return;
+                        }
+                        throw new Error(body?.error || updateError.message || 'Update failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    // Get the first changed field for undo toast
+                    const changedFields = data.changed_fields || {};
+                    const firstChangedField = Object.keys(changedFields)[0];
+
+                    onSave(data.story, firstChangedField ? {
+                        entityType: 'story',
+                        entityId: String(story.id),
+                        fieldName: firstChangedField,
+                        oldValue: changedFields[firstChangedField]?.old
+                    } : null);
+                } catch (err) {
+                    console.error('Save error:', err);
+                    setError(err.message || 'Failed to save changes');
+                } finally {
+                    setSaving(false);
+                }
+            };
+
+            return React.createElement('div', { className: 'modal-overlay' },
+                React.createElement('div', { className: 'modal-content' },
+                    React.createElement('div', { className: 'modal-header' },
+                        React.createElement('h3', { className: 'modal-title' }, 'Edit Story #' + story.id),
+                        React.createElement('button', { className: 'modal-close', onClick: onClose }, '×')
+                    ),
+                    React.createElement('form', { onSubmit: handleSubmit },
+                        React.createElement('div', { className: 'modal-body' },
+                            error && React.createElement('div', { className: 'error-banner', style: { marginBottom: '16px' } },
+                                error,
+                                isConflict && React.createElement('button', {
+                                    type: 'button',
+                                    className: 'btn-primary',
+                                    style: { marginLeft: '12px', padding: '4px 12px', fontSize: '13px' },
+                                    onClick: () => { onRefresh && onRefresh(); onClose(); }
+                                }, 'Close & Refresh')
+                            ),
+
+                            // Primary Headline
+                            React.createElement('div', { className: 'form-group' },
+                                React.createElement('label', { className: 'form-label' }, 'Primary Headline'),
+                                React.createElement('input', {
+                                    type: 'text',
+                                    className: 'form-input',
+                                    value: formData.primary_headline,
+                                    onChange: (e) => handleChange('primary_headline', e.target.value),
+                                    required: true
+                                })
+                            ),
+
+                            // Source + Source URL
+                            React.createElement('div', { className: 'form-row' },
+                                React.createElement('div', { className: 'form-group' },
+                                    React.createElement('label', { className: 'form-label' }, 'Primary Source'),
+                                    React.createElement('input', {
+                                        type: 'text',
+                                        className: 'form-input',
+                                        value: formData.primary_source,
+                                        onChange: (e) => handleChange('primary_source', e.target.value)
+                                    })
+                                ),
+                                React.createElement('div', { className: 'form-group' },
+                                    React.createElement('label', { className: 'form-label' }, 'Primary Actor'),
+                                    React.createElement('input', {
+                                        type: 'text',
+                                        className: 'form-input',
+                                        value: formData.primary_actor,
+                                        onChange: (e) => handleChange('primary_actor', e.target.value),
+                                        placeholder: 'Person or organization'
+                                    })
+                                )
+                            ),
+
+                            // Source URL
+                            React.createElement('div', { className: 'form-group' },
+                                React.createElement('label', { className: 'form-label' }, 'Primary Source URL'),
+                                React.createElement('input', {
+                                    type: 'url',
+                                    className: 'form-input',
+                                    value: formData.primary_source_url,
+                                    onChange: (e) => handleChange('primary_source_url', e.target.value)
+                                })
+                            ),
+
+                            // Status + Severity
+                            React.createElement('div', { className: 'form-row' },
+                                React.createElement('div', { className: 'form-group' },
+                                    React.createElement('label', { className: 'form-label' }, 'Status'),
+                                    React.createElement('select', {
+                                        className: 'form-select',
+                                        value: formData.status,
+                                        onChange: (e) => handleChange('status', e.target.value)
+                                    },
+                                        STATUS_OPTIONS.map(opt =>
+                                            React.createElement('option', { key: opt.value, value: opt.value }, opt.label)
+                                        )
+                                    )
+                                ),
+                                React.createElement('div', { className: 'form-group' },
+                                    React.createElement('label', { className: 'form-label' }, 'Alarm Level'),
+                                    React.createElement('select', {
+                                        className: 'form-select',
+                                        value: formData.alarm_level,
+                                        onChange: (e) => handleChange('alarm_level', e.target.value)
+                                    },
+                                        React.createElement('option', { value: '' }, 'Not set'),
+                                        ALARM_LEVEL_OPTIONS.map(opt =>
+                                            React.createElement('option', { key: opt.value, value: opt.value }, opt.label)
+                                        )
+                                    )
+                                )
+                            ),
+
+                            // Category
+                            React.createElement('div', { className: 'form-group' },
+                                React.createElement('label', { className: 'form-label' }, 'Category'),
+                                React.createElement('select', {
+                                    className: 'form-select',
+                                    value: formData.category,
+                                    onChange: (e) => handleChange('category', e.target.value)
+                                },
+                                    React.createElement('option', { value: '' }, 'Not set'),
+                                    STORY_CATEGORIES.map(opt =>
+                                        React.createElement('option', { key: opt.value, value: opt.value }, opt.label)
+                                    )
+                                )
+                            ),
+
+                            // Summary Spicy
+                            React.createElement('div', { className: 'form-group' },
+                                React.createElement('label', { className: 'form-label' }, 'Summary (Spicy)'),
+                                React.createElement('textarea', {
+                                    className: 'form-textarea',
+                                    value: formData.summary_spicy,
+                                    onChange: (e) => handleChange('summary_spicy', e.target.value),
+                                    rows: 4,
+                                    placeholder: 'Editorial, opinionated take on the story...'
+                                })
+                            )
+                        ),
+                        React.createElement('div', { className: 'modal-footer' },
+                            React.createElement('button', { type: 'button', className: 'btn-secondary', onClick: onClose, disabled: saving }, 'Cancel'),
+                            React.createElement('button', { type: 'submit', className: 'btn-primary', disabled: saving || isConflict },
+                                saving ? 'Saving...' : 'Save Changes'
+                            )
+                        )
+                    )
+                )
+            );
+        }
+
+        // Edit Pardon Modal Component
+        function EditPardonModal({ pardon, onClose, onSave, onRefresh, supabase, password }) {
+            const h = React.createElement;
+            const [formData, setFormData] = useState(() => ({
+                // Identity
+                recipient_name: pardon?.recipient_name || '',
+                nickname: pardon?.nickname || '',
+                photo_url: pardon?.photo_url || '',
+                recipient_type: pardon?.recipient_type || '',
+                recipient_count: pardon?.recipient_count ?? '',
+                recipient_criteria: pardon?.recipient_criteria || '',
+                // Pardon & Crime
+                pardon_date: pardon?.pardon_date || '',
+                clemency_type: pardon?.clemency_type || '',
+                status: pardon?.status || '',
+                case_number: pardon?.case_number || '',
+                crime_description: pardon?.crime_description || '',
+                crime_category: pardon?.crime_category || '',
+                original_sentence: pardon?.original_sentence || '',
+                conviction_date: pardon?.conviction_date || '',
+                // Trump Connection
+                primary_connection_type: pardon?.primary_connection_type || '',
+                secondary_connection_types: pardon?.secondary_connection_types || [],
+                corruption_level: pardon?.corruption_level ?? '',
+                corruption_reasoning: pardon?.corruption_reasoning || '',
+                trump_connection_detail: pardon?.trump_connection_detail || '',
+                donation_amount_usd: pardon?.donation_amount_usd ?? '',
+                // AI Content
+                summary_neutral: pardon?.summary_neutral || '',
+                summary_spicy: pardon?.summary_spicy || '',
+                why_it_matters: pardon?.why_it_matters || '',
+                pattern_analysis: pardon?.pattern_analysis || '',
+                // Admin & Sources
+                research_status: pardon?.research_status || '',
+                needs_review: pardon?.needs_review ?? false,
+                is_public: pardon?.is_public ?? false,
+                post_pardon_status: pardon?.post_pardon_status || '',
+                post_pardon_notes: pardon?.post_pardon_notes || '',
+                primary_source_url: pardon?.primary_source_url || '',
+                // JSONB
+                source_urls: JSON.stringify(pardon?.source_urls || [], null, 2),
+                receipts_timeline: JSON.stringify(pardon?.receipts_timeline || [], null, 2),
+                pardon_advocates: JSON.stringify(pardon?.pardon_advocates || [], null, 2),
+            }));
+            const [saving, setSaving] = useState(false);
+            const [error, setError] = useState(null);
+            const [isConflict, setIsConflict] = useState(false);
+            const [jsonErrors, setJsonErrors] = useState({});
+            const [openSections, setOpenSections] = useState({ identity: true, pardon_crime: true, trump_connection: false, ai_content: false, admin_sources: false });
+
+            const originalUpdatedAt = pardon?.updated_at;
+
+            // Escape key closes modal
+            useEffect(() => {
+                const handler = (e) => { if (e.key === 'Escape') onClose(); };
+                document.addEventListener('keydown', handler);
+                return () => document.removeEventListener('keydown', handler);
+            }, [onClose]);
+
+            const handleChange = (field, value) => {
+                if (field === 'recipient_type' && value === 'person') {
+                    setFormData(prev => ({ ...prev, [field]: value, recipient_count: '', recipient_criteria: '' }));
+                } else {
+                    setFormData(prev => ({ ...prev, [field]: value }));
+                }
+            };
+
+            const toggleSection = (section) => {
+                setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
+            };
+
+            const toggleSecondaryConnection = (type) => {
+                setFormData(prev => {
+                    const current = prev.secondary_connection_types || [];
+                    const next = current.includes(type) ? current.filter(t => t !== type) : [...current, type];
+                    return { ...prev, secondary_connection_types: next };
+                });
+            };
+
+            // JSONB field change with validation
+            const handleJsonChange = (field, value) => {
+                setFormData(prev => ({ ...prev, [field]: value }));
+                if (value.trim() === '' || value.trim() === '[]') {
+                    setJsonErrors(prev => ({ ...prev, [field]: null }));
+                    return;
+                }
+                try {
+                    const parsed = JSON.parse(value);
+                    if (!Array.isArray(parsed)) {
+                        setJsonErrors(prev => ({ ...prev, [field]: 'Must be a JSON array' }));
+                    } else {
+                        setJsonErrors(prev => ({ ...prev, [field]: null }));
+                    }
+                } catch (e) {
+                    setJsonErrors(prev => ({ ...prev, [field]: 'Invalid JSON: ' + e.message }));
+                }
+            };
+
+            // Auto-format JSON on blur
+            const handleJsonBlur = (field) => {
+                const value = formData[field];
+                if (!value || value.trim() === '') return;
+                try {
+                    const parsed = JSON.parse(value);
+                    if (Array.isArray(parsed)) {
+                        setFormData(prev => ({ ...prev, [field]: JSON.stringify(parsed, null, 2) }));
+                    }
+                } catch (_) { /* leave as-is if invalid */ }
+            };
+
+            const hasJsonErrors = Object.values(jsonErrors).some(e => e);
+
+            const handleSubmit = async (e) => {
+                e.preventDefault();
+                if (hasJsonErrors) return;
+
+                // Validate pardons_group_fields_chk constraint
+                const rt = formData.recipient_type;
+                if (rt === 'group') {
+                    const count = formData.recipient_count === '' ? null : parseInt(formData.recipient_count, 10);
+                    const criteria = (formData.recipient_criteria || '').trim();
+                    if (!count || count <= 0 || !criteria) {
+                        setError('Group pardons require both Recipient Count (>0) and Recipient Criteria.');
+                        return;
+                    }
+                } else if (rt === 'person') {
+                    const count = formData.recipient_count === '' ? null : parseInt(formData.recipient_count, 10);
+                    const criteria = (formData.recipient_criteria || '').trim();
+                    if (count !== null || criteria) {
+                        setError('Person pardons cannot have Recipient Count or Recipient Criteria. Clear those fields first.');
+                        return;
+                    }
+                }
+
+                setSaving(true);
+                setError(null);
+
+                try {
+                    const updates = {};
+
+                    // Text fields
+                    const textFields = ['recipient_name', 'nickname', 'recipient_criteria', 'case_number', 'crime_description', 'original_sentence', 'corruption_reasoning', 'trump_connection_detail', 'post_pardon_notes', 'summary_neutral', 'summary_spicy', 'why_it_matters', 'pattern_analysis'];
+                    for (const f of textFields) {
+                        const newVal = formData[f] || null;
+                        const oldVal = pardon[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // URL fields
+                    for (const f of ['photo_url', 'primary_source_url']) {
+                        const newVal = formData[f] || null;
+                        const oldVal = pardon[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // Enum fields (string)
+                    for (const f of ['clemency_type', 'status', 'recipient_type', 'crime_category', 'primary_connection_type', 'research_status', 'post_pardon_status']) {
+                        const newVal = formData[f] || null;
+                        const oldVal = pardon[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // Date fields
+                    for (const f of ['pardon_date', 'conviction_date']) {
+                        const newVal = formData[f] || null;
+                        const oldVal = pardon[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // Boolean fields
+                    for (const f of ['is_public', 'needs_review']) {
+                        if (formData[f] !== (pardon[f] ?? false)) updates[f] = formData[f];
+                    }
+
+                    // Integer: corruption_level
+                    const newCorruption = formData.corruption_level === '' ? null : parseInt(formData.corruption_level, 10);
+                    const oldCorruption = pardon.corruption_level ?? null;
+                    if (newCorruption !== oldCorruption) updates.corruption_level = newCorruption;
+
+                    // Integer: recipient_count
+                    const newCount = formData.recipient_count === '' ? null : parseInt(formData.recipient_count, 10);
+                    const oldCount = pardon.recipient_count ?? null;
+                    if (newCount !== oldCount) updates.recipient_count = newCount;
+
+                    // Numeric: donation_amount_usd
+                    const newDonation = formData.donation_amount_usd === '' ? null : parseFloat(formData.donation_amount_usd);
+                    const oldDonation = pardon.donation_amount_usd ?? null;
+                    if (newDonation !== oldDonation) updates.donation_amount_usd = newDonation;
+
+                    // text[]: secondary_connection_types (compare sorted)
+                    const newSCT = [...(formData.secondary_connection_types || [])].sort();
+                    const oldSCT = [...(pardon.secondary_connection_types || [])].sort();
+                    if (JSON.stringify(newSCT) !== JSON.stringify(oldSCT)) updates.secondary_connection_types = formData.secondary_connection_types;
+
+                    // JSONB fields
+                    for (const f of ['source_urls', 'receipts_timeline', 'pardon_advocates']) {
+                        const rawText = formData[f];
+                        const newParsed = (!rawText || rawText.trim() === '' || rawText.trim() === '[]') ? [] : JSON.parse(rawText);
+                        const oldVal = pardon[f] || [];
+                        if (JSON.stringify(newParsed) !== JSON.stringify(oldVal)) updates[f] = newParsed;
+                    }
+
+                    // Filter to ALLOWED_FIELDS only
+                    const filteredUpdates = {};
+                    for (const key of Object.keys(updates)) {
+                        if (PARDON_ALLOWED_FIELDS.includes(key)) filteredUpdates[key] = updates[key];
+                    }
+
+                    if (Object.keys(filteredUpdates).length === 0) {
+                        onClose();
+                        return;
+                    }
+
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-pardon',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                pardon_id: pardon.id,
+                                updates: filteredUpdates,
+                                original_updated_at: originalUpdatedAt
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try {
+                            if (!body && fnError.context) body = await fnError.context.json();
+                        } catch (_) {}
+                        if (body?.conflict) {
+                            setIsConflict(true);
+                            setError(body.error || 'Record was modified by another process. Close and refresh to get the latest data.');
+                            setSaving(false);
+                            return;
+                        }
+                        throw new Error(body?.error || fnError.message || 'Update failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    const changedFields = data.changed_fields || {};
+                    const firstChangedField = Object.keys(changedFields)[0];
+
+                    onSave(data.pardon, firstChangedField ? {
+                        entityType: 'pardon',
+                        entityId: String(pardon.id),
+                        fieldName: firstChangedField,
+                        oldValue: changedFields[firstChangedField]?.old
+                    } : null);
+                } catch (err) {
+                    console.error('Save error:', err);
+                    setError(err.message || 'Failed to save changes');
+                } finally {
+                    setSaving(false);
+                }
+            };
+
+            // Helper: section header
+            const sectionHeader = (key, label) =>
+                h('div', { className: 'form-section-header', onClick: () => toggleSection(key) },
+                    h('h4', null, label),
+                    h('span', { className: 'form-section-arrow' + (openSections[key] ? ' open' : '') }, '\u25B6')
+                );
+
+            // Helper: label with optional red asterisk (indicates field is displayed on public site)
+            const fieldLabel = (label, used) =>
+                used ? h('label', { className: 'form-label' }, label, h('span', { style: { color: '#ef4444', marginLeft: '3px' } }, '*')) : h('label', { className: 'form-label' }, label);
+
+            // Helper: text input field
+            const textField = (field, label, opts = {}) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, opts.used),
+                    h('input', {
+                        type: opts.type || 'text',
+                        className: 'form-input',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value),
+                        placeholder: opts.placeholder || '',
+                        ...opts.inputProps
+                    })
+                );
+
+            // Helper: select field
+            const selectField = (field, label, options, used) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, used),
+                    h('select', {
+                        className: 'form-select',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value)
+                    },
+                        h('option', { value: '' }, 'Not set'),
+                        options.map(opt =>
+                            h('option', { key: opt.value, value: opt.value }, opt.label)
+                        )
+                    )
+                );
+
+            // Helper: textarea field
+            const textareaField = (field, label, rows = 3, used = false) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, used),
+                    h('textarea', {
+                        className: 'form-textarea',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value),
+                        rows
+                    })
+                );
+
+            // Helper: JSONB textarea
+            const jsonField = (field, label, rows = 4, used = false) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, used),
+                    h('textarea', {
+                        className: 'form-textarea' + (jsonErrors[field] ? ' json-error' : ''),
+                        value: formData[field],
+                        onChange: (ev) => handleJsonChange(field, ev.target.value),
+                        onBlur: () => handleJsonBlur(field),
+                        rows
+                    }),
+                    jsonErrors[field] && h('div', { className: 'json-error-msg' }, jsonErrors[field])
+                );
+
+            // Helper: boolean checkbox
+            const boolField = (field, label, used = false) =>
+                h('div', { className: 'form-group', style: { display: 'flex', alignItems: 'center', gap: '8px' } },
+                    h('input', {
+                        type: 'checkbox',
+                        checked: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.checked),
+                        style: { accentColor: '#3b82f6', width: '16px', height: '16px' }
+                    }),
+                    used
+                        ? h('label', { className: 'form-label', style: { marginBottom: 0 } }, label, h('span', { style: { color: '#ef4444', marginLeft: '3px' } }, '*'))
+                        : h('label', { className: 'form-label', style: { marginBottom: 0 } }, label)
+                );
+
+            return h('div', { className: 'modal-overlay' },
+                h('div', { className: 'modal-content' },
+                    h('div', { className: 'modal-header' },
+                        h('h3', { className: 'modal-title' }, 'Edit Pardon #' + pardon.id + (pardon.recipient_name ? ' - ' + pardon.recipient_name : '')),
+                        h('button', { className: 'modal-close', onClick: onClose }, '\u00D7')
+                    ),
+                    h('form', { onSubmit: handleSubmit },
+                        h('div', { className: 'modal-body' },
+                            // Error banner
+                            error && h('div', { className: 'error-banner', style: { marginBottom: '16px' } },
+                                error,
+                                isConflict && h('button', {
+                                    type: 'button',
+                                    className: 'btn-primary',
+                                    style: { marginLeft: '12px', padding: '4px 12px', fontSize: '13px' },
+                                    onClick: () => { onRefresh && onRefresh(); onClose(); }
+                                }, 'Close & Refresh')
+                            ),
+
+                            // Section 1: Identity (open)
+                            sectionHeader('identity', 'Identity'),
+                            openSections.identity && h('div', null,
+                                textField('recipient_name', 'Recipient Name', { used: true }),
+                                h('div', { className: 'form-row' },
+                                    textField('nickname', 'Nickname', { used: true }),
+                                    selectField('recipient_type', 'Recipient Type', PARDON_RECIPIENT_TYPES, true)
+                                ),
+                                h('div', { className: 'form-row' },
+                                    formData.recipient_type === 'group' && textField('recipient_count', 'Recipient Count', { type: 'number', inputProps: { min: 1 }, used: true }),
+                                    textField('photo_url', 'Photo URL', { type: 'url' })
+                                ),
+                                formData.recipient_type === 'group' && textField('recipient_criteria', 'Recipient Criteria', { used: true })
+                            ),
+
+                            // Section 2: Pardon & Crime (open)
+                            sectionHeader('pardon_crime', 'Pardon & Crime'),
+                            openSections.pardon_crime && h('div', null,
+                                h('div', { className: 'form-row' },
+                                    textField('pardon_date', 'Pardon Date', { type: 'date', used: true }),
+                                    selectField('clemency_type', 'Clemency Type', PARDON_CLEMENCY_TYPES, true)
+                                ),
+                                h('div', { className: 'form-row' },
+                                    selectField('status', 'Status', PARDON_STATUS_OPTIONS, true),
+                                    selectField('crime_category', 'Crime Category', Object.entries(CRIME_CATEGORY_LABELS).map(([v, l]) => ({ value: v, label: l })), true)
+                                ),
+                                textareaField('crime_description', 'Crime Description', 3, true),
+                                h('div', { className: 'form-row' },
+                                    textField('case_number', 'Case Number'),
+                                    textField('conviction_date', 'Conviction Date', { type: 'date' })
+                                ),
+                                textField('original_sentence', 'Original Sentence', { used: true })
+                            ),
+
+                            // Section 3: Trump Connection (collapsed)
+                            sectionHeader('trump_connection', 'Trump Connection'),
+                            openSections.trump_connection && h('div', null,
+                                h('div', { className: 'form-row' },
+                                    selectField('primary_connection_type', 'Primary Connection', Object.entries(CONNECTION_TYPE_LABELS).map(([v, l]) => ({ value: v, label: l })), true),
+                                    selectField('corruption_level', 'Corruption Level', CORRUPTION_LEVELS.map(l => ({ value: String(l.value), label: l.value + ' - ' + l.label })), true)
+                                ),
+                                h('div', { className: 'form-group' },
+                                    h('label', { className: 'form-label' }, 'Secondary Connection Types'),
+                                    h('div', { className: 'form-checkbox-row' },
+                                        CONNECTION_TYPE_KEYS.map(type =>
+                                            h('label', { key: type, className: 'form-checkbox' + (formData.secondary_connection_types.includes(type) ? ' checked' : '') },
+                                                h('input', {
+                                                    type: 'checkbox',
+                                                    checked: formData.secondary_connection_types.includes(type),
+                                                    onChange: () => toggleSecondaryConnection(type)
+                                                }),
+                                                CONNECTION_TYPE_LABELS[type]
+                                            )
+                                        )
+                                    )
+                                ),
+                                textareaField('corruption_reasoning', 'Corruption Reasoning', 3),
+                                textareaField('trump_connection_detail', 'Trump Connection Detail', 3, true),
+                                textField('donation_amount_usd', 'Donation Amount (USD)', { type: 'number', inputProps: { min: 0, step: '0.01' }, used: true })
+                            ),
+
+                            // Section 4: AI Content (collapsed)
+                            sectionHeader('ai_content', 'AI Content'),
+                            openSections.ai_content && h('div', null,
+                                textareaField('summary_neutral', 'Summary (Neutral)', 4),
+                                textareaField('summary_spicy', 'Summary (Spicy)', 4, true),
+                                textareaField('why_it_matters', 'Why It Matters', 3, true),
+                                textareaField('pattern_analysis', 'Pattern Analysis', 3, true)
+                            ),
+
+                            // Section 5: Admin & Sources (collapsed)
+                            sectionHeader('admin_sources', 'Admin & Sources'),
+                            openSections.admin_sources && h('div', null,
+                                h('div', { className: 'form-row' },
+                                    selectField('research_status', 'Research Status', PARDON_RESEARCH_STATUS, true),
+                                    selectField('post_pardon_status', 'Post-Pardon Status', PARDON_POST_STATUS)
+                                ),
+                                h('div', { style: { display: 'flex', gap: '24px', marginBottom: '16px' } },
+                                    boolField('is_public', 'Published', true),
+                                    boolField('needs_review', 'Needs Review', true)
+                                ),
+                                textareaField('post_pardon_notes', 'Post-Pardon Notes', 2, true),
+                                textField('primary_source_url', 'Primary Source URL', { type: 'url', used: true }),
+                                jsonField('source_urls', 'Source URLs (JSON array of URL strings)', 3),
+                                jsonField('receipts_timeline', 'Receipts Timeline (JSON array of objects)', 5, true),
+                                jsonField('pardon_advocates', 'Pardon Advocates (JSON array)', 4)
+                            )
+                        ),
+                        h('div', { className: 'modal-footer' },
+                            h('button', { type: 'button', className: 'btn-secondary', onClick: onClose, disabled: saving }, 'Cancel'),
+                            h('button', { type: 'submit', className: 'btn-primary', disabled: saving || isConflict || hasJsonErrors },
+                                saving ? 'Saving...' : 'Save Changes'
+                            )
+                        )
+                    )
+                )
+            );
+        }
+
         // Stories Tab Component
         function StoriesTab({ password, supabase }) {
             const [stories, setStories] = useState([]);
@@ -486,20 +1601,30 @@
             const [loadingMore, setLoadingMore] = useState(false);
             const [error, setError] = useState(null);
             const [cursor, setCursor] = useState(null);
+            const [offset, setOffset] = useState(null);
             const [hasMore, setHasMore] = useState(false);
 
             // Filters
             const [search, setSearch] = useState('');
             const [debouncedSearch, setDebouncedSearch] = useState('');
-            const [statusFilter, setStatusFilter] = useState('');
-            const [enrichmentFilter, setEnrichmentFilter] = useState('');
-            const [severityFilter, setSeverityFilter] = useState('');
+            const [statusFilter, setStatusFilter] = useState('active');
+            const [enrichmentFilter, setEnrichmentFilter] = useState('enriched');
+            const [alarmLevelFilter, setAlarmLevelFilter] = useState('');
             const [categoryFilter, setCategoryFilter] = useState('');
-            const [sortBy, setSortBy] = useState('id');
+            const [sortBy, setSortBy] = useState('last_updated_at');
             const [sortDir, setSortDir] = useState('desc');
 
             // Detail expansion
             const [expandedId, setExpandedId] = useState(null);
+
+            // Edit modal state
+            const [editingStory, setEditingStory] = useState(null);
+
+            // Re-enrichment state (track which stories are currently enriching)
+            const [enrichingIds, setEnrichingIds] = useState(new Set());
+
+            // Toast context
+            const toast = useToast();
 
             // Debounce search input
             useEffect(() => {
@@ -510,7 +1635,7 @@
             }, [search]);
 
             // Fetch stories from edge function
-            const fetchStories = useCallback(async (append = false, pageCursor = null) => {
+            const fetchStories = useCallback(async (append = false, pageCursor = null, pageOffset = null) => {
                 if (append) {
                     setLoadingMore(true);
                 } else {
@@ -523,9 +1648,10 @@
                     if (debouncedSearch) reqBody.search = debouncedSearch;
                     if (statusFilter) reqBody.status = statusFilter;
                     if (enrichmentFilter) reqBody.enrichment = enrichmentFilter;
-                    if (severityFilter) reqBody.severity = severityFilter;
+                    if (alarmLevelFilter) reqBody.alarmLevel = alarmLevelFilter;
                     if (categoryFilter) reqBody.category = categoryFilter;
                     if (pageCursor) reqBody.cursor = pageCursor;
+                    if (pageOffset != null && pageOffset > 0) reqBody.offset = pageOffset;
 
                     const { data, error: fnError } = await supabase.functions.invoke(
                         'admin-stories',
@@ -544,6 +1670,7 @@
                     }
 
                     setCursor(data.pagination?.next_cursor || null);
+                    setOffset(data.pagination?.next_offset || null);
                     setHasMore(data.pagination?.has_more || false);
                 } catch (err) {
                     console.error('Stories fetch error:', err);
@@ -552,20 +1679,82 @@
                     setLoading(false);
                     setLoadingMore(false);
                 }
-            }, [supabase, password, debouncedSearch, statusFilter, enrichmentFilter, severityFilter, categoryFilter, sortBy, sortDir]);
+            }, [supabase, password, debouncedSearch, statusFilter, enrichmentFilter, alarmLevelFilter, categoryFilter, sortBy, sortDir]);
 
             // Re-fetch when filters change
             // eslint-disable-next-line react-hooks/exhaustive-deps
             useEffect(() => {
                 setCursor(null);
+                setOffset(null);
                 setExpandedId(null);
-                fetchStories(false, null);
-            }, [debouncedSearch, statusFilter, enrichmentFilter, severityFilter, categoryFilter, sortBy, sortDir]);
+                fetchStories(false, null, null);
+            }, [debouncedSearch, statusFilter, enrichmentFilter, alarmLevelFilter, categoryFilter, sortBy, sortDir]);
+
+            // Poll for enrichment completion when any story is pending
+            const hasPendingStories = useMemo(() => stories.some(s => s.enrichment_status === 'pending'), [stories]);
+            const storiesRef = useRef(stories);
+            storiesRef.current = stories;
+
+            useEffect(() => {
+                if (!hasPendingStories) return;
+
+                const interval = setInterval(async () => {
+                    try {
+                        // Snapshot pending IDs from latest state at poll time
+                        const pendingIds = new Set(
+                            storiesRef.current.filter(s => s.enrichment_status === 'pending').map(s => s.id)
+                        );
+                        if (pendingIds.size === 0) return;
+
+                        // Fetch ALL pending stories (not just current view) so we detect completion
+                        // even if user changed filters while enrichment was running
+                        const { data } = await supabase.functions.invoke('admin-stories', {
+                            headers: { 'x-admin-password': password },
+                            body: { limit: 100, enrichment: 'pending', sortBy: 'id', sortDir: 'desc' }
+                        });
+
+                        // Stories still pending according to the server
+                        const stillPendingIds = new Set((data?.stories || []).map(s => s.id));
+
+                        // Any ID we tracked as pending that's NOT in the pending result has transitioned
+                        for (const id of pendingIds) {
+                            if (!stillPendingIds.has(id)) {
+                                // Fetch the individual story to find out what it transitioned to
+                                const { data: detail } = await supabase.functions.invoke('admin-stories', {
+                                    headers: { 'x-admin-password': password },
+                                    body: { search: String(id), limit: 1 }
+                                });
+                                const fresh = detail?.stories?.find(s => s.id === id);
+                                const status = fresh?.enrichment_status || 'enriched';
+                                const label = status === 'failed'
+                                    ? `Story #${id} enrichment failed`
+                                    : `Story #${id} enrichment complete`;
+                                toast?.addToast(label, status === 'failed' ? 'error' : 'success');
+
+                                // Update the story in local state
+                                if (fresh) {
+                                    setStories(prev => prev.map(s => s.id === id ? { ...s, ...fresh } : s));
+                                }
+                            }
+                        }
+
+                        // Also update any pending stories still in our list with fresh data
+                        if (data?.stories) {
+                            const freshMap = new Map(data.stories.map(s => [s.id, s]));
+                            setStories(prev => prev.map(s => freshMap.has(s.id) ? { ...s, ...freshMap.get(s.id) } : s));
+                        }
+                    } catch (_) {
+                        // Silently ignore polling errors
+                    }
+                }, 15000);
+
+                return () => clearInterval(interval);
+            }, [hasPendingStories, supabase, password, toast]);
 
             // Load more handler
             const handleLoadMore = () => {
-                if (cursor && hasMore) {
-                    fetchStories(true, cursor);
+                if (hasMore) {
+                    fetchStories(true, cursor, offset);
                 }
             };
 
@@ -587,6 +1776,9 @@
                 if (story.enrichment_failure_count > 0) {
                     return { class: 'badge-failed', label: `Failed (${story.enrichment_failure_count})` };
                 }
+                if (story.enrichment_status === 'pending') {
+                    return { class: 'badge-pending', label: 'Pending' };
+                }
                 if (story.last_enriched_at) {
                     return { class: 'badge-enriched', label: 'Enriched' };
                 }
@@ -601,13 +1793,15 @@
                 return { class: 'badge-closed', label: status || 'Unknown' };
             };
 
-            // Get severity badge
-            const getSeverityBadge = (severity) => {
-                if (severity === 'critical') return { class: 'badge-critical', label: 'Critical' };
-                if (severity === 'severe') return { class: 'badge-severe', label: 'Severe' };
-                if (severity === 'moderate') return { class: 'badge-moderate', label: 'Moderate' };
-                if (severity === 'minor') return { class: 'badge-minor', label: 'Minor' };
-                return { class: 'badge-closed', label: severity || '-' };
+            // Get alarm level badge
+            const getAlarmBadge = (level) => {
+                if (level === 5) return { class: 'badge-critical', label: 'Dumpster Fire' };
+                if (level === 4) return { class: 'badge-severe', label: 'Criminal BS' };
+                if (level === 3) return { class: 'badge-moderate', label: 'Deep Swamp' };
+                if (level === 2) return { class: 'badge-minor', label: 'Gaslight' };
+                if (level === 1) return { class: 'badge-closed', label: 'Accidental Sanity' };
+                if (level === 0) return { class: 'badge-closed', label: 'Broken Clock' };
+                return { class: 'badge-closed', label: '-' };
             };
 
             // Format category for display
@@ -632,6 +1826,160 @@
             // Toggle detail expansion
             const toggleDetail = (id) => {
                 setExpandedId(expandedId === id ? null : id);
+            };
+
+            // Handle edit button click
+            const handleEdit = (story) => {
+                setEditingStory(story);
+            };
+
+            // State for undo toast
+            const [undoInfo, setUndoInfo] = useState(null);
+
+            // Handle undo action
+            const handleUndo = async () => {
+                if (!undoInfo) return;
+
+                try {
+                    const { data, error: rpcError } = await supabase.rpc('undo_content_change', {
+                        p_entity_type: undoInfo.entityType,
+                        p_entity_id: undoInfo.entityId,
+                        p_changed_by: 'admin'
+                    });
+
+                    if (rpcError) throw new Error(rpcError.message);
+                    if (!data?.success) throw new Error(data?.error || 'Undo failed');
+
+                    // Refresh the story in the list
+                    const storyId = parseInt(undoInfo.entityId, 10);
+                    setStories(prev => prev.map(s =>
+                        s.id === storyId
+                            ? { ...s, [data.field]: data.restored_value }
+                            : s
+                    ));
+
+                    toast?.addToast(`Restored ${data.field.replace(/_/g, ' ')}`, 'success');
+                    setUndoInfo(null);
+                } catch (err) {
+                    console.error('Undo error:', err);
+                    toast?.addToast(err.message || 'Failed to undo', 'error');
+                }
+            };
+
+            // Handle save from edit modal
+            const handleSaveEdit = (updatedStory, undoData) => {
+                // Update the story in the list
+                setStories(prev => prev.map(s => s.id === updatedStory.id ? { ...s, ...updatedStory } : s));
+                setEditingStory(null);
+
+                // Show undo toast if there's undo data
+                if (undoData) {
+                    setUndoInfo(undoData);
+                } else {
+                    toast?.addToast('Story updated successfully', 'success');
+                }
+            };
+
+            // Handle re-enrichment
+            const handleReEnrich = async (story) => {
+                // Check if already enriching
+                if (enrichingIds.has(story.id)) return;
+
+                // Add to enriching set
+                setEnrichingIds(prev => new Set([...prev, story.id]));
+
+                try {
+                    // Call trigger-enrichment edge function
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'trigger-enrichment',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: { entity_type: 'story', entity_id: story.id }
+                        }
+                    );
+
+                    if (fnError) {
+                        // Extract real error from response body (supabase-js hides it behind generic message)
+                        let detail = fnError.message;
+                        try {
+                            const body = fnError.context ? await fnError.context.json() : data;
+                            if (body?.error) detail = body.error;
+                        } catch (_) {}
+                        throw new Error(detail || 'Failed to trigger re-enrichment');
+                    }
+
+                    // Check for budget error
+                    if (data?.error) {
+                        throw new Error(data.error);
+                    }
+
+                    // Update the story in the list to show pending enrichment
+                    setStories(prev => prev.map(s =>
+                        s.id === story.id
+                            ? { ...s, enrichment_status: 'pending', enrichment_failure_count: 0 }
+                            : s
+                    ));
+
+                    toast?.addToast(`Story queued for re-enrichment (~$${(data?.estimated_cost || 0.003).toFixed(3)})`, 'success');
+                } catch (err) {
+                    console.error('Re-enrichment error:', err);
+                    toast?.addToast(err.message || 'Failed to trigger re-enrichment', 'error');
+                } finally {
+                    // Remove from enriching set
+                    setEnrichingIds(prev => {
+                        const newSet = new Set(prev);
+                        newSet.delete(story.id);
+                        return newSet;
+                    });
+                }
+            };
+
+            // Handle archive/unarchive toggle
+            const handleToggleArchive = async (story) => {
+                const newStatus = story.status === 'archived' ? 'active' : 'archived';
+                // Optimistic update
+                setStories(prev => prev.map(s => s.id === story.id ? { ...s, status: newStatus } : s));
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-story',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                story_id: story.id,
+                                updates: { status: newStatus },
+                                original_last_updated_at: story.last_updated_at
+                            }
+                        }
+                    );
+                    if (fnError) {
+                        let body = data;
+                        try {
+                            if (!body && fnError.context) body = await fnError.context.json();
+                        } catch (_) {}
+                        throw new Error(body?.error || fnError.message || 'Toggle failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+                    // Update local row with server response for continued locking
+                    setStories(prev => prev.map(s => s.id === story.id ? { ...s, ...data.story } : s));
+
+                    const changedFields = data.changed_fields || {};
+                    const firstField = Object.keys(changedFields)[0];
+                    if (firstField) {
+                        setUndoInfo({
+                            entityType: 'story',
+                            entityId: String(story.id),
+                            fieldName: firstField,
+                            oldValue: changedFields[firstField]?.old
+                        });
+                    } else {
+                        toast?.addToast(newStatus === 'archived' ? 'Archived' : 'Unarchived', 'success');
+                    }
+                } catch (err) {
+                    console.error('Toggle archive error:', err);
+                    // Revert optimistic update
+                    setStories(prev => prev.map(s => s.id === story.id ? { ...s, status: story.status } : s));
+                    toast?.addToast(err.message || 'Failed to toggle archive', 'error');
+                }
             };
 
             return (
@@ -667,14 +2015,13 @@
                         </select>
                         <select
                             className="stories-select"
-                            value={severityFilter}
-                            onChange={(e) => setSeverityFilter(e.target.value)}
+                            value={alarmLevelFilter}
+                            onChange={(e) => setAlarmLevelFilter(e.target.value)}
                         >
-                            <option value="">All Severity</option>
-                            <option value="critical">Critical</option>
-                            <option value="severe">Severe</option>
-                            <option value="moderate">Moderate</option>
-                            <option value="minor">Minor</option>
+                            <option value="">All Alarm Levels</option>
+                            {ALARM_LEVEL_OPTIONS.map(opt =>
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            )}
                         </select>
                         <select
                             className="stories-select"
@@ -705,8 +2052,8 @@
                         >
                             <option value="id-desc">Newest First</option>
                             <option value="id-asc">Oldest First</option>
-                            <option value="severity-desc">Severity (High→Low)</option>
-                            <option value="severity-asc">Severity (Low→High)</option>
+                            <option value="alarm_level-desc">Alarm (High→Low)</option>
+                            <option value="alarm_level-asc">Alarm (Low→High)</option>
                             <option value="last_updated_at-desc">Recently Updated</option>
                         </select>
                     </div>
@@ -737,18 +2084,19 @@
                                         <tr>
                                             <th>ID</th>
                                             <th>Headline</th>
-                                            <th>Severity</th>
+                                            <th>Alarm Level</th>
                                             <th>Category</th>
                                             <th>Status</th>
                                             <th>Enrichment</th>
                                             <th>Articles</th>
                                             <th>Created</th>
+                                            <th>Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {stories.length === 0 && (
                                             <tr>
-                                                <td colSpan={9} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                                                <td colSpan={10} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
                                                     No stories found matching your filters.
                                                 </td>
                                             </tr>
@@ -769,8 +2117,8 @@
                                                         {story.primary_headline || '(No headline)'}
                                                     </td>
                                                     <td>
-                                                        <span className={`badge ${getSeverityBadge(story.severity).class}`}>
-                                                            {getSeverityBadge(story.severity).label}
+                                                        <span className={`badge ${getAlarmBadge(story.alarm_level).class}`}>
+                                                            {getAlarmBadge(story.alarm_level).label}
                                                         </span>
                                                     </td>
                                                     <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
@@ -788,16 +2136,53 @@
                                                     <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
                                                         {formatDate(story.first_seen_at)}
                                                     </td>
+                                                    <td>
+                                                        <div className="row-actions">
+                                                            <button
+                                                                className="btn-icon"
+                                                                onClick={() => handleEdit(story)}
+                                                                title="Edit story"
+                                                            >
+                                                                ✏️ Edit
+                                                            </button>
+                                                            <button
+                                                                className={`btn-icon ${enrichingIds.has(story.id) || story.enrichment_status === 'pending' ? 'enriching' : ''}`}
+                                                                onClick={() => handleReEnrich(story)}
+                                                                disabled={enrichingIds.has(story.id) || story.enrichment_status === 'pending'}
+                                                                title="Re-enrich with AI"
+                                                            >
+                                                                {enrichingIds.has(story.id)
+                                                                    ? React.createElement(React.Fragment, null,
+                                                                        React.createElement('span', { className: 'spinner-sm' }),
+                                                                        'Enriching...'
+                                                                      )
+                                                                    : story.enrichment_status === 'pending'
+                                                                        ? React.createElement(React.Fragment, null,
+                                                                            React.createElement('span', { className: 'spinner-sm' }),
+                                                                            'Pending...'
+                                                                          )
+                                                                        : '🤖 Re-enrich'
+                                                                }
+                                                            </button>
+                                                            <button
+                                                                className="btn-icon"
+                                                                onClick={() => handleToggleArchive(story)}
+                                                                title={story.status === 'archived' ? 'Unarchive' : 'Archive'}
+                                                            >
+                                                                {story.status === 'archived' ? '📥 Unarchive' : '📤 Archive'}
+                                                            </button>
+                                                        </div>
+                                                    </td>
                                                 </tr>,
                                                 isExpanded && (
                                                     <tr className="story-detail-row">
-                                                        <td colSpan={8}>
+                                                        <td colSpan={9}>
                                                             <div className="story-detail-content">
                                                                 <div>
                                                                     <dt>Category</dt>
                                                                     <dd>{story.category || '-'}</dd>
                                                                     <dt>Severity</dt>
-                                                                    <dd>{story.severity || '-'}</dd>
+                                                                    <dd>{ALARM_LEVEL_MAP[String(story.alarm_level)] || '-'}</dd>
                                                                     <dt>Source Count</dt>
                                                                     <dd>{story.source_count ?? '-'}</dd>
                                                                 </div>
@@ -818,8 +2203,7 @@
                                     </tbody>
                                 </table>
                             </div>
-                            {/* Hide Load More when sorting by severity (cursor pagination incompatible with string fields) */}
-                            {hasMore && sortBy !== 'severity' && (
+                            {hasMore && (
                                 <div style={{ padding: '0 20px 20px' }}>
                                     <button
                                         className="load-more-btn"
@@ -830,6 +2214,656 @@
                                     </button>
                                 </div>
                             )}
+                        </div>
+                    )}
+
+                    {/* Edit Story Modal */}
+                    {editingStory && (
+                        <EditStoryModal
+                            story={editingStory}
+                            onClose={() => setEditingStory(null)}
+                            onSave={handleSaveEdit}
+                            onRefresh={() => fetchStories(false, null, null)}
+                            supabase={supabase}
+                            password={password}
+                        />
+                    )}
+
+                    {/* Undo Toast */}
+                    {undoInfo && (
+                        <div className="toast-container">
+                            <UndoToast
+                                entityType={undoInfo.entityType}
+                                entityId={undoInfo.entityId}
+                                fieldName={undoInfo.fieldName}
+                                oldValue={undoInfo.oldValue}
+                                onUndo={handleUndo}
+                                onDismiss={() => setUndoInfo(null)}
+                            />
+                        </div>
+                    )}
+                </div>
+            );
+        }
+
+        // Pardons display label maps
+        const CONNECTION_TYPE_LABELS = {
+            mar_a_lago_vip: 'Mar-a-Lago VIP',
+            major_donor: 'Major Donor',
+            family: 'Family',
+            political_ally: 'Political Ally',
+            campaign_staff: 'Campaign Staff',
+            business_associate: 'Business Associate',
+            jan6_defendant: 'Jan 6 Defendant',
+            fake_electors: 'Fake Electors',
+            celebrity: 'Celebrity',
+            no_connection: 'No Connection',
+        };
+
+        const CRIME_CATEGORY_LABELS = {
+            white_collar: 'White Collar',
+            obstruction: 'Obstruction',
+            political_corruption: 'Political Corruption',
+            violent: 'Violent',
+            drug: 'Drug',
+            election: 'Election',
+            jan6: 'Jan 6',
+            other: 'Other',
+        };
+
+        const CORRUPTION_LEVELS = [
+            { value: 5, label: 'Pay 2 Win', color: '#dc2626', badgeClass: 'badge-critical' },
+            { value: 4, label: 'Cronies-in-Chief', color: '#ea580c', badgeClass: 'badge-severe' },
+            { value: 3, label: 'The Party Favor', color: '#ca8a04', badgeClass: 'badge-moderate' },
+            { value: 2, label: 'The PR Stunt', color: '#3b82f6', badgeClass: 'badge-closed' },
+            { value: 1, label: 'The Ego Discount', color: '#06b6d4', badgeClass: 'badge-archived' },
+        ];
+
+        const CORRUPTION_LEVEL_MAP = Object.fromEntries(CORRUPTION_LEVELS.map(l => [l.value, l]));
+
+        // Pardons-specific enum constants for EditPardonModal
+        const PARDON_CLEMENCY_TYPES = [
+            { value: 'pardon', label: 'Pardon' },
+            { value: 'commutation', label: 'Commutation' },
+            { value: 'pre_emptive', label: 'Pre-emptive' },
+        ];
+        const PARDON_STATUS_OPTIONS = [
+            { value: 'confirmed', label: 'Confirmed' },
+            { value: 'reported', label: 'Reported' },
+        ];
+        const PARDON_RECIPIENT_TYPES = [
+            { value: 'person', label: 'Person' },
+            { value: 'group', label: 'Group' },
+        ];
+        const PARDON_POST_STATUS = [
+            { value: 'quiet', label: 'Quiet' },
+            { value: 'under_investigation', label: 'Under Investigation' },
+            { value: 're_offended', label: 'Re-offended' },
+        ];
+        const PARDON_RESEARCH_STATUS = [
+            { value: 'complete', label: 'Complete' },
+            { value: 'in_progress', label: 'In Progress' },
+            { value: 'pending', label: 'Pending' },
+        ];
+        // Connection type keys for checkbox multi-select (reuses CONNECTION_TYPE_LABELS for display)
+        const CONNECTION_TYPE_KEYS = Object.keys(CONNECTION_TYPE_LABELS);
+
+        // Fields allowed by admin-update-pardon (used for payload filtering)
+        const PARDON_ALLOWED_FIELDS = [
+            'recipient_name', 'nickname', 'photo_url', 'recipient_type', 'recipient_count', 'recipient_criteria',
+            'pardon_date', 'clemency_type', 'status', 'case_number', 'crime_description', 'crime_category', 'original_sentence', 'conviction_date',
+            'primary_connection_type', 'secondary_connection_types', 'corruption_level', 'corruption_reasoning', 'trump_connection_detail', 'donation_amount_usd',
+            'summary_neutral', 'summary_spicy', 'why_it_matters', 'pattern_analysis',
+            'receipts_timeline', 'pardon_advocates',
+            'research_status', 'post_pardon_status', 'post_pardon_notes', 'is_public', 'needs_review', 'primary_source_url', 'source_urls'
+        ];
+
+        // PardonsTab Component
+        function PardonsTab({ password, supabase }) {
+            const [pardons, setPardons] = useState([]);
+            const [loading, setLoading] = useState(true);
+            const [loadingMore, setLoadingMore] = useState(false);
+            const [error, setError] = useState(null);
+            const [cursor, setCursor] = useState(null);
+            const [hasMore, setHasMore] = useState(false);
+
+            // Sub-tab: '' = All, 'false' = Drafts, 'true' = Published
+            const [isPublicFilter, setIsPublicFilter] = useState('');
+
+            // Filters
+            const [search, setSearch] = useState('');
+            const [debouncedSearch, setDebouncedSearch] = useState('');
+            const [crimeCategoryFilter, setCrimeCategoryFilter] = useState('');
+            const [connectionTypeFilter, setConnectionTypeFilter] = useState('');
+            const [corruptionLevelFilter, setCorruptionLevelFilter] = useState('');
+            const [researchStatusFilter, setResearchStatusFilter] = useState('');
+            const [enrichmentFilter, setEnrichmentFilter] = useState('');
+            const [sortBy, setSortBy] = useState('pardon_date');
+            const [sortDir, setSortDir] = useState('desc');
+
+            // Edit / Enrich / Undo state
+            const [editingPardon, setEditingPardon] = useState(null);
+            const [enrichingIds, setEnrichingIds] = useState(new Set());
+            const enrichSnapshotsRef = useRef({}); // { pardonId: originalEnrichedAt }
+            const [undoInfo, setUndoInfo] = useState(null);
+
+            // Request token for race control
+            const fetchTokenRef = useRef(0);
+
+            // Toast context
+            const toast = useToast();
+
+            // Debounce search input (300ms)
+            useEffect(() => {
+                const timer = setTimeout(() => {
+                    setDebouncedSearch(search);
+                }, 300);
+                return () => clearTimeout(timer);
+            }, [search]);
+
+            // Poll enriching pardons until enriched_at changes (or 2 min timeout)
+            const hasEnriching = enrichingIds.size > 0;
+            const enrichingIdsRef = useRef(enrichingIds);
+            enrichingIdsRef.current = enrichingIds;
+            useEffect(() => {
+                if (!hasEnriching) return;
+                const interval = setInterval(async () => {
+                    try {
+                        const ids = [...enrichingIdsRef.current];
+                        for (const id of ids) {
+                            const { data } = await supabase.functions.invoke('admin-pardons', {
+                                headers: { 'x-admin-password': password },
+                                body: { search: String(id), limit: 1 }
+                            });
+                            const fresh = data?.pardons?.find(p => p.id === id);
+                            if (!fresh) continue;
+                            const oldEnrichedAt = enrichSnapshotsRef.current[id];
+                            if (fresh.enriched_at && fresh.enriched_at !== oldEnrichedAt) {
+                                toast?.addToast(`Pardon #${id} enrichment complete`, 'success');
+                                delete enrichSnapshotsRef.current[id];
+                                setEnrichingIds(prev => { const s = new Set(prev); s.delete(id); return s; });
+                                setPardons(prev => prev.map(p => p.id === id ? { ...p, ...fresh } : p));
+                            }
+                        }
+                    } catch (_) { /* silently ignore polling errors */ }
+                }, 15000);
+                // 2 min timeout: clear all enriching states
+                const timeout = setTimeout(() => {
+                    enrichSnapshotsRef.current = {};
+                    setEnrichingIds(new Set());
+                }, 120000);
+                return () => { clearInterval(interval); clearTimeout(timeout); };
+            }, [hasEnriching]);
+
+            // Fetch pardons from edge function
+            const fetchPardons = useCallback(async (loadMore = false, nextCursor = null) => {
+                const token = ++fetchTokenRef.current;
+
+                if (loadMore) {
+                    setLoadingMore(true);
+                } else {
+                    setLoading(true);
+                }
+                setError(null);
+
+                try {
+                    const reqBody = { limit: 25, sortBy, sortDir };
+                    if (debouncedSearch) reqBody.search = debouncedSearch;
+                    if (isPublicFilter !== '') reqBody.isPublic = isPublicFilter;
+                    if (crimeCategoryFilter) reqBody.crimeCategory = crimeCategoryFilter;
+                    if (connectionTypeFilter) reqBody.connectionType = connectionTypeFilter;
+                    if (corruptionLevelFilter) reqBody.corruptionLevel = corruptionLevelFilter;
+                    if (researchStatusFilter) reqBody.researchStatus = researchStatusFilter;
+                    if (enrichmentFilter) reqBody.enrichment = enrichmentFilter;
+                    if (nextCursor) reqBody.cursor = nextCursor;
+
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-pardons',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: reqBody
+                        }
+                    );
+
+                    if (fnError) throw new Error(fnError.message || 'Failed to fetch pardons');
+
+                    // Stale response check
+                    if (token !== fetchTokenRef.current) return;
+
+                    if (loadMore) {
+                        setPardons(prev => [...prev, ...(data.pardons || [])]);
+                    } else {
+                        setPardons(data.pardons || []);
+                    }
+
+                    setCursor(data.pagination?.next_cursor || null);
+                    setHasMore(data.pagination?.has_more || false);
+                } catch (err) {
+                    if (token !== fetchTokenRef.current) return;
+                    console.error('Pardons fetch error:', err);
+                    setError(err.message);
+                } finally {
+                    if (token === fetchTokenRef.current) {
+                        setLoading(false);
+                        setLoadingMore(false);
+                    }
+                }
+            }, [supabase, password, debouncedSearch, isPublicFilter, crimeCategoryFilter, connectionTypeFilter, corruptionLevelFilter, researchStatusFilter, enrichmentFilter, sortBy, sortDir]);
+
+            // Re-fetch when filters change
+            useEffect(() => {
+                setCursor(null);
+                fetchPardons(false, null);
+            }, [fetchPardons, debouncedSearch, isPublicFilter, crimeCategoryFilter, connectionTypeFilter, corruptionLevelFilter, researchStatusFilter, enrichmentFilter, sortBy, sortDir]);
+
+            // Load more handler with guard
+            const handleLoadMore = () => {
+                if (hasMore && !loadingMore) {
+                    fetchPardons(true, cursor);
+                }
+            };
+
+            // Format date for display
+            const formatDate = (d) => {
+                if (!d) return '-';
+                const date = new Date(d + (d.includes('T') ? '' : 'T00:00:00'));
+                return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+            };
+
+            // Get corruption badge
+            const getCorruptionBadge = (level) => {
+                const info = CORRUPTION_LEVEL_MAP[level];
+                if (!info) return { class: 'badge-archived', label: '-' };
+                return { class: info.badgeClass, label: `${level} - ${info.label}` };
+            };
+
+            // Get research status badge
+            const getResearchBadge = (status) => {
+                if (status === 'complete') return { class: 'badge-active', label: 'Complete' };
+                if (status === 'in_progress') return { class: 'badge-pending', label: 'In Progress' };
+                return { class: 'badge-archived', label: 'Pending' };
+            };
+
+            // Get published badge
+            const getPublishedBadge = (isPublic) => {
+                return isPublic
+                    ? { class: 'badge-active', label: 'Published' }
+                    : { class: 'badge-pending', label: 'Draft' };
+            };
+
+            // Get enrichment badge
+            const getEnrichmentBadge = (enrichedAt) => {
+                return enrichedAt
+                    ? { class: 'badge-active', label: 'Enriched' }
+                    : { class: 'badge-archived', label: 'Not Enriched' };
+            };
+
+            // Handle edit button click
+            const handleEdit = (pardon) => {
+                setEditingPardon(pardon);
+            };
+
+            // Handle save from edit modal
+            const handleSaveEdit = (updatedPardon, undoData) => {
+                setPardons(prev => prev.map(p => p.id === updatedPardon.id ? { ...p, ...updatedPardon } : p));
+                setEditingPardon(null);
+                if (undoData) {
+                    setUndoInfo(undoData);
+                } else {
+                    toast?.addToast('Pardon updated successfully', 'success');
+                }
+            };
+
+            // Handle undo action
+            const handleUndo = async () => {
+                if (!undoInfo) return;
+                try {
+                    const { data, error: rpcError } = await supabase.rpc('undo_content_change', {
+                        p_entity_type: undoInfo.entityType,
+                        p_entity_id: undoInfo.entityId,
+                        p_changed_by: 'admin'
+                    });
+                    if (rpcError) throw new Error(rpcError.message);
+                    if (!data?.success) throw new Error(data?.error || 'Undo failed');
+                    toast?.addToast(`Restored ${data.field.replace(/_/g, ' ')}`, 'success');
+                    setUndoInfo(null);
+                    // Refresh list to get correct updated_at for continued locking
+                    fetchPardons(false, null);
+                } catch (err) {
+                    console.error('Undo error:', err);
+                    toast?.addToast(err.message || 'Failed to undo', 'error');
+                }
+            };
+
+            // Handle re-enrichment
+            const handleReEnrich = async (pardon) => {
+                if (enrichingIds.has(pardon.id)) return;
+                enrichSnapshotsRef.current[pardon.id] = pardon.enriched_at || null;
+                setEnrichingIds(prev => new Set([...prev, pardon.id]));
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'trigger-enrichment',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: { entity_type: 'pardon', entity_id: pardon.id }
+                        }
+                    );
+                    if (fnError) {
+                        let detail = fnError.message;
+                        try {
+                            const body = fnError.context ? await fnError.context.json() : data;
+                            if (body?.error) detail = body.error;
+                        } catch (_) {}
+                        throw new Error(detail || 'Failed to trigger re-enrichment');
+                    }
+                    if (data?.error) throw new Error(data.error);
+                    toast?.addToast(`Pardon queued for re-enrichment (~$${(data?.estimated_cost || 0.005).toFixed(3)})`, 'success');
+                    // Keep enrichingIds — polling will clear it when enriched_at changes
+                } catch (err) {
+                    console.error('Re-enrichment error:', err);
+                    toast?.addToast(err.message || 'Failed to trigger re-enrichment', 'error');
+                    // Only clear on error
+                    delete enrichSnapshotsRef.current[pardon.id];
+                    setEnrichingIds(prev => {
+                        const s = new Set(prev);
+                        s.delete(pardon.id);
+                        return s;
+                    });
+                }
+            };
+
+            // Handle publish toggle
+            const handleTogglePublish = async (pardon) => {
+                const newIsPublic = !pardon.is_public;
+                // Optimistic update
+                setPardons(prev => prev.map(p => p.id === pardon.id ? { ...p, is_public: newIsPublic } : p));
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-pardon',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                pardon_id: pardon.id,
+                                updates: { is_public: newIsPublic },
+                                original_updated_at: pardon.updated_at
+                            }
+                        }
+                    );
+                    if (fnError) {
+                        let body = data;
+                        try {
+                            if (!body && fnError.context) body = await fnError.context.json();
+                        } catch (_) {}
+                        throw new Error(body?.error || fnError.message || 'Toggle failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+                    // Update local row with server-returned updated_at for continued locking
+                    setPardons(prev => prev.map(p => p.id === pardon.id ? { ...p, ...data.pardon } : p));
+
+                    const changedFields = data.changed_fields || {};
+                    const firstField = Object.keys(changedFields)[0];
+                    if (firstField) {
+                        setUndoInfo({
+                            entityType: 'pardon',
+                            entityId: String(pardon.id),
+                            fieldName: firstField,
+                            oldValue: changedFields[firstField]?.old
+                        });
+                    } else {
+                        toast?.addToast(newIsPublic ? 'Published' : 'Unpublished', 'success');
+                    }
+                } catch (err) {
+                    console.error('Toggle publish error:', err);
+                    // Revert optimistic update
+                    setPardons(prev => prev.map(p => p.id === pardon.id ? { ...p, is_public: pardon.is_public } : p));
+                    toast?.addToast(err.message || 'Failed to toggle publish', 'error');
+                }
+            };
+
+            const subTabs = [
+                { value: '', label: 'All' },
+                { value: 'false', label: 'Drafts' },
+                { value: 'true', label: 'Published' },
+            ];
+
+            return (
+                <div>
+                    {/* Sub-tabs: All / Drafts / Published */}
+                    <div style={{ display: 'flex', gap: '4px', marginBottom: '16px' }}>
+                        {subTabs.map(tab => (
+                            <button
+                                key={tab.value}
+                                className={`tab-btn ${isPublicFilter === tab.value ? 'active' : ''}`}
+                                onClick={() => setIsPublicFilter(tab.value)}
+                            >
+                                {tab.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* Toolbar: Search + Filters */}
+                    <div className="stories-toolbar">
+                        <input
+                            type="text"
+                            className="stories-search"
+                            placeholder="Search by name or ID..."
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                        <select
+                            className="stories-select"
+                            value={crimeCategoryFilter}
+                            onChange={(e) => setCrimeCategoryFilter(e.target.value)}
+                        >
+                            <option value="">All Crime Categories</option>
+                            {Object.entries(CRIME_CATEGORY_LABELS).map(([val, label]) =>
+                                <option key={val} value={val}>{label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={connectionTypeFilter}
+                            onChange={(e) => setConnectionTypeFilter(e.target.value)}
+                        >
+                            <option value="">All Connections</option>
+                            {Object.entries(CONNECTION_TYPE_LABELS).map(([val, label]) =>
+                                <option key={val} value={val}>{label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={corruptionLevelFilter}
+                            onChange={(e) => setCorruptionLevelFilter(e.target.value)}
+                        >
+                            <option value="">All Corruption Levels</option>
+                            {CORRUPTION_LEVELS.map(l =>
+                                <option key={l.value} value={l.value}>{l.value} - {l.label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={researchStatusFilter}
+                            onChange={(e) => setResearchStatusFilter(e.target.value)}
+                        >
+                            <option value="">All Research Status</option>
+                            <option value="complete">Complete</option>
+                            <option value="in_progress">In Progress</option>
+                            <option value="pending">Pending</option>
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={enrichmentFilter}
+                            onChange={(e) => setEnrichmentFilter(e.target.value)}
+                        >
+                            <option value="">All Enrichment</option>
+                            <option value="enriched">Enriched</option>
+                            <option value="pending">Not Enriched</option>
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={`${sortBy}-${sortDir}`}
+                            onChange={(e) => {
+                                const parts = e.target.value.split('-');
+                                setSortBy(parts[0]);
+                                setSortDir(parts[1]);
+                            }}
+                        >
+                            <option value="pardon_date-desc">Date (Newest)</option>
+                            <option value="pardon_date-asc">Date (Oldest)</option>
+                            <option value="corruption_level-desc">Corruption (High-Low)</option>
+                            <option value="corruption_level-asc">Corruption (Low-High)</option>
+                            <option value="name-asc">Name (A-Z)</option>
+                            <option value="name-desc">Name (Z-A)</option>
+                            <option value="id-desc">ID (Newest)</option>
+                            <option value="id-asc">ID (Oldest)</option>
+                        </select>
+                    </div>
+
+                    {error && (
+                        <div className="error-banner">
+                            <strong>Error:</strong> {error}
+                        </div>
+                    )}
+
+                    {loading ? (
+                        <div className="loading">
+                            <div className="spinner"></div>
+                            Loading pardons...
+                        </div>
+                    ) : (
+                        <div className="card">
+                            <div className="card-header">
+                                <h2 className="card-title">Pardons</h2>
+                                <span className="stories-count">
+                                    Showing {pardons.length} pardons
+                                    {hasMore && ' (more available)'}
+                                </span>
+                            </div>
+                            <div style={{ overflowX: 'auto' }}>
+                                <table className="stories-table">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>Name</th>
+                                            <th>Date</th>
+                                            <th>Clemency</th>
+                                            <th>Corruption</th>
+                                            <th>Connection</th>
+                                            <th>Category</th>
+                                            <th>Published</th>
+                                            <th>Research</th>
+                                            <th>Enriched</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {pardons.length === 0 && (
+                                            <tr>
+                                                <td colSpan={11} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                                                    No pardons found matching your filters.
+                                                </td>
+                                            </tr>
+                                        )}
+                                        {pardons.map(pardon => {
+                                            const corruptBadge = getCorruptionBadge(pardon.corruption_level);
+                                            const pubBadge = getPublishedBadge(pardon.is_public);
+                                            const resBadge = getResearchBadge(pardon.research_status);
+                                            const enrBadge = getEnrichmentBadge(pardon.enriched_at);
+
+                                            return (
+                                                <tr key={pardon.id}>
+                                                    <td style={{ color: '#64748b', fontSize: '13px' }}>{pardon.id}</td>
+                                                    <td style={{ maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: '#e2e8f0' }} title={pardon.recipient_name}>
+                                                        {pardon.recipient_name || '(Unknown)'}
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {formatDate(pardon.pardon_date)}
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {pardon.clemency_type || '-'}
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${corruptBadge.class}`}>{corruptBadge.label}</span>
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {CONNECTION_TYPE_LABELS[pardon.primary_connection_type] || pardon.primary_connection_type || '-'}
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {CRIME_CATEGORY_LABELS[pardon.crime_category] || pardon.crime_category || '-'}
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${pubBadge.class}`}>{pubBadge.label}</span>
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${resBadge.class}`}>{resBadge.label}</span>
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${enrBadge.class}`}>{enrBadge.label}</span>
+                                                    </td>
+                                                    <td>
+                                                        <div className="row-actions">
+                                                            <button className="btn-icon" onClick={() => handleEdit(pardon)} title="Edit">
+                                                                ✏️ Edit
+                                                            </button>
+                                                            <button
+                                                                className={`btn-icon${enrichingIds.has(pardon.id) ? ' enriching' : ''}`}
+                                                                onClick={() => handleReEnrich(pardon)}
+                                                                disabled={enrichingIds.has(pardon.id)}
+                                                                title="Re-enrich"
+                                                            >
+                                                                {enrichingIds.has(pardon.id)
+                                                                    ? <><span className="spinner-sm"></span> Enriching</>
+                                                                    : '🤖 Enrich'
+                                                                }
+                                                            </button>
+                                                            <button className="btn-icon" onClick={() => handleTogglePublish(pardon)} title={pardon.is_public ? 'Unpublish' : 'Publish'}>
+                                                                {pardon.is_public ? '📤 Unpublish' : '📥 Publish'}
+                                                            </button>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                            {hasMore && (
+                                <div style={{ padding: '0 20px 20px' }}>
+                                    <button
+                                        className="load-more-btn"
+                                        onClick={handleLoadMore}
+                                        disabled={loadingMore}
+                                    >
+                                        {loadingMore ? 'Loading...' : 'Load More'}
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Edit Pardon Modal */}
+                    {editingPardon && (
+                        <EditPardonModal
+                            pardon={editingPardon}
+                            onClose={() => setEditingPardon(null)}
+                            onSave={handleSaveEdit}
+                            onRefresh={() => fetchPardons(false, null)}
+                            supabase={supabase}
+                            password={password}
+                        />
+                    )}
+
+                    {/* Undo Toast */}
+                    {undoInfo && (
+                        <div className="toast-container">
+                            <UndoToast
+                                entityType={undoInfo.entityType}
+                                entityId={undoInfo.entityId}
+                                fieldName={undoInfo.fieldName}
+                                oldValue={undoInfo.oldValue}
+                                onUndo={handleUndo}
+                                onDismiss={() => setUndoInfo(null)}
+                            />
                         </div>
                     )}
                 </div>
@@ -1158,7 +3192,7 @@
             const tabs = [
                 { id: 'home', label: 'Home' },
                 { id: 'stories', label: 'Stories' },
-                { id: 'pardons', label: 'Pardons', disabled: true },
+                { id: 'pardons', label: 'Pardons' },
                 { id: 'scotus', label: 'SCOTUS', disabled: true },
                 { id: 'eos', label: 'Exec Orders', disabled: true },
                 { id: 'feeds', label: 'Feeds', disabled: true }
@@ -1445,7 +3479,11 @@
                             <StoriesTab password={password} supabase={supabase} />
                         )}
 
-                        {activeTab !== 'home' && activeTab !== 'stories' && (
+                        {activeTab === 'pardons' && (
+                            <PardonsTab password={password} supabase={supabase} />
+                        )}
+
+                        {activeTab !== 'home' && activeTab !== 'stories' && activeTab !== 'pardons' && (
                             <div className="card">
                                 <div className="card-body" style={{ textAlign: 'center', padding: '60px 20px' }}>
                                     <div style={{ fontSize: '48px', marginBottom: '16px' }}>🚧</div>
@@ -1461,7 +3499,12 @@
             );
         }
 
-        ReactDOM.render(<AdminDashboard />, document.getElementById('root'));
+        ReactDOM.render(
+            <ToastProvider>
+                <AdminDashboard />
+            </ToastProvider>,
+            document.getElementById('root')
+        );
     </script>
 </body>
 </html>

--- a/scripts/enrichment/enrich-single-story.js
+++ b/scripts/enrichment/enrich-single-story.js
@@ -84,10 +84,11 @@ async function main() {
   } catch (err) {
     console.error(`❌ Enrichment failed:`, err.message);
 
-    // Update failure count
+    // Update failure count and clear pending status
     await supabase
       .from('stories')
       .update({
+        enrichment_status: null,
         enrichment_failure_count: story.enrichment_failure_count + 1,
         last_error_message: err.message?.slice(0, 500)
       })

--- a/scripts/enrichment/prompts/stories.js
+++ b/scripts/enrichment/prompts/stories.js
@@ -1,0 +1,298 @@
+// Story Enrichment Prompts
+// Used by enrich-stories-inline.js and job-queue-worker.js
+
+// Dynamic year for prompts - use UTC to avoid timezone-related off-by-one day/year issues
+const CURRENT_YEAR = new Date().getUTCFullYear();
+
+export const SYSTEM_PROMPT = `You are a political analyst writing for TrumpyTracker. Return ONLY valid JSON (a single JSON object), no prose.
+
+CONTEXT: It's ${CURRENT_YEAR}. Trump is president. Reference current political reality accurately.
+
+═══════════════════════════════════════════════════════════════════════════════
+VOICE: "THE CHAOS"
+═══════════════════════════════════════════════════════════════════════════════
+
+Your voice is "The Chaos" — Look at this specific dumpster fire inside the larger dumpster fire.
+
+PERSPECTIVE:
+- You're writing for a progressive audience who opposes Trump and the Republican agenda.
+- Don't "both sides" corruption - when Republicans are doing the damage, say so.
+- This is accountability journalism from a liberal viewpoint, not neutral reporting.
+
+═══════════════════════════════════════════════════════════════════════════════
+TONE CALIBRATION BY ALARM LEVEL (0-5)
+═══════════════════════════════════════════════════════════════════════════════
+
+LEVEL 5 - "Constitutional Dumpster Fire"
+Tone: Cold fury. Prosecutorial. This is a crisis.
+Energy: Name names. Follow the money. Document the damage.
+Profanity: YES - for incredulity, not just anger.
+Example: "They actually fucking did it. Here's who gets hurt."
+
+LEVEL 4 - "Criminal Bullshit"
+Tone: Angry accountability. Suspicious and pointed.
+Energy: Who benefits? Who gets screwed? Make it personal.
+Profanity: YES - when it lands.
+Example: "YOUR tax dollars paid for this. Here's where they went."
+
+LEVEL 3 - "The Deep Swamp"
+Tone: Weary sardonic. "Seen this before" energy.
+Energy: Dark humor, let absurdity speak for itself.
+Profanity: NO.
+Example: "Standard operating procedure. The swamp feeds itself."
+
+LEVEL 2 - "The Great Gaslight"
+Tone: Eye-roll. Measured critique.
+Energy: Point out the spin, the misdirection, the bullshit.
+Profanity: NO.
+Example: "They said X. They did Y. Notice the gap?"
+
+LEVEL 1 - "Accidental Sanity"
+Tone: Cautious acknowledgment with context.
+Energy: Credit where due, but flag the asterisks.
+Profanity: NO.
+Example: "Against expectations, they got one right. Read the fine print."
+
+LEVEL 0 - "A Broken Clock Moment"
+Tone: Suspicious celebration. Genuine disbelief.
+Energy: The system worked. Don't get used to it.
+Profanity: NO.
+Example: "We checked twice. This is actually... good news?"
+
+═══════════════════════════════════════════════════════════════════════════════
+BANNED OPENINGS (never use these)
+═══════════════════════════════════════════════════════════════════════════════
+
+- "This is outrageous..."
+- "In a shocking move..."
+- "Once again..."
+- "It's no surprise..."
+- "Make no mistake..."
+- "Let that sink in..."
+- "Guess what?"
+- "So, " / "Well, " / "Look, " (as openers)
+- "In a stunning..." / "In a brazen..."
+- "Shocking absolutely no one..."
+- "In the latest move..."
+- "It remains to be seen..."
+
+═══════════════════════════════════════════════════════════════════════════════
+THIS CALL'S CREATIVE DIRECTION
+═══════════════════════════════════════════════════════════════════════════════
+
+{variation_injection}
+
+═══════════════════════════════════════════════════════════════════════════════
+OUTPUT FORMAT
+═══════════════════════════════════════════════════════════════════════════════
+
+Generate these outputs:
+
+1. summary_neutral (~100-140 words):
+   Strictly factual, concise, no hype, no opinion, no loaded language.
+   Include names, dates, and numbers when present.
+
+2. summary_spicy (~200-300 words):
+   ANGRY and TRUTHFUL. Match tone to alarm_level.
+   End with what readers should watch for OR one concrete thing they can do.
+
+3. alarm_level (0-5):
+   How alarming is this story? Use the calibration above.
+   5 = constitutional crisis, 0 = actually good news
+
+4. category: one of [Corruption & Scandals; Democracy & Elections; Policy & Legislation; Justice & Legal; Executive Actions; Foreign Policy; Corporate & Financial; Civil Liberties; Media & Disinformation; Epstein & Associates; Other]
+
+5. primary_actor: the entity PERFORMING the main action (the subject of the headline's verb).
+   For government actions, use the agency (ICE, DOJ, FBI), not the president unless he is directly acting.
+   Examples: "ICE conducts raid" → "ICE", "DOJ files suit" → "DOJ", "Trump signs order" → "Trump"
+
+6. entities: array of 3-8 key entities using CANONICAL IDs with stable prefixes:
+   * PERSON: US-<LASTNAME> (e.g., US-TRUMP, US-BIDEN, US-PELOSI)
+   * ORG: ORG-<CANONICAL_SNAKE> (e.g., ORG-DOJ, ORG-DHS, ORG-SUPREME-COURT, ORG-NYT)
+   * LOCATION: LOC-<REGION> (e.g., LOC-USA, LOC-TEXAS, LOC-CALIFORNIA)
+   * EVENT: EVT-<CANONICAL> (e.g., EVT-JAN6, EVT-IMPEACHMENT-2, EVT-HB-1234)
+
+   Entity format:
+   {
+     "id": "US-TRUMP",
+     "name": "Donald Trump",
+     "type": "PERSON",
+     "confidence": 0.95
+   }
+
+   Guidelines:
+   - Only include high-confidence entities (≥0.70)
+   - If you cannot assign a canonical ID, omit that entity
+   - Prefer fewer, higher-quality entities over many weak ones
+   - Keep diverse entity types (avoid all PERSONs unless justified)
+   - Sort by salience/importance
+   - For government agency stories, prioritize the agency (ORG-ICE, ORG-DOJ, ORG-FBI)
+   - Only include the president (US-TRUMP) if he is directly acting or quoted
+
+═══════════════════════════════════════════════════════════════════════════════
+RULES
+═══════════════════════════════════════════════════════════════════════════════
+
+- Use ONLY the provided snippets; do not speculate. If uncertain, keep it neutral.
+- Do not include citations or URLs in summaries.
+- Match tone to alarm_level (profanity ONLY at levels 4-5).
+- Output must be valid JSON with these exact keys: summary_neutral, summary_spicy, alarm_level, category, primary_actor, entities.`;
+
+// Enhanced enrichment prompt with action framework (TTRC-61 & TTRC-62)
+export const ENHANCED_SYSTEM_PROMPT = `You are a political analyst. Return ONLY valid JSON (a single JSON object), no prose.
+
+Generate enriched story data based solely on the provided article snippets:
+
+1. SUMMARIES (3 types):
+   - summary_neutral: ~100-140 words. Strictly factual, concise, no opinion. Include names, dates, numbers.
+   - summary_spicy: ~100-140 words. Truthful but punchy. Highlight hypocrisy, stakes, real impact. No profanity.
+   - summary_what_it_means: ~150-200 words. Plain English breakdown of real-world impact. Cut through euphemisms. Explain why regular people should care. Example: "Border security facility" → "Detention center designed to deter immigration through family separation."
+
+2. METADATA:
+   - category: one of [Corruption & Scandals; Democracy & Elections; Policy & Legislation; Justice & Legal; Executive Actions; Foreign Policy; Corporate & Financial; Civil Liberties; Media & Disinformation; Epstein & Associates; Other]
+   - severity: one of [critical, severe, moderate, minor]
+   - primary_actor: the entity PERFORMING the main action (the subject of the headline's verb).
+     For government actions, use the agency (ICE, DOJ, FBI), not the president unless he is directly acting.
+     Examples: "ICE conducts raid" → "ICE", "DOJ files suit" → "DOJ", "Trump signs order" → "Trump"
+   - regions: array of geographic areas affected (e.g., ["Texas", "Border States", "National"]). Use "National" for nationwide impact.
+   - policy_areas: array of policy topics (e.g., ["Immigration", "Civil Rights", "Healthcare", "Economy", "Environment"]). Max 3.
+
+3. ACTION FRAMEWORK (Tiered System):
+   You MUST determine the appropriate action tier and provide corresponding content:
+
+   TIER 1 - DIRECT ACTION (~30% of stories):
+   - When: Specific organizations working on THIS issue + concrete events/deadlines OR ongoing harm with clear advocacy
+   - Requirements: 2+ SPECIFIC actions (not generic), each with 8+ specificity score
+   - Output: action_tier="direct", action_section with title "What We Can Do"
+
+   TIER 2 - SYSTEMIC (~50% of stories):
+   - When: Damage already done (e.g., pardons, appointments) OR no direct intervention possible
+   - Reframe: "This is done, but here's how we prevent the next one" or "Build long-term power"
+   - Requirements: Focus on infrastructure (journalism, voter engagement, accountability orgs)
+   - Output: action_tier="systemic", action_section with title "How We Fight Back"
+
+   TIER 3 - TRACKING (~20% of stories):
+   - When: Cannot identify 2+ specific actions OR action_confidence <7/10
+   - Output: action_tier="tracking", action_section=null
+   - Better to omit than give weak/generic suggestions
+
+   ACTION SECTION STRUCTURE (for Tier 1 & 2 only):
+   {
+     "title": "What We Can Do" | "How We Fight Back",
+     "actions": [
+       {
+         "type": "donate" | "call" | "attend" | "support" | "organize" | "vote",
+         "description": "SPECIFIC action with details (not generic 'call your reps')",
+         "specificity": 0-10 (how specific vs generic, must be 7+ for Tier 1),
+         "url": "https://..." (optional but preferred),
+         "deadline": "YYYY-MM-DD" (optional)
+       }
+     ]
+   }
+
+   QUALITY CHECKS:
+   - Calculate action_confidence: 0-10 score for action quality
+   - Provide action_reasoning: brief explanation of tier choice
+   - If confidence <7 OR <2 specific actions → default to Tier 2 (systemic)
+   - NEVER include generic actions without context (e.g., "call your representative" without specific bill/deadline)
+
+EXAMPLES:
+
+Tier 1 Example (Immigration Detention):
+{
+  "action_tier": "direct",
+  "action_confidence": 9,
+  "action_reasoning": "Ongoing harm with specific orgs providing direct aid and concrete events",
+  "action_section": {
+    "title": "What We Can Do",
+    "actions": [
+      {
+        "type": "donate",
+        "description": "Support RAICES Texas bond fund to help families get released while awaiting hearings",
+        "specificity": 9,
+        "url": "https://www.raicestexas.org/bond-fund"
+      },
+      {
+        "type": "call",
+        "description": "Call your representative (202-224-3121) and demand they visit the detention facility",
+        "specificity": 8
+      }
+    ]
+  }
+}
+
+Tier 2 Example (Presidential Pardon):
+{
+  "action_tier": "systemic",
+  "action_confidence": 7,
+  "action_reasoning": "Pardons already issued, cannot reverse, reframe as long-term power building",
+  "action_section": {
+    "title": "How We Fight Back",
+    "actions": [
+      {
+        "type": "vote",
+        "description": "Vote in 2026 primaries to challenge senators who stayed silent on pardon abuse",
+        "specificity": 7
+      },
+      {
+        "type": "support",
+        "description": "Fund accountability journalism at ProPublica and similar outlets to keep tracking these stories",
+        "specificity": 8,
+        "url": "https://www.propublica.org/donate"
+      }
+    ]
+  }
+}
+
+Tier 3 Example (Vague Appointment):
+{
+  "action_tier": "tracking",
+  "action_confidence": 4,
+  "action_reasoning": "Once appointed, limited actionable response. Only generic suggestions possible.",
+  "action_section": null
+}
+
+OUTPUT FORMAT:
+{
+  "summary_neutral": "...",
+  "summary_spicy": "...",
+  "summary_what_it_means": "...",
+  "category": "...",
+  "severity": "...",
+  "primary_actor": "...",
+  "regions": [...],
+  "policy_areas": [...],
+  "action_tier": "direct" | "systemic" | "tracking",
+  "action_confidence": 0-10,
+  "action_reasoning": "...",
+  "action_section": { ... } | null
+}
+
+RULES:
+- Use ONLY provided snippets; do not speculate
+- No citations or URLs in summaries
+- Action URLs must be real organizations (don't make up URLs)
+- Default to Tier 2 if uncertain about action quality
+- Better to omit actions (Tier 3) than provide weak ones
+- Output must be valid JSON with all specified keys`;
+
+/**
+ * Build user payload for OpenAI enrichment
+ * @param {Object} params
+ * @param {string} params.primary_headline - Story headline
+ * @param {Array} params.articles - Array of article objects with title, source_name, excerpt
+ * @returns {string} Formatted payload string
+ */
+export function buildUserPayload({ primary_headline, articles }) {
+  const lines = [];
+  lines.push('Story context');
+  lines.push(`Headline: ${primary_headline || ''}`);
+  lines.push('');
+  lines.push('Articles (max 6; title + brief excerpt):');
+  for (const a of articles) {
+    lines.push(`- Title: ${a.title} | Source: ${a.source_name}`);
+    lines.push(`  ${a.excerpt}`);
+    lines.push('---');
+  }
+  return lines.join('\n');
+}

--- a/scripts/enrichment/stories-style-patterns.js
+++ b/scripts/enrichment/stories-style-patterns.js
@@ -1,0 +1,770 @@
+/**
+ * Stories Style Patterns (ADO-274)
+ *
+ * Frame-based variation system for Stories enrichment to prevent repetitive GPT outputs.
+ *
+ * Architecture:
+ * - 3 frame buckets: alarmed | critical | grudging_credit
+ * - 3 topic pools: investigations | policy | general (from feed_registry.topics)
+ * - 9 total pools (topic × frame)
+ * - Patterns from shared core + Stories-specific additions
+ * - Deterministic selection via FNV-1a hash with bias toward Stories-specific patterns
+ * - Tier (1-3) used as nudge for frame estimation, NOT as pool dimension
+ *
+ * Frame ≠ Intensity:
+ * - Frame: Directional stance (controlled by variation system)
+ * - Intensity: Emotional temperature (controlled by tone calibration in prompt)
+ *
+ * Usage:
+ *   import { estimateStoryFrame, selectVariation, buildVariationInjection, getStoryPoolKey, getStoryContentId } from './stories-style-patterns.js';
+ *   const frame = estimateStoryFrame(story.primary_headline, feedTier);
+ *   const poolKey = getStoryPoolKey(feedTopics, frame);
+ *   const variation = selectVariation(poolKey, contentId, promptVersion, recentIds);
+ *   const injection = buildVariationInjection(variation, frame);
+ */
+
+import { CORE_STYLE_PATTERNS, fnv1a32 } from '../shared/style-patterns-core.js';
+
+// ============================================================================
+// PROMPT VERSION (update when patterns change significantly)
+// ============================================================================
+
+export const PROMPT_VERSION = 'v4-ado274';
+
+// ============================================================================
+// TUNING KNOBS (exported for easy adjustment)
+// ============================================================================
+
+// Threshold for Stories-specific pattern bias (0-100)
+// Below threshold: pick from Stories-specific patterns
+// At or above threshold: pick from core patterns
+export const STORIES_SPECIFIC_BIAS_THRESHOLD = 40;
+
+// ============================================================================
+// STORIES-SPECIFIC STYLE PATTERNS (~15 patterns)
+// ============================================================================
+
+export const STORIES_SPECIFIC_PATTERNS = [
+  // --- BREAKING NEWS PATTERNS ---
+  {
+    id: 'story-breaking-impact',
+    opening_approach: 'Lead with immediate impact of breaking news.',
+    rhetorical_device: 'Cut through noise to essential change.',
+    structure: 'What just happened -> who is affected -> why now -> what next.',
+    closing_approach: 'End with what to watch for in next 24-48 hours.'
+  },
+  {
+    id: 'story-developing',
+    opening_approach: 'Open with what we know and what we do not.',
+    rhetorical_device: 'Distinguish confirmed from rumored.',
+    structure: 'Confirmed facts -> open questions -> competing narratives -> stakes.',
+    closing_approach: 'End with key questions that remain.'
+  },
+
+  // --- INVESTIGATIONS POOL SPECIFICS ---
+  {
+    id: 'story-investigation-trail',
+    opening_approach: 'Lead with the investigative thread being pulled.',
+    rhetorical_device: 'Frame as accountability journalism at work.',
+    structure: 'What was found -> how it connects -> who is implicated -> next steps.',
+    closing_approach: 'End with what investigators are looking at next.'
+  },
+  {
+    id: 'story-corruption-receipt',
+    opening_approach: 'Open with the most damning documented detail.',
+    rhetorical_device: 'Let receipts speak for themselves.',
+    structure: 'Documented fact -> timeline -> pattern -> implication.',
+    closing_approach: 'End with what the receipts make undeniable.'
+  },
+  {
+    id: 'story-scandal-names',
+    opening_approach: 'Lead by naming the specific actors involved.',
+    rhetorical_device: 'Attach actions to names, not passive voice.',
+    structure: 'Who did what -> when -> with what consequence -> accountability status.',
+    closing_approach: 'End with whether accountability is possible.'
+  },
+
+  // --- POLICY POOL SPECIFICS ---
+  {
+    id: 'story-policy-translation',
+    opening_approach: 'Open by translating policy-speak into plain impact.',
+    rhetorical_device: 'Cut through bureaucratic language.',
+    structure: 'What they said -> what it actually means -> who benefits/loses -> timeline.',
+    closing_approach: 'End with when regular people will feel this.'
+  },
+  {
+    id: 'story-policy-winners',
+    opening_approach: 'Lead with who wins and who loses.',
+    rhetorical_device: 'Frame policy as distribution, not abstraction.',
+    structure: 'Winners -> losers -> mechanism -> political context.',
+    closing_approach: 'End with whose interests drove this.'
+  },
+  {
+    id: 'story-analysis-context',
+    opening_approach: 'Open with the broader context this fits into.',
+    rhetorical_device: 'Connect dots across time and pattern.',
+    structure: 'Current event -> historical parallel -> pattern -> trajectory.',
+    closing_approach: 'End with what the pattern predicts.'
+  },
+
+  // --- GENERAL POOL SPECIFICS ---
+  {
+    id: 'story-chaos-specific',
+    opening_approach: 'Lead with this specific chaos within the larger chaos.',
+    rhetorical_device: 'Use dumpster fire framing without being lazy.',
+    structure: 'This specific mess -> how it connects to larger mess -> consequences.',
+    closing_approach: 'End with what this chaos enables.'
+  },
+  {
+    id: 'story-absurdity-flat',
+    opening_approach: 'Open by stating the absurd element flatly.',
+    rhetorical_device: 'Deadpan delivery letting absurdity land naturally.',
+    structure: 'Absurd fact -> context -> why this is happening -> implication.',
+    closing_approach: 'End without editorializing, let the fact sit.'
+  },
+  {
+    id: 'story-weary-pattern',
+    opening_approach: 'Lead with weary recognition of recurring pattern.',
+    rhetorical_device: 'This again framing without fatigue.',
+    structure: 'Pattern identified -> this instance -> why it keeps happening -> what would change it.',
+    closing_approach: 'End with systemic note.'
+  },
+
+  // --- LOW ALARM PATTERNS (for grudging_credit frame) ---
+  {
+    id: 'story-credit-asterisk',
+    opening_approach: 'Acknowledge the positive while noting the asterisks.',
+    rhetorical_device: 'Credit where due without abandoning skepticism.',
+    structure: 'What happened -> why it is good -> the caveats -> what to watch.',
+    closing_approach: 'End with whether this represents a pattern or exception.'
+  },
+  {
+    id: 'story-system-worked',
+    opening_approach: 'Lead with which part of the system actually functioned.',
+    rhetorical_device: 'Frame as guardrails holding, not administration goodness.',
+    structure: 'What was blocked -> who blocked it -> mechanism -> fragility.',
+    closing_approach: 'End with whether the guardrail is still secure.'
+  },
+  {
+    id: 'story-unexpected-good',
+    opening_approach: 'Open with genuine acknowledgment of unexpected outcome.',
+    rhetorical_device: 'Suspicious optimism energy.',
+    structure: 'Good news -> context -> why unexpected -> sustainability.',
+    closing_approach: 'End with do not get used to it but appreciate this one.'
+  }
+];
+
+// ============================================================================
+// COMBINED PATTERN POOLS (Core + Stories-Specific)
+// ============================================================================
+
+// Combine core patterns with Stories-specific patterns
+export const ALL_STORIES_PATTERNS = [...CORE_STYLE_PATTERNS, ...STORIES_SPECIFIC_PATTERNS];
+
+// Build pattern lookup by ID with collision check (fail-closed on duplicates)
+const PATTERN_BY_ID = {};
+for (const p of ALL_STORIES_PATTERNS) {
+  if (PATTERN_BY_ID[p.id]) {
+    throw new Error(`Duplicate pattern ID detected: "${p.id}" - check CORE_STYLE_PATTERNS and STORIES_SPECIFIC_PATTERNS`);
+  }
+  PATTERN_BY_ID[p.id] = p;
+}
+
+// ============================================================================
+// POOL KEY PARSING
+// ============================================================================
+
+/**
+ * Parse pool key into topic and frame components
+ * Handles multi-part frames like "grudging_credit"
+ * Fail-soft: defaults to 'general' topic and 'critical' frame if malformed
+ *
+ * @param {string} poolKey - Pool key (e.g., "policy_grudging_credit")
+ * @returns {{ topicPool: string, frame: string }}
+ */
+function parsePoolKey(poolKey) {
+  const [topicPool, ...frameParts] = String(poolKey || '').split('_');
+  const frame = frameParts.join('_') || 'critical';
+  const topic = topicPool || 'general';
+  return { topicPool: topic, frame };
+}
+
+// ============================================================================
+// FEED TOPIC MAPPING
+// ============================================================================
+
+/**
+ * Map feed_registry.topics array to story pool topic
+ * @param {string[]} topics - Array of topics from feed_registry
+ * @returns {'investigations' | 'policy' | 'general'} Pool topic
+ */
+export function mapFeedTopicsToPool(topics) {
+  if (!topics || !Array.isArray(topics) || topics.length === 0) {
+    return 'general';
+  }
+
+  // Safely convert to lowercase strings
+  const topicsLower = topics.map(t => String(t).toLowerCase());
+
+  // Investigations pool: scrutiny-focused sources
+  if (topicsLower.some(t =>
+    t.includes('investigation') ||
+    t.includes('corruption') ||
+    t.includes('accountability') ||
+    t.includes('watchdog')
+  )) {
+    return 'investigations';
+  }
+
+  // Policy pool: analysis-focused sources
+  if (topicsLower.some(t =>
+    t.includes('policy') ||
+    t.includes('legislation') ||
+    t.includes('congress') ||
+    t.includes('analysis')
+  )) {
+    return 'policy';
+  }
+
+  // Default: general coverage
+  return 'general';
+}
+
+// ============================================================================
+// FRAME ESTIMATION
+// ============================================================================
+
+// Negative-context patterns that indicate "blocked/stopped" is BAD news
+// NOTE: Allow a few bridge-words ("DOJ", "congressional", etc.) between the verb and the noun.
+// Example: "Trump blocked DOJ investigation" should be negative context (NOT grudging_credit).
+const NEGATIVE_CONTEXT_PATTERNS = [
+  /\bblock(?:ed|s|ing)?\s+(?:\w+\s+){0,3}(aid|relief|funding|assistance|access|investigation|inquiry|oversight|probe|subpoena|testimony)\b/i,
+  /\bstop(?:ped|s|ping)?\s+(?:\w+\s+){0,3}(aid|relief|funding|assistance|access|investigation|inquiry|oversight|probe|subpoena|testimony)\b/i,
+  /\boverturned\s+(?:\w+\s+){0,2}(protection|rights|ruling|decision)\b/i,
+  /\bstruck\s+down\s+(?:\w+\s+){0,2}(protection|rights|law)\b/i
+];
+
+/**
+ * Check if headline contains negative context that would make
+ * credit-sounding words actually bad news
+ * @param {string} text - Lowercase headline text
+ * @returns {boolean}
+ */
+function hasNegativeContext(text) {
+  return NEGATIVE_CONTEXT_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
+ * Estimate frame bucket from story metadata (pre-enrichment)
+ *
+ * Frame buckets:
+ * - alarmed: Crisis mode, this is an attack (maps to alarm levels 4-5)
+ * - critical: Standard sardonic voice, default (maps to alarm levels 2-3)
+ * - grudging_credit: Credit where due (maps to alarm levels 0-1)
+ *
+ * @param {string} headline - Story primary_headline
+ * @param {number|null} tier - Feed tier (1-3), used as nudge
+ * @returns {'alarmed' | 'critical' | 'grudging_credit'} Frame bucket
+ */
+export function estimateStoryFrame(headline, tier) {
+  // Warn if no headline provided (data quality issue)
+  if (!headline) {
+    console.warn('estimateStoryFrame: No headline provided, defaulting to critical frame');
+    return 'critical';
+  }
+
+  // Safely convert to lowercase string
+  const text = String(headline).toLowerCase();
+
+  // Safely convert tier to number (handles string "1" from config)
+  const tierNum = tier == null ? null : Number(tier);
+
+  // ALARMED: Strong crisis signals
+  const alarmedPatterns = [
+    /insurrection/,
+    /coup/,
+    /fascis/,
+    /authoritarian/,
+    /martial\s+law/,
+    /mass\s+deportation/,
+    /constitutional\s+crisis/,
+    /impeach/,
+    /indicted?/,
+    /arrested/,
+    /raided?/,
+    /charged\s+with/,
+    /emergency\s+powers?/,
+    /suspend(ed|s)?\s+(rights|constitution|habeas)/,
+    /dictator|dictatorship/  // Tightened: was /dictat/ which matched "dictate"
+  ];
+
+  for (const pattern of alarmedPatterns) {
+    if (pattern.test(text)) return 'alarmed';
+  }
+
+  // Tier 1 sources (breaking news) + urgent language bias toward alarmed
+  if (tierNum === 1 && /breaking|urgent|emergency|crisis/.test(text)) {
+    return 'alarmed';
+  }
+
+  // GRUDGING_CREDIT: Explicit good news signals (rare)
+  // Check for negative context first - "blocked aid" is bad, not good
+  if (hasNegativeContext(text)) {
+    return 'critical'; // Don't misclassify as good news
+  }
+
+  // Note: Some patterns like "blocked" can still be ambiguous.
+  // The mismatch fuse in the prompt lets GPT correct if frame estimate is wrong.
+  const creditPatterns = [
+    /victory\s+for/,
+    /wins?\s+(case|suit|ruling|appeal)/,
+    /court\s+rules?\s+against/,
+    /blocked/,
+    /stopped/,
+    /defeated/,
+    /overturned/,
+    /struck\s+down/,
+    /dismissed/,
+    /acquitted/,
+    /exonerated/,
+    /protected/,
+    /restored/
+  ];
+
+  for (const pattern of creditPatterns) {
+    if (pattern.test(text)) return 'grudging_credit';
+  }
+
+  // DEFAULT: Critical (the baseline TrumpyTracker voice)
+  return 'critical';
+}
+
+// ============================================================================
+// POOL KEY SELECTION
+// ============================================================================
+
+/**
+ * Get the pool key for a story
+ *
+ * Pool structure: {topic}_{frame}
+ * - investigations_alarmed, investigations_critical, investigations_grudging_credit
+ * - policy_alarmed, policy_critical, policy_grudging_credit
+ * - general_alarmed, general_critical, general_grudging_credit
+ *
+ * @param {string[]} feedTopics - Topics from feed_registry
+ * @param {'alarmed' | 'critical' | 'grudging_credit'} frame - Estimated frame
+ * @returns {string} Pool key
+ */
+export function getStoryPoolKey(feedTopics, frame) {
+  const topicPool = mapFeedTopicsToPool(feedTopics);
+  return `${topicPool}_${frame}`;
+}
+
+// ============================================================================
+// PATTERN SELECTION BY POOL
+// ============================================================================
+
+/**
+ * Get Stories-specific patterns for a given topic pool and frame
+ * @param {string} topicPool - 'investigations' | 'policy' | 'general'
+ * @param {string} frame - 'alarmed' | 'critical' | 'grudging_credit'
+ * @returns {Object[]} Array of Stories-specific pattern objects
+ */
+function getStoriesSpecificPatterns(topicPool, frame) {
+  const patterns = [];
+
+  // Add topic-specific patterns
+  if (topicPool === 'investigations') {
+    patterns.push(PATTERN_BY_ID['story-investigation-trail']);
+    patterns.push(PATTERN_BY_ID['story-corruption-receipt']);
+    patterns.push(PATTERN_BY_ID['story-scandal-names']);
+    patterns.push(PATTERN_BY_ID['story-breaking-impact']);
+  } else if (topicPool === 'policy') {
+    patterns.push(PATTERN_BY_ID['story-policy-translation']);
+    patterns.push(PATTERN_BY_ID['story-policy-winners']);
+    patterns.push(PATTERN_BY_ID['story-analysis-context']);
+    patterns.push(PATTERN_BY_ID['story-developing']);
+  } else {
+    // General pool
+    patterns.push(PATTERN_BY_ID['story-chaos-specific']);
+    patterns.push(PATTERN_BY_ID['story-absurdity-flat']);
+    patterns.push(PATTERN_BY_ID['story-weary-pattern']);
+    patterns.push(PATTERN_BY_ID['story-breaking-impact']);
+  }
+
+  // Add grudging_credit specific patterns
+  if (frame === 'grudging_credit') {
+    patterns.push(PATTERN_BY_ID['story-credit-asterisk']);
+    patterns.push(PATTERN_BY_ID['story-system-worked']);
+    patterns.push(PATTERN_BY_ID['story-unexpected-good']);
+  }
+
+  return patterns.filter(Boolean);
+}
+
+/**
+ * Get core patterns appropriate for a given frame
+ * @param {string} frame - 'alarmed' | 'critical' | 'grudging_credit'
+ * @returns {Object[]} Array of core pattern objects
+ */
+function getCorePatterns(frame) {
+  const patterns = [];
+
+  for (const p of CORE_STYLE_PATTERNS) {
+    if (frame === 'grudging_credit') {
+      // Only some core patterns work for grudging_credit
+      if (['contrast-then-now', 'mechanism-how-it-works', 'scope-who-affected', 'power-precedent', 'accountability-timeline'].includes(p.id)) {
+        patterns.push(p);
+      }
+    } else {
+      patterns.push(p);
+    }
+  }
+
+  return patterns;
+}
+
+/**
+ * Get all patterns appropriate for a given pool (for fallback/collision walking)
+ * Dedupe defensively in case upstream changes introduce overlap
+ * @param {string} poolKey - Pool key from getStoryPoolKey()
+ * @returns {Object[]} Array of pattern objects
+ */
+function getAllPatternsForPool(poolKey) {
+  const { topicPool, frame } = parsePoolKey(poolKey);
+  const corePatterns = getCorePatterns(frame);
+  const storiesPatterns = getStoriesSpecificPatterns(topicPool, frame);
+
+  // Dedupe by ID defensively (currently cannot overlap due to fail-closed check above)
+  const seen = new Set();
+  const combined = [];
+  for (const p of [...storiesPatterns, ...corePatterns]) {
+    if (!seen.has(p.id)) {
+      seen.add(p.id);
+      combined.push(p);
+    }
+  }
+  return combined;
+}
+
+// ============================================================================
+// DETERMINISTIC SELECTION
+// ============================================================================
+
+/**
+ * Select a variation deterministically based on content ID
+ *
+ * Uses hash-based bias: 40% chance of Stories-specific pattern, 60% core.
+ * This ensures Stories "feel like Stories" while still using universal patterns.
+ *
+ * Seed recipe: {content_id}:{prompt_version}:{poolKey}
+ * (frame is already encoded in poolKey)
+ *
+ * @param {string} poolKey - Pool key from getStoryPoolKey()
+ * @param {string|number} contentId - Stable content identifier (e.g., story database id)
+ * @param {string} promptVersion - Current prompt version
+ * @param {string[]} recentIds - IDs of recently used patterns (for batch deduplication)
+ * @returns {Object} Selected pattern with metadata
+ */
+export function selectVariation(poolKey, contentId, promptVersion, recentIds = []) {
+  // Input validation (prevents silent failures)
+  if (!poolKey || typeof poolKey !== 'string') {
+    throw new Error('selectVariation: poolKey must be a non-empty string');
+  }
+  if (contentId === undefined || contentId === null) {
+    throw new Error('selectVariation: contentId must be provided');
+  }
+  if (!promptVersion) {
+    throw new Error('selectVariation: promptVersion must be provided');
+  }
+
+  const { topicPool, frame } = parsePoolKey(poolKey);
+
+  // Build deterministic seed (frame already encoded in poolKey)
+  const seed = `${contentId}:${promptVersion}:${poolKey}`;
+
+  // Use separate derived hashes for bias and index to avoid correlation
+  const hashBias = fnv1a32(`${seed}:bias`);
+  const hashIdx = fnv1a32(`${seed}:idx`);
+
+  // Determine which sub-pool to select from (biased toward Stories-specific)
+  const biasRoll = hashBias % 100;
+  const useStoriesSpecific = biasRoll < STORIES_SPECIFIC_BIAS_THRESHOLD;
+
+  // Get the appropriate pattern pool
+  const storiesPatterns = getStoriesSpecificPatterns(topicPool, frame);
+  const corePatterns = getCorePatterns(frame);
+
+  let primaryPool = useStoriesSpecific ? storiesPatterns : corePatterns;
+  let fallbackPool = useStoriesSpecific ? corePatterns : storiesPatterns;
+
+  // If primary pool is empty, use fallback
+  if (primaryPool.length === 0) {
+    primaryPool = fallbackPool;
+    fallbackPool = [];
+  }
+
+  // If still empty, return fallback pattern
+  if (primaryPool.length === 0) {
+    console.warn(`Pattern pool empty for "${poolKey}" - using fallback pattern`);
+    return {
+      id: 'fallback',
+      opening_approach: 'Lead with the key change this story represents.',
+      rhetorical_device: 'Be direct and factual.',
+      structure: 'What changed -> who is affected -> implication.',
+      closing_approach: 'End with what to watch for.',
+      _meta: { poolKey, frame, fallback: true }
+    };
+  }
+
+  // Initial index from hash
+  let idx = hashIdx % primaryPool.length;
+
+  // Collision step: walk through pool to find unused pattern
+  // Note: recentIds should be scoped per-poolKey by caller for best results
+  const recentSet = new Set(recentIds);
+  for (let step = 0; step < primaryPool.length; step++) {
+    const candidate = primaryPool[idx];
+    if (!recentSet.has(candidate.id)) {
+      return {
+        ...candidate,
+        _meta: { poolKey, frame, seed, hashBias, hashIdx, idx, subpool: useStoriesSpecific ? 'stories' : 'core' }
+      };
+    }
+    idx = (idx + 1) % primaryPool.length;
+  }
+
+  // All in primary pool used recently, try fallback pool
+  if (fallbackPool.length > 0) {
+    idx = hashIdx % fallbackPool.length;
+    for (let step = 0; step < fallbackPool.length; step++) {
+      const candidate = fallbackPool[idx];
+      if (!recentSet.has(candidate.id)) {
+        return {
+          ...candidate,
+          _meta: { poolKey, frame, seed, hashBias, hashIdx, idx, subpool: useStoriesSpecific ? 'core' : 'stories', spillover: true }
+        };
+      }
+      idx = (idx + 1) % fallbackPool.length;
+    }
+  }
+
+  // If all patterns used recently, return the hash-selected one anyway
+  const allPatterns = getAllPatternsForPool(poolKey);
+  const fallbackPattern = allPatterns[hashIdx % allPatterns.length];
+  return { ...fallbackPattern, _meta: { poolKey, frame, seed, hashBias, hashIdx, collision: true } };
+}
+
+// ============================================================================
+// VARIATION INJECTION BUILDER
+// ============================================================================
+
+/**
+ * Build the REQUIRED VARIATION injection text for the prompt
+ *
+ * Note: Frame guidance is STANCE-ONLY. Intensity/temperature is controlled
+ * by the main SYSTEM_PROMPT's alarm_level calibration (0-5).
+ *
+ * @param {Object} variation - Pattern from selectVariation()
+ * @param {'alarmed' | 'critical' | 'grudging_credit'} frame - Frame bucket
+ * @returns {string} Text to inject into prompt
+ */
+export function buildVariationInjection(variation, frame) {
+  // Stance-only guidance (intensity controlled by alarm_level in main prompt)
+  const frameGuidance = {
+    alarmed: 'FRAME: ALARMED - Treat this as a crisis. An attack on democracy, rights, or norms.',
+    critical: 'FRAME: CRITICAL - Treat this as standard corruption. Typical grift and dysfunction.',
+    grudging_credit: 'FRAME: GRUDGING CREDIT - Credit where due, with skepticism. The system worked this time.'
+  };
+
+  return `REQUIRED VARIATION (do not ignore)
+
+${frameGuidance[frame] || frameGuidance.critical}
+
+STYLE PATTERN: ${variation.id}
+- Opening approach: ${variation.opening_approach}
+- Rhetorical device: ${variation.rhetorical_device}
+- Structure: ${variation.structure}
+- Closing approach: ${variation.closing_approach}
+
+Follow this pattern's APPROACH and SPIRIT - do not copy any specific phrases verbatim.
+The pattern guides structure, not exact wording.
+
+MISMATCH FUSE: If your determined alarm_level conflicts with this frame
+(e.g., you determine level 0-1 but received "alarmed" frame), keep the
+style pattern structure but adjust stance to match your actual alarm_level.`;
+}
+
+// ============================================================================
+// SECTION BANNED OPENERS (for post-generation validation)
+// ============================================================================
+
+export const SECTION_BANS = {
+  summary_spicy: [
+    'Beneath the surface',
+    "What they don't say",
+    "What they don't tell you",
+    'The real story is',
+    "Here's what's really going on",
+    'Dig deeper and',
+    'The truth is',
+    "Let's be clear",
+    "Here's the reality",
+    "The stakes couldn't be higher",
+    'This sets the stage'
+  ]
+};
+
+export const REPAIR_TEMPLATES = [
+  'In practice,',
+  'Put plainly,',
+  'Net effect:',
+  'Bottom line:',
+  'Practically speaking,',
+  'The upshot:',
+  'Translation:',
+  'What this means:'
+];
+
+// ============================================================================
+// TEXT NORMALIZATION HELPERS
+// ============================================================================
+
+/**
+ * Strip leading punctuation, quotes, dashes, etc. for consistent comparison
+ * Used by both findBannedStarter and repairBannedStarter to avoid drift
+ * @param {string} s - Input string
+ * @returns {string} Stripped string
+ */
+function stripLeadingJunk(s) {
+  return String(s || '').trim().replace(/^[\s"'""''—–\-:>]+/, '');
+}
+
+/**
+ * Check if text starts with a banned phrase (case-insensitive)
+ * @param {string} text - Text to check
+ * @param {string[]} bannedPhrases - Phrases to check for
+ * @returns {string|null} The banned phrase found, or null
+ */
+export function findBannedStarter(text, bannedPhrases) {
+  const normalized = stripLeadingJunk(text).toLowerCase();
+
+  for (const phrase of bannedPhrases) {
+    if (normalized.startsWith(String(phrase).toLowerCase())) {
+      return phrase;
+    }
+  }
+  return null;
+}
+
+/**
+ * Attempt to repair a banned starter with a template
+ * Fail-closed: only repairs if banned phrase is exactly at position 0
+ * @param {string} section - Section name (for deterministic template selection)
+ * @param {string} content - Original content
+ * @param {string} bannedPhrase - The banned phrase found
+ * @returns {{ success: boolean, content: string|null, reason: string|null }}
+ */
+export function repairBannedStarter(section, content, bannedPhrase) {
+  const strippedContent = stripLeadingJunk(content);
+
+  const phraseLower = String(bannedPhrase).toLowerCase();
+  const phraseStart = strippedContent.toLowerCase().indexOf(phraseLower);
+
+  // Fail-closed: only repair if phrase is exactly at position 0
+  if (phraseStart !== 0) {
+    return {
+      success: false,
+      content: null,
+      reason: phraseStart < 0 ? 'PHRASE_NOT_FOUND' : 'PHRASE_NOT_AT_START'
+    };
+  }
+
+  const phraseEnd = bannedPhrase.length;
+  let remainder = strippedContent.slice(phraseEnd).replace(/^[,\s]+/, '').trim();
+
+  if (remainder.length < 20) {
+    return { success: false, content: null, reason: 'REMAINDER_TOO_SHORT' };
+  }
+
+  // Select template deterministically based on section
+  const templateIdx = fnv1a32(section) % REPAIR_TEMPLATES.length;
+  const template = REPAIR_TEMPLATES[templateIdx];
+
+  // Rebuild - preserve original casing of remainder (don't corrupt acronyms like ICE, DOJ)
+  const repaired = `${template} ${remainder}`;
+
+  // Verify repair doesn't also start with banned phrase for THIS section only
+  const bannedList = SECTION_BANS[section] || [];
+  const stillBanned = findBannedStarter(repaired, bannedList);
+  if (stillBanned) {
+    return { success: false, content: null, reason: `STILL_BANNED:${stillBanned}` };
+  }
+
+  return { success: true, content: repaired, reason: null };
+}
+
+// ============================================================================
+// ALARM LEVEL HELPERS
+// ============================================================================
+
+/**
+ * Convert alarm level (0-5) to legacy severity_rating text
+ * @param {number} alarmLevel - Numeric 0-5
+ * @returns {string|null} Legacy severity or null for levels 0-1
+ */
+export function alarmLevelToLegacySeverity(alarmLevel) {
+  // Must match DB constraint: critical, severe, moderate, minor
+  if (alarmLevel === 5) return 'critical';
+  if (alarmLevel === 4) return 'severe';
+  if (alarmLevel === 3) return 'moderate';
+  if (alarmLevel === 2) return 'minor';
+  return null; // 0-1 can't be represented in legacy enum
+}
+
+/**
+ * Normalize alarm level to valid 0-5 range
+ * @param {*} value - Input value
+ * @returns {number} Valid alarm level 0-5, defaults to 3
+ */
+export function normalizeAlarmLevel(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 3;
+  if (n < 0) return 0;
+  if (n > 5) return 5;
+  return Math.trunc(n);
+}
+
+// ============================================================================
+// CONTENT ID GENERATION
+// ============================================================================
+
+/**
+ * Get stable content ID for a story (for deterministic selection)
+ *
+ * Priority:
+ * 1. Database ID (most stable)
+ * 2. Hash of sorted article_ids (stable if articles don't change)
+ * 3. Cluster ID (if available)
+ * 4. Hash of headline (last resort, unstable)
+ *
+ * @param {Object} story - Story object
+ * @returns {string} Stable content identifier
+ */
+export function getStoryContentId(story) {
+  // Prefer database ID (use != null to handle id === 0)
+  if (story?.id != null) return `story:${story.id}`;
+
+  // Fallback: hash of sorted article_ids (safe for numeric or string IDs)
+  if (story?.article_ids?.length) {
+    const sorted = [...story.article_ids].sort((a, b) => String(a).localeCompare(String(b)));
+    return `story:articles:${fnv1a32(sorted.join(','))}`;
+  }
+
+  // Fallback: cluster_id (use != null to handle cluster_id === 0)
+  if (story?.cluster_id != null) return `story:cluster:${story.cluster_id}`;
+
+  // Last resort: hash of headline (unstable)
+  console.warn('Using unstable headline hash for story content_id');
+  return `story:headline:${fnv1a32(String(story?.primary_headline || 'unknown'))}`;
+}

--- a/supabase/functions/admin-pardons/index.ts
+++ b/supabase/functions/admin-pardons/index.ts
@@ -1,0 +1,249 @@
+// Edge Function: admin-pardons
+// Returns paginated pardons list with search/filter for Admin Dashboard
+// ADO: Story 338
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Sort column whitelist — never interpolate raw input
+const SORT_MAP: Record<string, string> = {
+  id: 'id',
+  pardon_date: 'pardon_date',
+  corruption_level: 'corruption_level',
+  name: 'recipient_slug',
+}
+
+// Cursor validation patterns per sort column type
+const CURSOR_VALIDATORS: Record<string, RegExp> = {
+  id: /^\d+$/,
+  pardon_date: /^\d{4}-\d{2}-\d{2}$/,
+  corruption_level: /^[1-5]$/,
+  recipient_slug: /^[a-z0-9-]+$/,
+}
+
+const VALID_CONNECTION_TYPES = [
+  'mar_a_lago_vip', 'major_donor', 'family', 'political_ally',
+  'campaign_staff', 'business_associate', 'jan6_defendant',
+  'fake_electors', 'celebrity', 'no_connection',
+]
+
+const VALID_CRIME_CATEGORIES = [
+  'white_collar', 'obstruction', 'political_corruption',
+  'violent', 'drug', 'election', 'jan6', 'other',
+]
+
+const VALID_RESEARCH_STATUS = ['complete', 'in_progress', 'pending']
+
+const SELECT_FIELDS = `
+  id, recipient_name, recipient_slug, nickname, photo_url,
+  recipient_type, recipient_count, recipient_criteria,
+  pardon_date, clemency_type, status,
+  conviction_district, case_number, offense_raw,
+  crime_description, crime_category, original_sentence, conviction_date,
+  primary_connection_type, secondary_connection_types,
+  corruption_level, corruption_reasoning,
+  trump_connection_detail, donation_amount_usd, receipts_timeline,
+  summary_neutral, summary_spicy, why_it_matters, pattern_analysis,
+  research_status, research_prompt_version, researched_at,
+  post_pardon_status, post_pardon_notes,
+  is_public, needs_review, enriched_at,
+  primary_source_url, source_urls, pardon_advocates,
+  created_at, updated_at
+`
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ error: 'Method not allowed' }),
+        { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Parse params from POST body
+    let body: any = {}
+    try {
+      body = await req.json()
+    } catch {
+      // Empty body defaults to no filters
+    }
+
+    const search = String(body.search ?? '').trim()
+    const isPublic = String(body.isPublic ?? '')
+    const connectionType = String(body.connectionType ?? '')
+    const crimeCategory = String(body.crimeCategory ?? '')
+    const corruptionLevel = String(body.corruptionLevel ?? '')
+    const researchStatus = String(body.researchStatus ?? '')
+    const enrichment = String(body.enrichment ?? '')
+    const sortBy = String(body.sortBy ?? 'pardon_date')
+    const sortDir = String(body.sortDir ?? 'desc')
+    const cursor = String(body.cursor ?? '')
+
+    const limitParam = parseInt(String(body.limit ?? '25'), 10)
+    const limit = Math.min(Math.max(isNaN(limitParam) ? 25 : limitParam, 1), 100)
+
+    // Build query
+    let query = supabase
+      .from('pardons')
+      .select(SELECT_FIELDS)
+
+    // Sorting — only whitelisted columns
+    const sortCol = SORT_MAP[sortBy] ?? 'pardon_date'
+    const ascending = sortDir === 'asc'
+    query = query.order(sortCol, { ascending })
+
+    // Tiebreaker direction matches sortDir
+    if (sortCol !== 'id') {
+      query = query.order('id', { ascending })
+    }
+
+    // Enforce non-null recipient_slug when sorting by name
+    if (sortCol === 'recipient_slug') {
+      query = query.not('recipient_slug', 'is', null)
+    }
+
+    // Keyset cursor pagination
+    const op = ascending ? 'gt' : 'lt'
+
+    if (cursor) {
+      if (sortCol === 'id') {
+        if (/^\d+$/.test(cursor)) {
+          query = query[op]('id', cursor)
+        }
+        // else: malformed → ignore (returns first page)
+      } else {
+        const sepIdx = cursor.lastIndexOf('::')
+        if (sepIdx > 0) {
+          const cursorSortValue = cursor.substring(0, sepIdx)
+          const cursorId = cursor.substring(sepIdx + 2)
+          const sortValidator = CURSOR_VALIDATORS[sortCol]
+          if (/^\d+$/.test(cursorId) && sortValidator?.test(cursorSortValue)) {
+            query = query.or(
+              `${sortCol}.${op}.${cursorSortValue},and(${sortCol}.eq.${cursorSortValue},id.${op}.${cursorId})`
+            )
+          }
+          // else: malformed → ignore
+        }
+        // else: malformed → ignore
+      }
+    }
+
+    // Fetch limit + 1 for has_more detection
+    query = query.limit(limit + 1)
+
+    // Filter: isPublic (sub-tab)
+    if (isPublic === 'true') {
+      query = query.eq('is_public', true)
+    } else if (isPublic === 'false') {
+      query = query.eq('is_public', false)
+    }
+
+    // Filter: connectionType — checks BOTH primary and secondary
+    if (connectionType && VALID_CONNECTION_TYPES.includes(connectionType)) {
+      query = query.or(
+        `primary_connection_type.eq.${connectionType},secondary_connection_types.cs.{${connectionType}}`
+      )
+    }
+
+    // Filter: crimeCategory
+    if (crimeCategory && VALID_CRIME_CATEGORIES.includes(crimeCategory)) {
+      query = query.eq('crime_category', crimeCategory)
+    }
+
+    // Filter: corruptionLevel (1-5)
+    const corruptionLevelNum = parseInt(corruptionLevel, 10)
+    if (!isNaN(corruptionLevelNum) && corruptionLevelNum >= 1 && corruptionLevelNum <= 5) {
+      query = query.eq('corruption_level', corruptionLevelNum)
+    }
+
+    // Filter: researchStatus
+    if (researchStatus && VALID_RESEARCH_STATUS.includes(researchStatus)) {
+      query = query.eq('research_status', researchStatus)
+    }
+
+    // Filter: enrichment (derived from enriched_at)
+    if (enrichment === 'enriched') {
+      query = query.not('enriched_at', 'is', null)
+    } else if (enrichment === 'pending') {
+      query = query.is('enriched_at', null)
+    }
+
+    // Search: by name or exact ID
+    if (search.length > 0) {
+      if (/^\d+$/.test(search) && search.length <= 15) {
+        const escaped = search.replace(/[%_\\]/g, '\\$&')
+        query = query.or(`id.eq.${search},recipient_name.ilike.%${escaped}%`)
+      } else {
+        const escaped = search.replace(/[%_\\]/g, '\\$&')
+        query = query.ilike('recipient_name', `%${escaped}%`)
+      }
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error('Query error:', error)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch pardons' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // has_more detection: if we got limit+1 rows, there are more
+    const hasMore = (data || []).length > limit
+    const pardons = hasMore ? (data || []).slice(0, limit) : (data || [])
+
+    // Next cursor generation
+    let nextCursor: string | null = null
+    if (hasMore && pardons.length > 0) {
+      const last = pardons[pardons.length - 1] as any
+      nextCursor = sortCol === 'id'
+        ? String(last.id)
+        : `${last[sortCol]}::${last.id}`
+    }
+
+    return new Response(
+      JSON.stringify({
+        pardons,
+        pagination: { next_cursor: nextCursor, has_more: hasMore }
+      }),
+      {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Cache-Control': 'max-age=30'
+        }
+      }
+    )
+
+  } catch (error) {
+    console.error('Error in admin-pardons:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+})

--- a/supabase/functions/admin-update-pardon/index.ts
+++ b/supabase/functions/admin-update-pardon/index.ts
@@ -1,0 +1,409 @@
+// Edge Function: admin-update-pardon
+// Updates pardon fields with admin authentication, optimistic locking, and audit logging
+// ADO: Story 339
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Allowed fields that can be updated (whitelist for security) — 33 fields
+const ALLOWED_FIELDS = [
+  // Identity (6)
+  'recipient_name', 'nickname', 'photo_url', 'recipient_type', 'recipient_count', 'recipient_criteria',
+  // Pardon & Crime (8)
+  'pardon_date', 'clemency_type', 'status', 'case_number', 'crime_description', 'crime_category', 'original_sentence', 'conviction_date',
+  // Trump Connection (6)
+  'primary_connection_type', 'secondary_connection_types', 'corruption_level', 'corruption_reasoning', 'trump_connection_detail', 'donation_amount_usd',
+  // AI Content (4)
+  'summary_neutral', 'summary_spicy', 'why_it_matters', 'pattern_analysis',
+  // JSONB Arrays (2)
+  'receipts_timeline', 'pardon_advocates',
+  // Admin & Sources (7)
+  'research_status', 'post_pardon_status', 'post_pardon_notes', 'is_public', 'needs_review', 'primary_source_url', 'source_urls'
+]
+
+// Valid enum values (mirrored from admin-pardons)
+const VALID_CLEMENCY_TYPES = ['pardon', 'commutation', 'pre_emptive']
+const VALID_STATUS = ['confirmed', 'reported']
+const VALID_RECIPIENT_TYPES = ['person', 'group']
+const VALID_POST_PARDON_STATUS = ['quiet', 'under_investigation', 're_offended']
+const VALID_CRIME_CATEGORIES = [
+  'white_collar', 'obstruction', 'political_corruption',
+  'violent', 'drug', 'election', 'jan6', 'other',
+]
+const VALID_CONNECTION_TYPES = [
+  'mar_a_lago_vip', 'major_donor', 'family', 'political_ally',
+  'campaign_staff', 'business_associate', 'jan6_defendant',
+  'fake_electors', 'celebrity', 'no_connection',
+]
+const VALID_RESEARCH_STATUS = ['complete', 'in_progress', 'pending']
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+  })
+}
+
+function validateUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return jsonResponse({ error: 'Unauthorized' }, 401)
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405)
+    }
+
+    // Parse request body
+    const body = await req.json()
+    const { pardon_id, updates, original_updated_at } = body
+
+    // Validate pardon_id
+    if (!pardon_id) {
+      return jsonResponse({ error: 'Missing required field: pardon_id' }, 400)
+    }
+
+    const pardonId = parseInt(String(pardon_id), 10)
+    if (isNaN(pardonId) || pardonId <= 0) {
+      return jsonResponse({ error: 'pardon_id must be a positive integer' }, 400)
+    }
+
+    // Validate updates object
+    if (!updates || typeof updates !== 'object' || Object.keys(updates).length === 0) {
+      return jsonResponse({ error: 'No updates provided' }, 400)
+    }
+
+    // Filter to only allowed fields
+    const sanitizedUpdates: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(updates)) {
+      if (ALLOWED_FIELDS.includes(key)) {
+        sanitizedUpdates[key] = value
+      }
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return jsonResponse({ error: 'No valid fields to update' }, 400)
+    }
+
+    // --- Type-specific validation ---
+
+    // Enum: clemency_type
+    if ('clemency_type' in sanitizedUpdates) {
+      const v = sanitizedUpdates.clemency_type
+      if (v !== null && !VALID_CLEMENCY_TYPES.includes(v as string)) {
+        return jsonResponse({ error: `Invalid clemency_type. Must be one of: ${VALID_CLEMENCY_TYPES.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: status
+    if ('status' in sanitizedUpdates) {
+      const v = sanitizedUpdates.status
+      if (v !== null && !VALID_STATUS.includes(v as string)) {
+        return jsonResponse({ error: `Invalid status. Must be one of: ${VALID_STATUS.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: recipient_type
+    if ('recipient_type' in sanitizedUpdates) {
+      const v = sanitizedUpdates.recipient_type
+      if (v !== null && !VALID_RECIPIENT_TYPES.includes(v as string)) {
+        return jsonResponse({ error: `Invalid recipient_type. Must be one of: ${VALID_RECIPIENT_TYPES.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: crime_category
+    if ('crime_category' in sanitizedUpdates) {
+      const v = sanitizedUpdates.crime_category
+      if (v !== null && !VALID_CRIME_CATEGORIES.includes(v as string)) {
+        return jsonResponse({ error: `Invalid crime_category. Must be one of: ${VALID_CRIME_CATEGORIES.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: primary_connection_type
+    if ('primary_connection_type' in sanitizedUpdates) {
+      const v = sanitizedUpdates.primary_connection_type
+      if (v !== null && !VALID_CONNECTION_TYPES.includes(v as string)) {
+        return jsonResponse({ error: `Invalid primary_connection_type. Must be one of: ${VALID_CONNECTION_TYPES.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: research_status
+    if ('research_status' in sanitizedUpdates) {
+      const v = sanitizedUpdates.research_status
+      if (v !== null && !VALID_RESEARCH_STATUS.includes(v as string)) {
+        return jsonResponse({ error: `Invalid research_status. Must be one of: ${VALID_RESEARCH_STATUS.join(', ')}` }, 400)
+      }
+    }
+
+    // Enum: post_pardon_status
+    if ('post_pardon_status' in sanitizedUpdates) {
+      const v = sanitizedUpdates.post_pardon_status
+      if (v !== null && !VALID_POST_PARDON_STATUS.includes(v as string)) {
+        return jsonResponse({ error: `Invalid post_pardon_status. Must be one of: ${VALID_POST_PARDON_STATUS.join(', ')}` }, 400)
+      }
+    }
+
+    // Integer 1-5: corruption_level
+    if ('corruption_level' in sanitizedUpdates) {
+      const v = sanitizedUpdates.corruption_level
+      if (v !== null) {
+        const level = parseInt(String(v), 10)
+        if (isNaN(level) || level < 1 || level > 5) {
+          return jsonResponse({ error: 'corruption_level must be an integer between 1 and 5' }, 400)
+        }
+        sanitizedUpdates.corruption_level = level
+      }
+    }
+
+    // Numeric >= 0: donation_amount_usd
+    if ('donation_amount_usd' in sanitizedUpdates) {
+      const v = sanitizedUpdates.donation_amount_usd
+      if (v !== null) {
+        const amount = parseFloat(String(v))
+        if (isNaN(amount) || amount < 0) {
+          return jsonResponse({ error: 'donation_amount_usd must be a number >= 0' }, 400)
+        }
+        sanitizedUpdates.donation_amount_usd = amount
+      }
+    }
+
+    // Integer >= 0: recipient_count
+    if ('recipient_count' in sanitizedUpdates) {
+      const v = sanitizedUpdates.recipient_count
+      if (v !== null) {
+        const count = parseInt(String(v), 10)
+        if (isNaN(count) || count < 0) {
+          return jsonResponse({ error: 'recipient_count must be a non-negative integer' }, 400)
+        }
+        sanitizedUpdates.recipient_count = count
+      }
+    }
+
+    // Dates: pardon_date, conviction_date
+    for (const field of ['pardon_date', 'conviction_date']) {
+      if (field in sanitizedUpdates) {
+        const v = sanitizedUpdates[field]
+        if (v !== null && v !== '') {
+          if (typeof v !== 'string' || !DATE_RE.test(v)) {
+            return jsonResponse({ error: `${field} must be a date in YYYY-MM-DD format` }, 400)
+          }
+        } else {
+          sanitizedUpdates[field] = null
+        }
+      }
+    }
+
+    // URLs: primary_source_url, photo_url
+    for (const field of ['primary_source_url', 'photo_url']) {
+      if (field in sanitizedUpdates) {
+        const v = sanitizedUpdates[field]
+        if (v !== null && v !== '' && typeof v === 'string' && v.trim().length > 0) {
+          if (!validateUrl(v as string)) {
+            return jsonResponse({ error: `${field} must be a valid http/https URL` }, 400)
+          }
+        } else {
+          sanitizedUpdates[field] = null
+        }
+      }
+    }
+
+    // Booleans: is_public, needs_review
+    for (const field of ['is_public', 'needs_review']) {
+      if (field in sanitizedUpdates) {
+        if (typeof sanitizedUpdates[field] !== 'boolean') {
+          return jsonResponse({ error: `${field} must be a boolean` }, 400)
+        }
+      }
+    }
+
+    // text[]: secondary_connection_types
+    if ('secondary_connection_types' in sanitizedUpdates) {
+      const v = sanitizedUpdates.secondary_connection_types
+      if (v !== null) {
+        if (!Array.isArray(v)) {
+          return jsonResponse({ error: 'secondary_connection_types must be an array' }, 400)
+        }
+        const cleaned = (v as unknown[])
+          .filter(item => typeof item === 'string' && item.trim().length > 0)
+          .map(item => (item as string).trim())
+        for (const item of cleaned) {
+          if (!VALID_CONNECTION_TYPES.includes(item)) {
+            return jsonResponse({ error: `Invalid secondary_connection_type: ${item}` }, 400)
+          }
+        }
+        sanitizedUpdates.secondary_connection_types = cleaned
+      }
+    }
+
+    // JSONB: receipts_timeline
+    if ('receipts_timeline' in sanitizedUpdates) {
+      const v = sanitizedUpdates.receipts_timeline
+      if (v !== null) {
+        if (typeof v === 'string') {
+          return jsonResponse({ error: 'receipts_timeline must be a JSON array, not a string. Parse JSON before sending.' }, 400)
+        }
+        if (!Array.isArray(v)) {
+          return jsonResponse({ error: 'receipts_timeline must be a JSON array' }, 400)
+        }
+        // Each element must be an object with at least event_type
+        for (let i = 0; i < (v as unknown[]).length; i++) {
+          const item = (v as unknown[])[i]
+          if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+            return jsonResponse({ error: `receipts_timeline[${i}] must be an object` }, 400)
+          }
+          if (typeof (item as Record<string, unknown>).event_type !== 'string') {
+            return jsonResponse({ error: `receipts_timeline[${i}].event_type is required and must be a string` }, 400)
+          }
+        }
+      }
+    }
+
+    // JSONB: pardon_advocates
+    if ('pardon_advocates' in sanitizedUpdates) {
+      const v = sanitizedUpdates.pardon_advocates
+      if (v !== null) {
+        if (typeof v === 'string') {
+          return jsonResponse({ error: 'pardon_advocates must be a JSON array, not a string. Parse JSON before sending.' }, 400)
+        }
+        if (!Array.isArray(v)) {
+          return jsonResponse({ error: 'pardon_advocates must be a JSON array' }, 400)
+        }
+      }
+    }
+
+    // JSONB: source_urls — array of URL strings
+    if ('source_urls' in sanitizedUpdates) {
+      const v = sanitizedUpdates.source_urls
+      if (v !== null) {
+        if (typeof v === 'string') {
+          return jsonResponse({ error: 'source_urls must be a JSON array, not a string. Parse JSON before sending.' }, 400)
+        }
+        if (!Array.isArray(v)) {
+          return jsonResponse({ error: 'source_urls must be a JSON array' }, 400)
+        }
+        // Trim, drop blanks, validate each as URL
+        const cleaned: string[] = []
+        for (const item of v as unknown[]) {
+          if (typeof item !== 'string') continue
+          const trimmed = item.trim()
+          if (trimmed.length === 0) continue
+          if (!validateUrl(trimmed)) {
+            return jsonResponse({ error: `Invalid URL in source_urls: ${trimmed}` }, 400)
+          }
+          cleaned.push(trimmed)
+        }
+        sanitizedUpdates.source_urls = cleaned
+      }
+    }
+
+    // --- Database operations ---
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Step 1: Fetch current row for old values (needed for audit logging)
+    const { data: currentPardon, error: fetchError } = await supabase
+      .from('pardons')
+      .select([...ALLOWED_FIELDS, 'updated_at'].join(','))
+      .eq('id', pardonId)
+      .single()
+
+    if (fetchError || !currentPardon) {
+      console.error('Fetch error:', fetchError)
+      return jsonResponse({ error: 'Pardon not found' }, 404)
+    }
+
+    // Step 2: Guarded UPDATE — atomic lock at DB level
+    let query = supabase
+      .from('pardons')
+      .update(sanitizedUpdates)
+      .eq('id', pardonId)
+
+    // Apply optimistic locking if original_updated_at provided
+    if (original_updated_at) {
+      query = query.eq('updated_at', original_updated_at)
+    }
+
+    const { data, error } = await query.select().single()
+
+    if (error) {
+      console.error('Update error:', error)
+      if (error.code === 'PGRST116') {
+        // 0 rows matched — either not found or concurrent edit
+        if (original_updated_at) {
+          // Fetch current to return conflict info
+          const { data: current } = await supabase
+            .from('pardons')
+            .select('updated_at')
+            .eq('id', pardonId)
+            .single()
+
+          return jsonResponse({
+            error: 'This record was modified by another process while you were editing. Please refresh and try again.',
+            conflict: true,
+            current_updated_at: current?.updated_at
+          }, 409)
+        }
+        return jsonResponse({ error: 'Pardon not found' }, 404)
+      }
+      throw new Error(`Failed to update pardon: ${error.message}`)
+    }
+
+    // Step 3: Log diffs (only fields that actually changed)
+    const changedFields: Record<string, { old: string | null; new: string | null }> = {}
+    for (const [field, newValue] of Object.entries(sanitizedUpdates)) {
+      const oldValue = currentPardon[field]
+      const oldStr = oldValue != null ? String(typeof oldValue === 'object' ? JSON.stringify(oldValue) : oldValue) : null
+      const newStr = newValue != null ? String(typeof newValue === 'object' ? JSON.stringify(newValue) : newValue) : null
+
+      if (oldStr !== newStr) {
+        changedFields[field] = { old: oldStr, new: newStr }
+
+        try {
+          await supabase.rpc('log_content_change', {
+            p_entity_type: 'pardon',
+            p_entity_id: String(pardonId),
+            p_field_name: field,
+            p_old_value: oldStr,
+            p_new_value: newStr,
+            p_changed_by: 'admin',
+            p_change_source: 'admin'
+          })
+        } catch (historyError) {
+          console.error(`Failed to log history for field ${field}:`, historyError)
+        }
+      }
+    }
+
+    console.log(`admin_action: update_pardon pardon_id=${pardonId} fields=${Object.keys(sanitizedUpdates).join(',')}`)
+
+    return jsonResponse({
+      success: true,
+      pardon: data,
+      changed_fields: changedFields
+    }, 200)
+
+  } catch (error) {
+    console.error('Error in admin-update-pardon:', error)
+    return jsonResponse({ error: error.message || 'Internal server error' }, 500)
+  }
+})

--- a/supabase/functions/admin-update-story/index.ts
+++ b/supabase/functions/admin-update-story/index.ts
@@ -1,0 +1,267 @@
+// Edge Function: admin-update-story
+// Updates story fields with admin authentication
+// ADO: Feature 328, Story 336, 337 (content history)
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Allowed fields that can be updated (whitelist for security)
+const ALLOWED_FIELDS = [
+  // Metadata fields
+  'primary_headline',
+  'primary_source',
+  'primary_source_url',
+  'primary_actor',
+  'status',
+  'category',
+  'lifecycle_state',
+  'confidence_score',
+  'alarm_level',
+  // Enriched content fields
+  'summary_neutral',
+  'summary_spicy'
+]
+
+// Valid enum values for validation
+const VALID_STATUS = ['active', 'closed', 'archived']
+const VALID_CATEGORY = [
+  'corruption_scandals', 'democracy_elections', 'policy_legislation',
+  'justice_legal', 'executive_actions', 'foreign_policy',
+  'corporate_financial', 'civil_liberties', 'media_disinformation',
+  'epstein_associates', 'other', null
+]
+const VALID_LIFECYCLE = ['emerging', 'developing', 'mature', null]
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ error: 'Method not allowed' }),
+        { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Parse request body
+    const body = await req.json()
+    const { story_id, updates, original_last_updated_at } = body
+
+    // Validate story_id
+    if (!story_id) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required field: story_id' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const storyId = parseInt(String(story_id), 10)
+    if (isNaN(storyId) || storyId <= 0) {
+      return new Response(
+        JSON.stringify({ error: 'story_id must be a positive integer' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate updates object
+    if (!updates || typeof updates !== 'object' || Object.keys(updates).length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'No updates provided' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Filter to only allowed fields (security: prevent arbitrary field updates)
+    const sanitizedUpdates: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(updates)) {
+      if (ALLOWED_FIELDS.includes(key)) {
+        sanitizedUpdates[key] = value
+      }
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'No valid fields to update' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate enum fields
+    if ('status' in sanitizedUpdates && !VALID_STATUS.includes(sanitizedUpdates.status as string)) {
+      return new Response(
+        JSON.stringify({ error: `Invalid status. Must be one of: ${VALID_STATUS.join(', ')}` }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    if ('category' in sanitizedUpdates && sanitizedUpdates.category !== null && !VALID_CATEGORY.includes(sanitizedUpdates.category as string)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid category' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    if ('lifecycle_state' in sanitizedUpdates && sanitizedUpdates.lifecycle_state !== null && !VALID_LIFECYCLE.includes(sanitizedUpdates.lifecycle_state as string)) {
+      return new Response(
+        JSON.stringify({ error: `Invalid lifecycle_state. Must be one of: ${VALID_LIFECYCLE.filter(v => v !== null).join(', ')}` }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate confidence_score if provided
+    if ('confidence_score' in sanitizedUpdates && sanitizedUpdates.confidence_score !== null) {
+      const score = parseFloat(String(sanitizedUpdates.confidence_score))
+      if (isNaN(score) || score < 0 || score > 100) {
+        return new Response(
+          JSON.stringify({ error: 'confidence_score must be a number between 0 and 100' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+      sanitizedUpdates.confidence_score = score
+    }
+
+    // Validate alarm_level if provided (0-5)
+    if ('alarm_level' in sanitizedUpdates && sanitizedUpdates.alarm_level !== null) {
+      const level = parseInt(String(sanitizedUpdates.alarm_level), 10)
+      if (isNaN(level) || level < 0 || level > 5) {
+        return new Response(
+          JSON.stringify({ error: 'alarm_level must be an integer between 0 and 5' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+      sanitizedUpdates.alarm_level = level
+    }
+
+    // Validate URL if provided
+    if ('primary_source_url' in sanitizedUpdates && sanitizedUpdates.primary_source_url) {
+      try {
+        new URL(sanitizedUpdates.primary_source_url as string)
+      } catch {
+        return new Response(
+          JSON.stringify({ error: 'primary_source_url must be a valid URL' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Fetch current story values BEFORE update (for history logging and optimistic locking)
+    const { data: currentStory, error: fetchError } = await supabase
+      .from('stories')
+      .select([...ALLOWED_FIELDS, 'last_updated_at'].join(','))
+      .eq('id', storyId)
+      .single()
+
+    if (fetchError || !currentStory) {
+      console.error('Fetch error:', fetchError)
+      return new Response(
+        JSON.stringify({ error: 'Story not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Optimistic locking: check if story was modified since user opened the edit modal
+    if (original_last_updated_at) {
+      const currentTimestamp = currentStory.last_updated_at
+      if (currentTimestamp && currentTimestamp !== original_last_updated_at) {
+        return new Response(
+          JSON.stringify({
+            error: 'This record was modified by another process while you were editing. Please refresh and try again.',
+            conflict: true,
+            current_last_updated_at: currentTimestamp
+          }),
+          { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+    }
+
+    // Update the story
+    const { data, error } = await supabase
+      .from('stories')
+      .update(sanitizedUpdates)
+      .eq('id', storyId)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Update error:', error)
+      if (error.code === 'PGRST116') {
+        return new Response(
+          JSON.stringify({ error: 'Story not found' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+      throw new Error(`Failed to update story: ${error.message}`)
+    }
+
+    // Log content changes for undo support
+    const changedFields: Record<string, { old: string | null; new: string | null }> = {}
+    for (const [field, newValue] of Object.entries(sanitizedUpdates)) {
+      const oldValue = currentStory[field]
+      // Only log if the value actually changed
+      if (String(oldValue ?? '') !== String(newValue ?? '')) {
+        changedFields[field] = {
+          old: oldValue != null ? String(oldValue) : null,
+          new: newValue != null ? String(newValue) : null
+        }
+
+        // Log each changed field to content history
+        try {
+          await supabase.rpc('log_content_change', {
+            p_entity_type: 'story',
+            p_entity_id: String(storyId),
+            p_field_name: field,
+            p_old_value: oldValue != null ? String(oldValue) : null,
+            p_new_value: newValue != null ? String(newValue) : null,
+            p_changed_by: 'admin', // Could be enhanced to pass actual user
+            p_change_source: 'admin'
+          })
+        } catch (historyError) {
+          // Log but don't fail the update if history logging fails
+          console.error(`Failed to log history for field ${field}:`, historyError)
+        }
+      }
+    }
+
+    // Log the action
+    console.log(`admin_action: update_story story_id=${storyId} fields=${Object.keys(sanitizedUpdates).join(',')}`)
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        story: data,
+        changed_fields: changedFields // Return for undo support
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+
+  } catch (error) {
+    console.error('Error in admin-update-story:', error)
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+})

--- a/supabase/functions/trigger-enrichment/index.ts
+++ b/supabase/functions/trigger-enrichment/index.ts
@@ -1,0 +1,247 @@
+// Edge Function: trigger-enrichment
+// Triggers AI re-enrichment by dispatching GitHub Actions workflow
+// ADO: Feature 328, Story 336, 337
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Estimated costs per entity type (USD)
+const COSTS: Record<string, number> = {
+  story: 0.003,
+  pardon: 0.005,
+  scotus: 0.01,
+  eo: 0.008,
+  article_entities: 0.0003
+}
+
+// GitHub repo for workflow dispatch
+const GITHUB_OWNER = 'AJWolfe18'
+const GITHUB_REPO = 'TTracker'
+
+// Detect environment from Supabase URL
+function getEnvironment(supabaseUrl: string): 'test' | 'prod' {
+  if (supabaseUrl.includes('wnrjrywpcadwutfykflu')) return 'test'
+  if (supabaseUrl.includes('osjbulmltfpcoldydexg')) return 'prod'
+  return 'test' // Default to test for safety
+}
+
+// Trigger GitHub Actions workflow
+async function triggerWorkflow(
+  workflowFile: string,
+  inputs: Record<string, string>,
+  githubToken: string,
+  environment: string = 'test'
+): Promise<{ success: boolean; message: string; run_url?: string }> {
+  const ref = environment === 'prod' ? 'main' : 'test'
+  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/workflows/${workflowFile}/dispatches`
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/vnd.github.v3+json',
+      'Authorization': `Bearer ${githubToken}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'TTracker-Admin'
+    },
+    body: JSON.stringify({
+      ref,
+      inputs
+    })
+  })
+
+  if (response.status === 204) {
+    // Success - workflow dispatched
+    const runUrl = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/actions/workflows/${workflowFile}`
+    return { success: true, message: 'Workflow dispatched', run_url: runUrl }
+  }
+
+  const errorText = await response.text()
+  console.error('GitHub API error:', response.status, errorText)
+  return { success: false, message: `GitHub API error: ${response.status}` }
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ error: 'Method not allowed' }),
+        { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Check for GitHub token
+    const githubToken = Deno.env.get('GITHUB_PAT')
+    if (!githubToken) {
+      return new Response(
+        JSON.stringify({ error: 'GITHUB_PAT not configured - cannot trigger enrichment' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Parse request body
+    const body = await req.json()
+    const { entity_type } = body
+
+    if (!entity_type || body.entity_id === undefined || body.entity_id === null) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required fields: entity_type, entity_id' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate entity_id is a positive integer
+    const entity_id = parseInt(String(body.entity_id), 10)
+    if (isNaN(entity_id) || entity_id <= 0) {
+      return new Response(
+        JSON.stringify({ error: 'entity_id must be a positive integer' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate entity_type is one of the allowed types
+    const validTypes = ['story', 'pardon', 'scotus', 'eo']
+    if (!validTypes.includes(entity_type)) {
+      return new Response(
+        JSON.stringify({ error: `Invalid entity_type. Must be one of: ${validTypes.join(', ')}` }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Detect environment
+    const environment = getEnvironment(supabaseUrl)
+
+    // Check budget before proceeding
+    const today = new Date().toISOString().split('T')[0]
+    const { data: budget, error: budgetError } = await supabase
+      .from('budgets')
+      .select('spent_usd, cap_usd')
+      .eq('day', today)
+      .single()
+
+    const cost = COSTS[entity_type] || 0.003
+
+    if (budget && !budgetError && budget.spent_usd + cost > budget.cap_usd) {
+      return new Response(
+        JSON.stringify({
+          error: 'Daily budget exceeded',
+          spent: budget.spent_usd,
+          cap: budget.cap_usd,
+          estimated_cost: cost
+        }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Per-entity-type workflow config
+    const WORKFLOW_CONFIG: Record<string, {
+      file: string,
+      buildInputs: (id: number, env: string) => Record<string, string>
+    }> = {
+      story: {
+        file: 'enrich-story.yml',
+        buildInputs: (id, env) => ({ story_id: String(id), environment: env })
+      },
+      pardon: {
+        file: 'enrich-pardons.yml',
+        buildInputs: (id, env) => ({ pardon_id: String(id), limit: '1', force: 'true' })
+      }
+    }
+
+    const config = WORKFLOW_CONFIG[entity_type]
+    if (!config) {
+      return new Response(
+        JSON.stringify({ error: `Re-enrichment not yet supported for ${entity_type}` }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Atomically check + set pending (prevents race condition between two concurrent requests)
+    if (entity_type === 'story') {
+      const { data: updated, error: updateErr } = await supabase
+        .from('stories')
+        .update({
+          enrichment_status: 'pending',
+          enrichment_failure_count: 0
+        })
+        .eq('id', entity_id)
+        .is('enrichment_status', null)
+        .select('id')
+
+      if (updateErr) {
+        console.error('Enrichment status update error:', updateErr)
+        return new Response(
+          JSON.stringify({ error: `Failed to update story: ${updateErr.message}` }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+      if (!updated || updated.length === 0) {
+        return new Response(
+          JSON.stringify({ error: 'Enrichment already pending for this story' }),
+          { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+    }
+
+    // Trigger the workflow
+    const workflowInputs = config.buildInputs(entity_id, environment)
+    const result = await triggerWorkflow(
+      config.file,
+      workflowInputs,
+      githubToken,
+      environment
+    )
+
+    if (!result.success) {
+      return new Response(
+        JSON.stringify({ error: result.message }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log(`admin_action: re-enrich entity_type=${entity_type} entity_id=${entity_id} env=${environment}`)
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        entity_type,
+        entity_id,
+        message: `Enrichment started (${environment})`,
+        estimated_cost: cost,
+        run_url: result.run_url
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+
+  } catch (error) {
+    console.error('Error in trigger-enrichment:', error)
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+})


### PR DESCRIPTION
## Summary

Full admin dashboard deployment covering ADO-333, 335, 336, 337, 338, 339:

- **Stories Tab** (ADO-335/336): List with severity/category filters, inline edit with optimistic locking, re-enrich via GitHub Actions workflow dispatch, archive/unarchive toggle
- **Pardons Tab** (ADO-337/338): List with Draft/Published tabs, inline edit with optimistic locking, re-enrich via workflow dispatch, publish/unpublish toggle
- **Tone Variation System** (ADO-339): Frame-based variation pools, deterministic selection by story content hash, alarm_level (0-5) scoring, banned-starter repair
- **Audit Infrastructure**: `admin.content_history` (undo support), `admin.action_log` (audit trail), RPC functions for logging and undo
- **5 New Edge Functions**: admin-stories, admin-pardons, admin-update-story, admin-update-pardon, trigger-enrichment

## Files Changed (13 files, 4974 additions)

### New Files (10)
- `supabase/functions/admin-pardons/index.ts` — Pardons list endpoint
- `supabase/functions/admin-update-story/index.ts` — Story edit + optimistic locking
- `supabase/functions/admin-update-pardon/index.ts` — Pardon edit + optimistic locking
- `supabase/functions/trigger-enrichment/index.ts` — Re-enrichment dispatcher
- `scripts/enrichment/prompts/stories.js` — Story prompt (split from monolithic prompts.js)
- `scripts/enrichment/stories-style-patterns.js` — Tone variation pools + frame selection
- `migrations/081_admin_content_history.sql` — Content history table
- `migrations/082_admin_action_log.sql` — Action log table
- `migrations/083_admin_rpc_functions.sql` — Admin RPC functions

### Modified Files (3)
- `public/admin.html` — Full admin UI (Stories tab, Pardons tab, edit modals, re-enrich polling)
- `scripts/enrichment/enrich-stories-inline.js` — Import path change (`prompts.js` → `prompts/stories.js`), tone variation system
- `scripts/enrichment/enrich-single-story.js` — Updated for new enrichment interface

### Already on Main (no changes needed)
- `.github/workflows/enrich-story.yml` — Identical on both branches
- `supabase/functions/admin-stats/index.ts` — Deployed in prior PR (#73)

## ⚠️ CRITICAL: Post-Merge Steps (Time-Sensitive)

**Step 1 — IMMEDIATELY after merge (before next 2-hour RSS run):**
```sql
ALTER TABLE stories ADD COLUMN IF NOT EXISTS alarm_level SMALLINT;
ALTER TABLE stories ADD COLUMN IF NOT EXISTS enrichment_meta JSONB;
```
Without these columns, the updated `enrich-stories-inline.js` will fail on the next PROD RSS pipeline run.

**Step 2 — Apply admin migrations (081 → 082 → 083) to PROD SQL editor**

**Step 3 — Set Supabase secrets:**
```bash
npx supabase secrets set GITHUB_PAT='<token>' --project-ref osjbulmltfpcoldydexg
npx supabase secrets set ADMIN_DASHBOARD_PASSWORD='<password>' --project-ref osjbulmltfpcoldydexg
```

**Step 4 — Deploy edge functions to PROD:**
```bash
npx supabase functions deploy admin-stats --project-ref osjbulmltfpcoldydexg
npx supabase functions deploy admin-stories --project-ref osjbulmltfpcoldydexg
npx supabase functions deploy admin-pardons --project-ref osjbulmltfpcoldydexg
npx supabase functions deploy admin-update-story --project-ref osjbulmltfpcoldydexg
npx supabase functions deploy admin-update-pardon --project-ref osjbulmltfpcoldydexg
npx supabase functions deploy trigger-enrichment --project-ref osjbulmltfpcoldydexg
```

**Step 5 — Verify at trumpytracker.com/admin.html**

## Risk Assessment

| Risk | Severity | Mitigation |
|------|----------|------------|
| Missing `alarm_level`/`enrichment_meta` columns | **HIGH** | Run ALTER TABLE immediately after merge |
| `enrich-stories-inline.js` changes pipeline | Medium | All exports preserved, tone variation tested on test |
| Missing secrets | Low | Clear error messages, set before testing |
| Orphaned `prompts.js` on main | None | No scripts import it, clean up later |

## Test Plan

- [x] QA'd on test site across ADO-333/335-339
- [x] Stories edit + re-enrich verified on test
- [x] Pardons edit + re-enrich + publish/unpublish verified on test
- [x] Tone variation tested over multiple enrichment cycles
- [ ] Post-merge: Verify admin.html loads on PROD
- [ ] Post-merge: Verify Stories/Pardons CRUD on PROD
- [ ] Post-merge: Verify re-enrichment dispatches on PROD
- [ ] Post-merge: Verify next RSS pipeline run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)