### PR TITLE
feat: SCOTUS GitHub Actions workflows + edge function wiring (ADO-81)

### DIFF
--- a/.github/workflows/enrich-scotus.yml
+++ b/.github/workflows/enrich-scotus.yml
@@ -1,0 +1,74 @@
+name: Enrich SCOTUS (single case)
+
+on:
+  workflow_dispatch:
+    inputs:
+      case_id:
+        description: "SCOTUS case ID"
+        required: true
+        type: string
+      environment:
+        description: "Which environment to run against"
+        required: true
+        type: choice
+        options:
+          - test
+          - prod
+
+jobs:
+  enrich_single:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Create logs dir
+        run: mkdir -p logs
+
+      - name: Validate case_id
+        env:
+          INPUT_CASE_ID: ${{ inputs.case_id }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${INPUT_CASE_ID}" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+            echo "Error: case_id must be numeric (or comma-separated numeric IDs)"
+            exit 1
+          fi
+
+      - name: Enrich (TEST)
+        if: inputs.environment == 'test'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_TEST_URL: ${{ secrets.SUPABASE_TEST_URL }}
+          SUPABASE_TEST_SERVICE_KEY: ${{ secrets.SUPABASE_TEST_SERVICE_KEY }}
+          INPUT_CASE_ID: ${{ inputs.case_id }}
+        run: |
+          set -euo pipefail
+          node scripts/scotus/enrich-scotus.js --case-ids="${INPUT_CASE_ID}" 2>&1 | tee logs/enrich-test.log
+
+      - name: Enrich (PROD)
+        if: inputs.environment == 'prod'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          INPUT_CASE_ID: ${{ inputs.case_id }}
+        run: |
+          set -euo pipefail
+          node scripts/scotus/enrich-scotus.js --case-ids="${INPUT_CASE_ID}" --prod 2>&1 | tee logs/enrich-prod.log
+
+      - name: Upload logs on failure/cancel
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enrich-scotus-logs
+          path: logs

--- a/.github/workflows/scotus-tracker.yml
+++ b/.github/workflows/scotus-tracker.yml
@@ -1,0 +1,129 @@
+name: SCOTUS Tracker (PROD scheduled)
+
+on:
+  schedule:
+    # 18:00 UTC = 12:00 CT (standard time) / 13:00 ET (standard time). DST will shift.
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "How many cases to enrich (default 10)"
+        required: false
+        default: "10"
+        type: string
+      skip_fetch:
+        description: "Skip fetch phase"
+        required: false
+        type: boolean
+        default: false
+      skip_enrich:
+        description: "Skip enrich phase"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: scotus-pipeline-main
+  cancel-in-progress: false
+
+jobs:
+  scotus_pipeline:
+    name: SCOTUS pipeline
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Kill switch + branch lock
+    if: github.ref == 'refs/heads/main' && vars.ENABLE_PROD_SCHEDULES == 'true'
+    env:
+      NODE_ENV: production
+      # workflow_dispatch inputs land here as strings; schedule has none
+      LIMIT: ${{ github.event.inputs.limit || '10' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Create logs dir
+        run: mkdir -p logs
+
+      - name: Set day (UTC)
+        id: day
+        run: echo "day=$(date -u +%F)" >> $GITHUB_OUTPUT
+
+      # --------------------------
+      # Phase 1: Fetch (CourtListener)
+      # --------------------------
+      - name: Fetch cases (CourtListener → Supabase PROD via TEST-named env vars)
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_fetch != 'true' }}
+        env:
+          COURTLISTENER_API_TOKEN: ${{ secrets.COURTLISTENER_API_TOKEN }}
+          # IMPORTANT: fetch-cases.js is hardcoded to SUPABASE_TEST_* names.
+          # We map PROD secrets into those names ONLY for this step.
+          SUPABASE_TEST_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_TEST_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          node scripts/scotus/fetch-cases.js --resume 2>&1 | tee logs/fetch.log
+
+      # --------------------------
+      # Budget guard between phases
+      # --------------------------
+      - name: Budget guard (block if spent_usd >= 4.50)
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_enrich != 'true' }}
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          DAY: ${{ steps.day.outputs.day }}
+        run: |
+          set -euo pipefail
+          url="${SUPABASE_URL}/rest/v1/budgets?day=eq.${DAY}&select=spent_usd"
+          echo "Checking budget: ${url}" | tee -a logs/budget.log
+          resp="$(curl -sS --fail-with-body "${url}" \
+            -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Accept: application/json")" || {
+            echo "Budget API call failed" | tee -a logs/budget.log
+            exit 1
+          }
+          echo "${resp}" | tee -a logs/budget.log
+          if ! echo "${resp}" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "Budget API returned unexpected response" | tee -a logs/budget.log
+            exit 1
+          fi
+          spent="$(echo "${resp}" | jq -r '.[0].spent_usd // 0')"
+          echo "spent_usd=${spent}" | tee -a logs/budget.log
+          ok="$(awk -v s="${spent}" 'BEGIN { if (s+0 < 4.50) print "true"; else print "false"; }')"
+          if [ "${ok}" != "true" ]; then
+            echo "Budget guard tripped: spent_usd=${spent} >= 4.50" | tee -a logs/budget.log
+            exit 1
+          fi
+
+      # --------------------------
+      # Phase 2: Enrich
+      # --------------------------
+      - name: Enrich cases (PROD)
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_enrich != 'true' }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          # IMPORTANT: Do NOT set SUPABASE_TEST_* in this step.
+          node scripts/scotus/enrich-scotus.js --limit="${LIMIT}" --prod 2>&1 | tee logs/enrich.log
+
+      - name: Upload logs on failure/cancel
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scotus-tracker-logs
+          path: logs

--- a/docs/handoffs/2026-02-09-ado-81-scotus-workflows.md
+++ b/docs/handoffs/2026-02-09-ado-81-scotus-workflows.md
@@ -1,5 +1,32 @@
 # ADO-81: SCOTUS GitHub Actions Workflows
 
-**Date:** 2026-02-09 | **ADO:** 81 | **Branch:** test
+**Date:** 2026-02-09 | **ADO:** 81 (Active) | **Branch:** test | **Commit:** f9c5531
 
-Created 2 workflow files + edited trigger-enrichment edge function. `scotus-tracker.yml` is the daily PROD pipeline (fetch from CourtListener + budget guard + enrich). `enrich-scotus.yml` is the single-case re-enrichment workflow triggered by the admin dashboard. Both deployed to test branch; trigger-enrichment edge function deployed to TEST Supabase. **Next:** Push to test, then PR to main — both workflow files must reach main for the scheduled SCOTUS pipeline to activate (gated by `ENABLE_PROD_SCHEDULES` var + `refs/heads/main` check). Verify `COURTLISTENER_API_TOKEN` secret exists in GitHub repo settings before first PROD run.
+Created `scotus-tracker.yml` (daily PROD pipeline: fetch + budget guard + enrich), `enrich-scotus.yml` (single-case re-enrichment for admin dashboard), and added scotus to trigger-enrichment edge function WORKFLOW_CONFIG (deployed to TEST). Code review caught and fixed command injection in case_id input + hardened budget guard error handling. Pushed to test.
+
+## Next Session Testing
+
+1. **Test `enrich-scotus.yml` workflow on test branch:**
+   ```bash
+   # Pick a SCOTUS case ID from TEST DB, then:
+   gh workflow run "Enrich SCOTUS (single case)" --ref test -f case_id=<ID> -f environment=test
+   gh run watch
+   ```
+
+2. **Test edge function trigger on TEST:**
+   ```bash
+   curl -X POST "https://wnrjrywpcadwutfykflu.supabase.co/functions/v1/trigger-enrichment" \
+     -H "Content-Type: application/json" \
+     -H "x-admin-password: <ADMIN_PASSWORD>" \
+     -d '{"entity_type":"scotus","entity_id":<ID>}'
+   ```
+
+3. **After both pass → PR to main** (cherry-pick f9c5531), then test PROD dispatch:
+   ```bash
+   gh workflow run "SCOTUS Tracker (PROD scheduled)" --ref main -f skip_fetch=true -f limit=1
+   ```
+
+4. **Pre-PR checklist:** Verify `COURTLISTENER_API_TOKEN` secret exists in GitHub repo settings.
+
+## Next Card
+Check ADO backlog for the next prioritized item after ADO-81 moves to Testing.

--- a/docs/handoffs/2026-02-09-ado-81-scotus-workflows.md
+++ b/docs/handoffs/2026-02-09-ado-81-scotus-workflows.md
@@ -1,0 +1,5 @@
+# ADO-81: SCOTUS GitHub Actions Workflows
+
+**Date:** 2026-02-09 | **ADO:** 81 | **Branch:** test
+
+Created 2 workflow files + edited trigger-enrichment edge function. `scotus-tracker.yml` is the daily PROD pipeline (fetch from CourtListener + budget guard + enrich). `enrich-scotus.yml` is the single-case re-enrichment workflow triggered by the admin dashboard. Both deployed to test branch; trigger-enrichment edge function deployed to TEST Supabase. **Next:** Push to test, then PR to main — both workflow files must reach main for the scheduled SCOTUS pipeline to activate (gated by `ENABLE_PROD_SCHEDULES` var + `refs/heads/main` check). Verify `COURTLISTENER_API_TOKEN` secret exists in GitHub repo settings before first PROD run.

--- a/supabase/functions/trigger-enrichment/index.ts
+++ b/supabase/functions/trigger-enrichment/index.ts
@@ -163,6 +163,10 @@ Deno.serve(async (req) => {
       pardon: {
         file: 'enrich-pardons.yml',
         buildInputs: (id, env) => ({ pardon_id: String(id), limit: '1', force: 'true' })
+      },
+      scotus: {
+        file: 'enrich-scotus.yml',
+        buildInputs: (id, env) => ({ case_id: String(id), environment: env })
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `scotus-tracker.yml` — daily PROD pipeline: fetch cases from CourtListener → budget guard → AI enrichment
- Add `enrich-scotus.yml` — single-case re-enrichment workflow (triggered from admin dashboard)
- Wire `scotus` entity type into `trigger-enrichment` edge function WORKFLOW_CONFIG

## Notes
- `scotus-tracker.yml` is gated by `vars.ENABLE_PROD_SCHEDULES == 'true'` and `refs/heads/main` — safe to merge without triggering
- `COURTLISTENER_API_TOKEN` secret needs to be added before enabling the scheduled pipeline
- Edge function already deployed to TEST (Supabase ref: wnrjrywpcadwutfykflu)
- Edge function needs PROD deploy after merge (ref: osjbulmltfpcoldydexg)
- Code reviewed in prior session: fixed command injection in case_id input + hardened budget guard error handling

## Test plan
- [ ] Merge PR (workflows won't auto-run — gated by ENABLE_PROD_SCHEDULES)
- [ ] Test `enrich-scotus.yml`: `gh workflow run "Enrich SCOTUS (single case)" -f case_id=294 -f environment=test`
- [ ] Test `scotus-tracker.yml`: `gh workflow run "SCOTUS Tracker (PROD scheduled)" -f skip_fetch=true -f limit=1`
- [ ] Deploy trigger-enrichment edge function to PROD
- [ ] Add `COURTLISTENER_API_TOKEN` secret before enabling daily schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)