### PR TITLE
feat: SCOTUS admin dashboard (ADO-340)

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -3373,9 +3373,6 @@
             const [undoInfo, setUndoInfo] = useState(null);
             const [enrichingIds, setEnrichingIds] = useState(new Set());
             const [selectedIds, setSelectedIds] = useState(new Set());
-            const [showRejectDialog, setShowRejectDialog] = useState(false);
-            const [rejectingCase, setRejectingCase] = useState(null);
-            const [rejectNote, setRejectNote] = useState('');
 
             // Run log
             const [runLogData, setRunLogData] = useState(null);
@@ -3535,6 +3532,8 @@
             // Handle re-enrich
             const handleReEnrich = async (c) => {
                 if (enrichingIds.has(c.id)) return;
+                const wasPublic = c.is_public;
+                if (wasPublic && !confirm('This will unpublish the case and queue it for re-enrichment. Continue?')) return;
                 setEnrichingIds(prev => new Set([...prev, c.id]));
                 try {
                     const { data, error: fnError } = await supabase.functions.invoke(
@@ -3543,7 +3542,7 @@
                             headers: { 'x-admin-password': password },
                             body: {
                                 case_id: c.id,
-                                updates: { enrichment_status: 'pending', enriched_at: null },
+                                updates: { enrichment_status: 'pending' },
                                 original_updated_at: c.updated_at
                             }
                         }
@@ -3558,10 +3557,13 @@
 
                     setCases(prev => prev.map(sc =>
                         sc.id === c.id
-                            ? { ...sc, ...(data?.scotus_case ?? { enrichment_status: 'pending' }) }
+                            ? { ...sc, ...(data?.scotus_case ?? { enrichment_status: 'pending', is_public: false }) }
                             : sc
                     ));
-                    toast?.addToast('Queued for re-enrichment. Will be enriched on next agent run (weekdays 4PM UTC).', 'success');
+                    const msg = wasPublic
+                        ? 'Unpublished and queued for re-enrichment. Next agent run: weekdays 4PM UTC.'
+                        : 'Queued for re-enrichment. Next agent run: weekdays 4PM UTC.';
+                    toast?.addToast(msg, 'success');
                 } catch (err) {
                     console.error('Re-enrich error:', err);
                     toast?.addToast(err.message || 'Failed to re-enrich', 'error');
@@ -3639,45 +3641,6 @@
                 }
             };
 
-            // Handle reject
-            const handleReject = async () => {
-                if (!rejectNote.trim()) return;
-                try {
-                    const { data, error: fnError } = await supabase.functions.invoke(
-                        'admin-update-scotus',
-                        {
-                            headers: { 'x-admin-password': password },
-                            body: {
-                                case_id: rejectingCase.id,
-                                updates: { qa_status: 'rejected', qa_review_note: rejectNote.trim() },
-                                original_updated_at: rejectingCase.updated_at
-                            }
-                        }
-                    );
-
-                    if (fnError) {
-                        let body = data;
-                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
-                        if (body?.conflict) {
-                            toast?.addToast('Conflict: record was modified. Refresh and try again.', 'error');
-                            setShowRejectDialog(false);
-                            setRejectingCase(null);
-                            return;
-                        }
-                        throw new Error(body?.error || fnError.message || 'Reject failed');
-                    }
-                    if (data?.error) throw new Error(data.error);
-
-                    setCases(prev => prev.map(sc => sc.id === rejectingCase.id ? { ...sc, ...data.scotus_case } : sc));
-                    toast?.addToast('Rejected. Will be re-enriched on next agent run (weekdays 4PM UTC).', 'success');
-                    setShowRejectDialog(false);
-                    setRejectingCase(null);
-                    setRejectNote('');
-                } catch (err) {
-                    console.error('Reject error:', err);
-                    toast?.addToast(err.message || 'Failed to reject', 'error');
-                }
-            };
 
             // Handle bulk publish
             const handleBulkPublish = async () => {
@@ -4002,11 +3965,6 @@
                                                                     &#128229; Publish
                                                                 </button>
                                                             )}
-                                                            {!c.is_public && (
-                                                                <button className="btn-icon" onClick={() => { setRejectingCase(c); setShowRejectDialog(true); setRejectNote(''); }} title="Reject & Re-queue">
-                                                                    &#128683; Reject
-                                                                </button>
-                                                            )}
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -4026,28 +3984,6 @@
                                     </button>
                                 </div>
                             )}
-                        </div>
-                    )}
-
-                    {/* Reject Dialog */}
-                    {showRejectDialog && rejectingCase && (
-                        <div className="modal-overlay">
-                            <div style={{ background: '#1e293b', border: '1px solid #ef4444', borderRadius: '12px', padding: '24px', width: '100%', maxWidth: '480px' }}>
-                                <h3 style={{ margin: '0 0 12px', color: '#f8fafc', fontSize: '16px' }}>Reject & Re-queue: #{rejectingCase.id}</h3>
-                                <p style={{ color: '#94a3b8', fontSize: '13px', margin: '0 0 12px' }}>{rejectingCase.case_name}</p>
-                                <textarea
-                                    className="form-textarea"
-                                    placeholder="Reason for rejection (required)..."
-                                    value={rejectNote}
-                                    onChange={(e) => setRejectNote(e.target.value)}
-                                    rows={3}
-                                    autoFocus
-                                />
-                                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '12px' }}>
-                                    <button className="btn-secondary" onClick={() => { setShowRejectDialog(false); setRejectingCase(null); setRejectNote(''); }}>Cancel</button>
-                                    <button className="btn-primary" onClick={handleReject} disabled={!rejectNote.trim()} style={{ background: '#ef4444' }}>Reject & Re-queue</button>
-                                </div>
-                            </div>
                         </div>
                     )}
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -2431,6 +2431,10 @@
             const h = React.createElement;
             const [formData, setFormData] = useState(() => ({
                 // Case Identity (read-only in display but included for reference)
+                case_name: scotusCase?.case_name || '',
+                docket_number: scotusCase?.docket_number || '',
+                term: scotusCase?.term || '',
+                decided_at: scotusCase?.decided_at ? scotusCase.decided_at.substring(0, 10) : '',
                 disposition: scotusCase?.disposition || '',
                 case_type: scotusCase?.case_type || '',
                 // Vote & Opinion
@@ -2464,7 +2468,7 @@
             const [saving, setSaving] = useState(false);
             const [error, setError] = useState(null);
             const [isConflict, setIsConflict] = useState(false);
-            const [openSections, setOpenSections] = useState({ case_identity: true, vote_opinion: true, editorial: true, evidence: false, status_qa: false });
+            const [openSections, setOpenSections] = useState({ case_identity: true, vote_opinion: true, editorial: true, evidence: true, status_qa: false });
 
             const originalUpdatedAt = scotusCase?.updated_at;
 
@@ -2491,8 +2495,15 @@
                 try {
                     const updates = {};
 
-                    // Text fields
-                    const textFields = ['vote_split', 'majority_author', 'ruling_label', 'summary_spicy', 'who_wins', 'who_loses', 'why_it_matters', 'dissent_highlights', 'practical_effect', 'media_says', 'actually_means', 'holding', 'qa_review_note', 'manual_review_note'];
+                    // Text fields (case identity + vote + editorial)
+                    const textFields = ['case_name', 'docket_number', 'term', 'vote_split', 'majority_author', 'ruling_label', 'summary_spicy', 'who_wins', 'who_loses', 'why_it_matters', 'dissent_highlights', 'practical_effect', 'media_says', 'actually_means', 'holding'];
+
+                    // Date fields
+                    for (const f of ['decided_at']) {
+                        const newVal = formData[f] || null;
+                        const oldVal = scotusCase[f] ? scotusCase[f].substring(0, 10) : null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
                     for (const f of textFields) {
                         const newVal = formData[f] || null;
                         const oldVal = scotusCase[f] || null;
@@ -2673,13 +2684,13 @@
                             // Section 1: Case Identity (open)
                             sectionHeader('case_identity', 'Case Identity'),
                             openSections.case_identity && h('div', null,
-                                readOnlyField('Case Name', scotusCase.case_name),
+                                textField('case_name', 'Case Name', { used: true }),
                                 h('div', { className: 'form-row' },
-                                    readOnlyField('Docket Number', scotusCase.docket_number),
-                                    readOnlyField('Term', scotusCase.term)
+                                    textField('docket_number', 'Docket Number', { used: true }),
+                                    textField('term', 'Term', { used: true })
                                 ),
                                 h('div', { className: 'form-row' },
-                                    readOnlyField('Decided', scotusCase.decided_at ? new Date(scotusCase.decided_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : null),
+                                    textField('decided_at', 'Decided (YYYY-MM-DD)', { type: 'date', used: true }),
                                     selectField('disposition', 'Disposition', SCOTUS_DISPOSITIONS, true)
                                 ),
                                 selectField('case_type', 'Case Type', SCOTUS_CASE_TYPES, true)

--- a/public/admin.html
+++ b/public/admin.html
@@ -414,6 +414,14 @@
         .badge-severe { background: rgba(249, 115, 22, 0.2); color: #f97316; }
         .badge-moderate { background: rgba(234, 179, 8, 0.2); color: #eab308; }
         .badge-minor { background: rgba(34, 197, 94, 0.2); color: #22c55e; }
+        .badge-info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
+        .badge-cool { background: rgba(6, 182, 212, 0.2); color: #06b6d4; }
+        .scotus-needs-review { border-left: 3px solid #fbbf24; }
+        .bulk-checkbox { accent-color: #3b82f6; width: 16px; height: 16px; cursor: pointer; }
+        .reject-dialog { background: #1e293b; border: 1px solid #ef4444; border-radius: 8px; padding: 16px; margin-top: 12px; }
+        .run-log-card { margin-top: 16px; }
+        .run-log-card .card-header { cursor: pointer; user-select: none; }
+        .run-log-card .card-header:hover { background: rgba(59, 130, 246, 0.05); }
         .load-more-btn {
             display: block;
             width: 100%;
@@ -2357,6 +2365,420 @@
             'research_status', 'post_pardon_status', 'post_pardon_notes', 'is_public', 'needs_review', 'primary_source_url', 'source_urls'
         ];
 
+        // SCOTUS constants — source: public/shared/tone-system.json scotus labels
+        const SCOTUS_IMPACT_LEVELS = [
+            { value: 5, label: 'Constitutional Crisis', badgeClass: 'badge-critical' },
+            { value: 4, label: 'Rubber-stamping Tyranny', badgeClass: 'badge-severe' },
+            { value: 3, label: 'Institutional Sabotage', badgeClass: 'badge-moderate' },
+            { value: 2, label: 'Judicial Sidestepping', badgeClass: 'badge-info' },
+            { value: 1, label: 'Crumbs from the Bench', badgeClass: 'badge-cool' },
+            { value: 0, label: 'Democracy Wins', badgeClass: 'badge-active' },
+        ];
+        const SCOTUS_IMPACT_MAP = Object.fromEntries(SCOTUS_IMPACT_LEVELS.map(l => [l.value, l]));
+
+        // Source: migration 087 CHECK constraint on scotus_cases.disposition
+        const SCOTUS_DISPOSITIONS = [
+            { value: 'affirmed', label: 'Affirmed' },
+            { value: 'reversed', label: 'Reversed' },
+            { value: 'vacated', label: 'Vacated' },
+            { value: 'remanded', label: 'Remanded' },
+            { value: 'reversed_and_remanded', label: 'Reversed & Remanded' },
+            { value: 'vacated_and_remanded', label: 'Vacated & Remanded' },
+            { value: 'affirmed_and_remanded', label: 'Affirmed & Remanded' },
+            { value: 'dismissed', label: 'Dismissed' },
+            { value: 'granted', label: 'Granted' },
+            { value: 'denied', label: 'Denied' },
+            { value: 'GVR', label: 'GVR' },
+            { value: 'other', label: 'Other' },
+        ];
+
+        // Source: migration 087 CHECK constraint on scotus_cases.case_type
+        const SCOTUS_CASE_TYPES = [
+            { value: 'merits', label: 'Merits' },
+            { value: 'procedural', label: 'Procedural' },
+            { value: 'shadow_docket', label: 'Shadow Docket' },
+            { value: 'cert_stage', label: 'Cert Stage' },
+            { value: 'unclear', label: 'Unclear' },
+        ];
+
+        // Source: migration 087 CHECK constraint on scotus_cases.qa_status
+        const SCOTUS_QA_STATUSES = [
+            { value: 'pending_qa', label: 'Pending QA' },
+            { value: 'approved', label: 'Approved' },
+            { value: 'flagged', label: 'Flagged' },
+            { value: 'rejected', label: 'Rejected' },
+            { value: 'human_override', label: 'Human Override' },
+        ];
+
+        // Source: migration 087 CHECK constraint on scotus_cases.enrichment_status
+        const SCOTUS_ENRICHMENT_STATUSES = [
+            { value: 'pending', label: 'Pending' },
+            { value: 'enriched', label: 'Enriched' },
+            { value: 'flagged', label: 'Flagged' },
+            { value: 'failed', label: 'Failed' },
+        ];
+
+        // Source: migration 087 CHECK constraint on scotus_cases.prevailing_party
+        const SCOTUS_PREVAILING_PARTIES = [
+            { value: 'petitioner', label: 'Petitioner' },
+            { value: 'respondent', label: 'Respondent' },
+            { value: 'partial', label: 'Partial' },
+            { value: 'unclear', label: 'Unclear' },
+        ];
+
+        // EditScotusModal Component
+        function EditScotusModal({ scotusCase, onClose, onSave, onRefresh, supabase, password }) {
+            const h = React.createElement;
+            const [formData, setFormData] = useState(() => ({
+                // Case Identity (read-only in display but included for reference)
+                disposition: scotusCase?.disposition || '',
+                case_type: scotusCase?.case_type || '',
+                // Vote & Opinion
+                vote_split: scotusCase?.vote_split || '',
+                majority_author: scotusCase?.majority_author || '',
+                dissent_authors: (scotusCase?.dissent_authors || []).join(', '),
+                prevailing_party: scotusCase?.prevailing_party || '',
+                merits_reached: scotusCase?.merits_reached ?? false,
+                // Editorial Content
+                ruling_impact_level: scotusCase?.ruling_impact_level ?? '',
+                ruling_label: scotusCase?.ruling_label || '',
+                summary_spicy: scotusCase?.summary_spicy || '',
+                who_wins: scotusCase?.who_wins || '',
+                who_loses: scotusCase?.who_loses || '',
+                why_it_matters: scotusCase?.why_it_matters || '',
+                dissent_highlights: scotusCase?.dissent_highlights || '',
+                practical_effect: scotusCase?.practical_effect || '',
+                media_says: scotusCase?.media_says || '',
+                actually_means: scotusCase?.actually_means || '',
+                // Evidence
+                evidence_anchors: (scotusCase?.evidence_anchors || []).join('\n'),
+                holding: scotusCase?.holding || '',
+                // Status & QA
+                is_public: scotusCase?.is_public ?? false,
+                qa_status: scotusCase?.qa_status || '',
+                qa_review_note: scotusCase?.qa_review_note || '',
+                needs_manual_review: scotusCase?.needs_manual_review ?? false,
+                manual_review_note: scotusCase?.manual_review_note || '',
+                enrichment_status: scotusCase?.enrichment_status || '',
+            }));
+            const [saving, setSaving] = useState(false);
+            const [error, setError] = useState(null);
+            const [isConflict, setIsConflict] = useState(false);
+            const [openSections, setOpenSections] = useState({ case_identity: true, vote_opinion: true, editorial: false, evidence: false, status_qa: false });
+
+            const originalUpdatedAt = scotusCase?.updated_at;
+
+            // Escape key closes modal
+            useEffect(() => {
+                const handler = (e) => { if (e.key === 'Escape') onClose(); };
+                document.addEventListener('keydown', handler);
+                return () => document.removeEventListener('keydown', handler);
+            }, [onClose]);
+
+            const handleChange = (field, value) => {
+                setFormData(prev => ({ ...prev, [field]: value }));
+            };
+
+            const toggleSection = (section) => {
+                setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
+            };
+
+            const handleSubmit = async (e) => {
+                e.preventDefault();
+                setSaving(true);
+                setError(null);
+
+                try {
+                    const updates = {};
+
+                    // Text fields
+                    const textFields = ['vote_split', 'majority_author', 'ruling_label', 'summary_spicy', 'who_wins', 'who_loses', 'why_it_matters', 'dissent_highlights', 'practical_effect', 'media_says', 'actually_means', 'holding', 'qa_review_note', 'manual_review_note'];
+                    for (const f of textFields) {
+                        const newVal = formData[f] || null;
+                        const oldVal = scotusCase[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // Enum fields
+                    for (const f of ['disposition', 'case_type', 'prevailing_party', 'qa_status', 'enrichment_status']) {
+                        const newVal = formData[f] || null;
+                        const oldVal = scotusCase[f] || null;
+                        if (newVal !== oldVal) updates[f] = newVal;
+                    }
+
+                    // Boolean fields
+                    for (const f of ['is_public', 'needs_manual_review', 'merits_reached']) {
+                        if (formData[f] !== (scotusCase[f] ?? false)) updates[f] = formData[f];
+                    }
+
+                    // Integer: ruling_impact_level
+                    const newImpact = formData.ruling_impact_level === '' ? null : parseInt(formData.ruling_impact_level, 10);
+                    const oldImpact = scotusCase.ruling_impact_level ?? null;
+                    if (newImpact !== oldImpact) updates.ruling_impact_level = newImpact;
+
+                    // Array: dissent_authors (comma-separated) — sort before comparing to avoid spurious writes
+                    const newDissent = formData.dissent_authors ? formData.dissent_authors.split(',').map(s => s.trim()).filter(Boolean) : [];
+                    const oldDissent = scotusCase.dissent_authors || [];
+                    if (JSON.stringify([...newDissent].sort()) !== JSON.stringify([...oldDissent].sort())) updates.dissent_authors = newDissent;
+
+                    // Array: evidence_anchors (newline-separated)
+                    const newAnchors = formData.evidence_anchors ? formData.evidence_anchors.split('\n').map(s => s.trim()).filter(Boolean) : [];
+                    const oldAnchors = scotusCase.evidence_anchors || [];
+                    if (JSON.stringify(newAnchors) !== JSON.stringify(oldAnchors)) updates.evidence_anchors = newAnchors;
+
+                    if (Object.keys(updates).length === 0) {
+                        onClose();
+                        return;
+                    }
+
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_id: scotusCase.id,
+                                updates,
+                                original_updated_at: originalUpdatedAt
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try {
+                            if (!body && fnError.context) body = await fnError.context.json();
+                        } catch (_) {}
+                        if (body?.conflict) {
+                            setIsConflict(true);
+                            setError(body.error || 'Record was modified by another process. Close and refresh to get the latest data.');
+                            setSaving(false);
+                            return;
+                        }
+                        throw new Error(body?.error || fnError.message || 'Update failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    const changedFields = data.changed_fields || {};
+                    const firstChangedField = Object.keys(changedFields)[0];
+
+                    onSave(data.scotus_case, firstChangedField ? {
+                        entityType: 'scotus',
+                        entityId: String(scotusCase.id),
+                        fieldName: firstChangedField,
+                        oldValue: changedFields[firstChangedField]?.old
+                    } : null);
+                } catch (err) {
+                    console.error('Save error:', err);
+                    setError(err.message || 'Failed to save changes');
+                } finally {
+                    setSaving(false);
+                }
+            };
+
+            // Helper: section header
+            const sectionHeader = (key, label) =>
+                h('div', { className: 'form-section-header', onClick: () => toggleSection(key) },
+                    h('h4', null, label),
+                    h('span', { className: 'form-section-arrow' + (openSections[key] ? ' open' : '') }, '\u25B6')
+                );
+
+            // Helper: label with optional red asterisk (indicates field is displayed on public site)
+            const fieldLabel = (label, used) =>
+                used ? h('label', { className: 'form-label' }, label, h('span', { style: { color: '#ef4444', marginLeft: '3px' } }, '*')) : h('label', { className: 'form-label' }, label);
+
+            // Helper: text input field
+            const textField = (field, label, opts = {}) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, opts.used),
+                    h('input', {
+                        type: opts.type || 'text',
+                        className: 'form-input',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value),
+                        placeholder: opts.placeholder || '',
+                        readOnly: opts.readOnly || false,
+                        style: opts.readOnly ? { opacity: 0.6, cursor: 'not-allowed' } : {},
+                        ...opts.inputProps
+                    })
+                );
+
+            // Helper: read-only display field
+            const readOnlyField = (label, value) =>
+                h('div', { className: 'form-group' },
+                    h('label', { className: 'form-label' }, label),
+                    h('div', { style: { padding: '10px 12px', background: '#0f172a', border: '1px solid #334155', borderRadius: '8px', color: '#94a3b8', fontSize: '14px' } }, value || '-')
+                );
+
+            // Helper: select field
+            const selectField = (field, label, options, used) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, used),
+                    h('select', {
+                        className: 'form-select',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value)
+                    },
+                        h('option', { value: '' }, 'Not set'),
+                        options.map(opt =>
+                            h('option', { key: opt.value, value: opt.value }, opt.label)
+                        )
+                    )
+                );
+
+            // Helper: textarea field
+            const textareaField = (field, label, rows = 3, used = false) =>
+                h('div', { className: 'form-group' },
+                    fieldLabel(label, used),
+                    h('textarea', {
+                        className: 'form-textarea',
+                        value: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.value),
+                        rows
+                    })
+                );
+
+            // Helper: boolean checkbox
+            const boolField = (field, label, used = false) =>
+                h('div', { className: 'form-group', style: { display: 'flex', alignItems: 'center', gap: '8px' } },
+                    h('input', {
+                        type: 'checkbox',
+                        checked: formData[field],
+                        onChange: (ev) => handleChange(field, ev.target.checked),
+                        style: { accentColor: '#3b82f6', width: '16px', height: '16px' }
+                    }),
+                    used
+                        ? h('label', { className: 'form-label', style: { marginBottom: 0 } }, label, h('span', { style: { color: '#ef4444', marginLeft: '3px' } }, '*'))
+                        : h('label', { className: 'form-label', style: { marginBottom: 0 } }, label)
+                );
+
+            return h('div', { className: 'modal-overlay' },
+                h('div', { className: 'modal-content' },
+                    h('div', { className: 'modal-header' },
+                        h('h3', { className: 'modal-title' }, 'Edit SCOTUS Case #' + scotusCase.id + (scotusCase.case_name ? ' - ' + scotusCase.case_name : '')),
+                        h('button', { className: 'modal-close', onClick: onClose }, '\u00D7')
+                    ),
+                    h('form', { onSubmit: handleSubmit },
+                        h('div', { className: 'modal-body' },
+                            // Error banner
+                            error && h('div', { className: 'error-banner', style: { marginBottom: '16px' } },
+                                error,
+                                isConflict && h('button', {
+                                    type: 'button',
+                                    className: 'btn-primary',
+                                    style: { marginLeft: '12px', padding: '4px 12px', fontSize: '13px' },
+                                    onClick: () => { onRefresh && onRefresh(); onClose(); }
+                                }, 'Close & Refresh')
+                            ),
+
+                            // Section 1: Case Identity (open)
+                            sectionHeader('case_identity', 'Case Identity'),
+                            openSections.case_identity && h('div', null,
+                                readOnlyField('Case Name', scotusCase.case_name),
+                                h('div', { className: 'form-row' },
+                                    readOnlyField('Docket Number', scotusCase.docket_number),
+                                    readOnlyField('Term', scotusCase.term)
+                                ),
+                                h('div', { className: 'form-row' },
+                                    readOnlyField('Decided', scotusCase.decided_at ? new Date(scotusCase.decided_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : null),
+                                    selectField('disposition', 'Disposition', SCOTUS_DISPOSITIONS, true)
+                                ),
+                                selectField('case_type', 'Case Type', SCOTUS_CASE_TYPES, true)
+                            ),
+
+                            // Section 2: Vote & Opinion (open)
+                            sectionHeader('vote_opinion', 'Vote & Opinion'),
+                            openSections.vote_opinion && h('div', null,
+                                h('div', { className: 'form-row' },
+                                    textField('vote_split', 'Vote Split', { placeholder: 'e.g. 6-3', used: true }),
+                                    textField('majority_author', 'Majority Author', { used: true })
+                                ),
+                                textField('dissent_authors', 'Dissent Authors (comma-separated)', { placeholder: 'e.g. Sotomayor, Kagan, Jackson', used: true }),
+                                h('div', { className: 'form-row' },
+                                    selectField('prevailing_party', 'Prevailing Party', SCOTUS_PREVAILING_PARTIES, true),
+                                    boolField('merits_reached', 'Merits Reached', true)
+                                )
+                            ),
+
+                            // Section 3: Editorial Content (collapsed)
+                            sectionHeader('editorial', 'Editorial Content'),
+                            openSections.editorial && h('div', null,
+                                h('div', { className: 'form-row' },
+                                    h('div', { className: 'form-group' },
+                                        fieldLabel('Impact Level', true),
+                                        h('select', {
+                                            className: 'form-select',
+                                            value: formData.ruling_impact_level,
+                                            onChange: (ev) => handleChange('ruling_impact_level', ev.target.value)
+                                        },
+                                            h('option', { value: '' }, 'Not set'),
+                                            SCOTUS_IMPACT_LEVELS.map(l =>
+                                                h('option', { key: l.value, value: String(l.value) }, l.value + ' - ' + l.label)
+                                            )
+                                        )
+                                    ),
+                                    textField('ruling_label', 'Ruling Label', { used: true })
+                                ),
+                                textareaField('summary_spicy', 'Summary (Spicy)', 5, true),
+                                h('div', { className: 'form-row' },
+                                    textareaField('who_wins', 'Who Wins', 3, true),
+                                    textareaField('who_loses', 'Who Loses', 3, true)
+                                ),
+                                textareaField('why_it_matters', 'Why It Matters', 3, true),
+                                textareaField('dissent_highlights', 'Dissent Highlights', 3, true),
+                                textareaField('practical_effect', 'Practical Effect', 3, true),
+                                h('div', { className: 'form-row' },
+                                    textareaField('media_says', 'Media Says', 3),
+                                    textareaField('actually_means', 'Actually Means', 3)
+                                )
+                            ),
+
+                            // Section 4: Evidence (collapsed)
+                            sectionHeader('evidence', 'Evidence'),
+                            openSections.evidence && h('div', null,
+                                h('div', { className: 'form-group' },
+                                    fieldLabel('Evidence Anchors (one per line)', true),
+                                    h('textarea', {
+                                        className: 'form-textarea',
+                                        value: formData.evidence_anchors,
+                                        onChange: (ev) => handleChange('evidence_anchors', ev.target.value),
+                                        rows: 5,
+                                        placeholder: 'One evidence anchor per line...'
+                                    })
+                                ),
+                                textareaField('holding', 'Holding', 3, true)
+                            ),
+
+                            // Section 5: Status & QA (collapsed)
+                            sectionHeader('status_qa', 'Status & QA'),
+                            openSections.status_qa && h('div', null,
+                                h('div', { style: { display: 'flex', gap: '24px', marginBottom: '16px' } },
+                                    boolField('is_public', 'Published', true),
+                                    boolField('needs_manual_review', 'Needs Manual Review')
+                                ),
+                                h('div', { className: 'form-row' },
+                                    selectField('qa_status', 'QA Status', SCOTUS_QA_STATUSES),
+                                    selectField('enrichment_status', 'Enrichment Status', SCOTUS_ENRICHMENT_STATUSES)
+                                ),
+                                textareaField('qa_review_note', 'QA Review Note', 2),
+                                textareaField('manual_review_note', 'Manual Review Note', 2),
+                                readOnlyField('Low Confidence Reason', scotusCase.low_confidence_reason),
+                                h('div', { className: 'form-row' },
+                                    readOnlyField('Enriched At', scotusCase.enriched_at ? new Date(scotusCase.enriched_at).toLocaleString() : null),
+                                    readOnlyField('Prompt Version', scotusCase.prompt_version)
+                                )
+                            )
+                        ),
+                        h('div', { className: 'modal-footer' },
+                            h('button', { type: 'button', className: 'btn-secondary', onClick: onClose, disabled: saving }, 'Cancel'),
+                            h('button', { type: 'submit', className: 'btn-primary', disabled: saving || isConflict },
+                                saving ? 'Saving...' : 'Save Changes'
+                            )
+                        )
+                    )
+                )
+            );
+        }
+
         // PardonsTab Component
         function PardonsTab({ password, supabase }) {
             const [pardons, setPardons] = useState([]);
@@ -2742,9 +3164,10 @@
                             className="stories-select"
                             value={`${sortBy}-${sortDir}`}
                             onChange={(e) => {
-                                const parts = e.target.value.split('-');
-                                setSortBy(parts[0]);
-                                setSortDir(parts[1]);
+                                const val = e.target.value;
+                                const lastDash = val.lastIndexOf('-');
+                                setSortBy(val.substring(0, lastDash));
+                                setSortDir(val.substring(lastDash + 1));
                             }}
                         >
                             <option value="pardon_date-desc">Date (Newest)</option>
@@ -2887,6 +3310,818 @@
                             onClose={() => setEditingPardon(null)}
                             onSave={handleSaveEdit}
                             onRefresh={() => fetchPardons(false, null)}
+                            supabase={supabase}
+                            password={password}
+                        />
+                    )}
+
+                    {/* Undo Toast */}
+                    {undoInfo && (
+                        <div className="toast-container">
+                            <UndoToast
+                                entityType={undoInfo.entityType}
+                                entityId={undoInfo.entityId}
+                                fieldName={undoInfo.fieldName}
+                                oldValue={undoInfo.oldValue}
+                                onUndo={handleUndo}
+                                onDismiss={() => setUndoInfo(null)}
+                            />
+                        </div>
+                    )}
+                </div>
+            );
+        }
+
+        // ScotusTab Component
+        function ScotusTab({ password, supabase }) {
+            const [cases, setCases] = useState([]);
+            const [loading, setLoading] = useState(true);
+            const [loadingMore, setLoadingMore] = useState(false);
+            const [error, setError] = useState(null);
+            const [cursor, setCursor] = useState(null);
+            const [hasMore, setHasMore] = useState(false);
+            const [availableTerms, setAvailableTerms] = useState([]);
+
+            // Sub-tab: '' = All, 'false' = Drafts (default), 'true' = Published
+            const [isPublicFilter, setIsPublicFilter] = useState('false');
+
+            // Filters
+            const [search, setSearch] = useState('');
+            const [debouncedSearch, setDebouncedSearch] = useState('');
+            const [termFilter, setTermFilter] = useState('');
+            const [enrichmentStatusFilter, setEnrichmentStatusFilter] = useState('');
+            const [needsManualReviewFilter, setNeedsManualReviewFilter] = useState('');
+            const [qaStatusFilter, setQaStatusFilter] = useState('');
+            const [caseTypeFilter, setCaseTypeFilter] = useState('');
+            const [impactLevelFilter, setImpactLevelFilter] = useState('');
+            const [sortBy, setSortBy] = useState('decided_at');
+            const [sortDir, setSortDir] = useState('desc');
+
+            // Actions
+            const [editingCase, setEditingCase] = useState(null);
+            const [undoInfo, setUndoInfo] = useState(null);
+            const [selectedIds, setSelectedIds] = useState(new Set());
+            const [showRejectDialog, setShowRejectDialog] = useState(false);
+            const [rejectingCase, setRejectingCase] = useState(null);
+            const [rejectNote, setRejectNote] = useState('');
+
+            // Run log
+            const [runLogData, setRunLogData] = useState(null);
+            const [runLogLoading, setRunLogLoading] = useState(false);
+            const [runLogExpanded, setRunLogExpanded] = useState(false);
+
+            // Race control
+            const fetchTokenRef = useRef(0);
+
+            // Toast context
+            const toast = useToast();
+
+            // Debounce search (300ms)
+            useEffect(() => {
+                const timer = setTimeout(() => setDebouncedSearch(search), 300);
+                return () => clearTimeout(timer);
+            }, [search]);
+
+            // Fetch cases from edge function
+            const fetchCases = useCallback(async (loadMore = false, nextCursor = null) => {
+                const token = ++fetchTokenRef.current;
+
+                if (loadMore) {
+                    setLoadingMore(true);
+                } else {
+                    setLoading(true);
+                }
+                setError(null);
+
+                try {
+                    const reqBody = { action: 'list', limit: 25, sortBy, sortDir };
+                    if (debouncedSearch) reqBody.search = debouncedSearch;
+                    if (isPublicFilter !== '') reqBody.isPublic = isPublicFilter;
+                    if (termFilter) reqBody.term = termFilter;
+                    if (enrichmentStatusFilter) reqBody.enrichmentStatus = enrichmentStatusFilter;
+                    if (needsManualReviewFilter) reqBody.needsManualReview = needsManualReviewFilter;
+                    if (qaStatusFilter) reqBody.qaStatus = qaStatusFilter;
+                    if (caseTypeFilter) reqBody.caseType = caseTypeFilter;
+                    if (impactLevelFilter !== '') reqBody.impactLevel = parseInt(impactLevelFilter, 10);
+                    if (nextCursor) reqBody.cursor = nextCursor;
+
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: reqBody
+                        }
+                    );
+
+                    if (fnError) throw new Error(fnError.message || 'Failed to fetch SCOTUS cases');
+
+                    // Stale response check
+                    if (token !== fetchTokenRef.current) return;
+
+                    if (loadMore) {
+                        setCases(prev => [...prev, ...(data.scotus_cases || [])]);
+                    } else {
+                        setCases(data.scotus_cases || []);
+                    }
+
+                    setCursor(data.pagination?.next_cursor || null);
+                    setHasMore(data.pagination?.has_more || false);
+
+                    // Update available terms from response
+                    if (data.available_terms && data.available_terms.length > 0) {
+                        setAvailableTerms(data.available_terms);
+                    }
+                } catch (err) {
+                    if (token !== fetchTokenRef.current) return;
+                    console.error('SCOTUS fetch error:', err);
+                    setError(err.message);
+                } finally {
+                    if (token === fetchTokenRef.current) {
+                        setLoading(false);
+                        setLoadingMore(false);
+                    }
+                }
+            }, [supabase, password, debouncedSearch, isPublicFilter, termFilter, enrichmentStatusFilter, needsManualReviewFilter, qaStatusFilter, caseTypeFilter, impactLevelFilter, sortBy, sortDir]);
+
+            // Re-fetch when filters change — reset state
+            useEffect(() => {
+                setCases([]);
+                setCursor(null);
+                setHasMore(false);
+                setSelectedIds(new Set());
+                fetchCases(false, null);
+            }, [fetchCases]);
+
+            // Load more handler
+            const handleLoadMore = () => {
+                if (hasMore && !loadingMore) {
+                    fetchCases(true, cursor);
+                }
+            };
+
+            // Format date
+            const formatDate = (d) => {
+                if (!d) return '-';
+                const date = new Date(d + (d.includes('T') ? '' : 'T00:00:00'));
+                return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+            };
+
+            // Get impact badge
+            const getImpactBadge = (level) => {
+                const info = SCOTUS_IMPACT_MAP[level];
+                if (!info) return { class: 'badge-archived', label: '-' };
+                return { class: info.badgeClass, label: `${level} - ${info.label}` };
+            };
+
+            // Get enrichment status badge
+            const getEnrichmentBadge = (status) => {
+                if (status === 'enriched') return { class: 'badge-active', label: 'Enriched' };
+                if (status === 'pending') return { class: 'badge-pending', label: 'Pending' };
+                if (status === 'failed') return { class: 'badge-failed', label: 'Failed' };
+                if (status === 'flagged') return { class: 'badge-moderate', label: 'Flagged' };
+                return { class: 'badge-archived', label: status || '-' };
+            };
+
+            // Handle edit
+            const handleEdit = (c) => setEditingCase(c);
+
+            // Handle save from edit modal
+            const handleSaveEdit = (updatedCase, undoData) => {
+                setCases(prev => prev.map(c => c.id === updatedCase.id ? { ...c, ...updatedCase } : c));
+                setEditingCase(null);
+                if (undoData) {
+                    setUndoInfo(undoData);
+                } else {
+                    toast?.addToast('SCOTUS case updated successfully', 'success');
+                }
+            };
+
+            // Handle undo
+            const handleUndo = async () => {
+                if (!undoInfo) return;
+                try {
+                    const { data, error: rpcError } = await supabase.rpc('undo_content_change', {
+                        p_entity_type: undoInfo.entityType,
+                        p_entity_id: undoInfo.entityId,
+                        p_changed_by: 'admin'
+                    });
+                    if (rpcError) throw new Error(rpcError.message);
+                    if (!data?.success) throw new Error(data?.error || 'Undo failed');
+                    toast?.addToast(`Restored ${data.field.replace(/_/g, ' ')}`, 'success');
+                    setUndoInfo(null);
+                    fetchCases(false, null);
+                } catch (err) {
+                    console.error('Undo error:', err);
+                    toast?.addToast(err.message || 'Failed to undo', 'error');
+                }
+            };
+
+            // Handle re-enrich
+            const handleReEnrich = async (c) => {
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_id: c.id,
+                                updates: { enrichment_status: 'pending', enriched_at: null },
+                                original_updated_at: c.updated_at
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
+                        throw new Error(body?.error || fnError.message || 'Re-enrich failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
+                    toast?.addToast('Queued for re-enrichment. Will be enriched on next agent run (weekdays 4PM UTC).', 'success');
+                } catch (err) {
+                    console.error('Re-enrich error:', err);
+                    toast?.addToast(err.message || 'Failed to re-enrich', 'error');
+                }
+            };
+
+            // Handle publish
+            const handlePublish = async (c) => {
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_id: c.id,
+                                updates: { is_public: true },
+                                original_updated_at: c.updated_at
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
+                        if (body?.conflict) {
+                            toast?.addToast('Conflict: record was modified. Refresh and try again.', 'error');
+                            return;
+                        }
+                        throw new Error(body?.error || fnError.message || 'Publish failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
+
+                    const changedFields = data.changed_fields || {};
+                    const firstField = Object.keys(changedFields)[0];
+                    if (firstField) {
+                        setUndoInfo({
+                            entityType: 'scotus',
+                            entityId: String(c.id),
+                            fieldName: firstField,
+                            oldValue: changedFields[firstField]?.old
+                        });
+                    } else {
+                        toast?.addToast('Published', 'success');
+                    }
+                } catch (err) {
+                    console.error('Publish error:', err);
+                    toast?.addToast(err.message || 'Failed to publish', 'error');
+                }
+            };
+
+            // Handle unpublish
+            const handleUnpublish = async (c) => {
+                if (!confirm('Unpublish this case? It will be removed from the public site.')) return;
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_id: c.id,
+                                updates: { is_public: false },
+                                original_updated_at: c.updated_at
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
+                        if (body?.conflict) {
+                            toast?.addToast('Conflict: record was modified. Refresh and try again.', 'error');
+                            return;
+                        }
+                        throw new Error(body?.error || fnError.message || 'Unpublish failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
+
+                    const changedFields = data.changed_fields || {};
+                    const firstField = Object.keys(changedFields)[0];
+                    if (firstField) {
+                        setUndoInfo({
+                            entityType: 'scotus',
+                            entityId: String(c.id),
+                            fieldName: firstField,
+                            oldValue: changedFields[firstField]?.old
+                        });
+                    } else {
+                        toast?.addToast('Unpublished', 'success');
+                    }
+                } catch (err) {
+                    console.error('Unpublish error:', err);
+                    toast?.addToast(err.message || 'Failed to unpublish', 'error');
+                }
+            };
+
+            // Handle reject
+            const handleReject = async () => {
+                if (!rejectNote.trim()) return;
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_id: rejectingCase.id,
+                                updates: { qa_status: 'rejected', qa_review_note: rejectNote.trim() },
+                                original_updated_at: rejectingCase.updated_at
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
+                        if (body?.conflict) {
+                            toast?.addToast('Conflict: record was modified. Refresh and try again.', 'error');
+                            setShowRejectDialog(false);
+                            setRejectingCase(null);
+                            return;
+                        }
+                        throw new Error(body?.error || fnError.message || 'Reject failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    setCases(prev => prev.map(sc => sc.id === rejectingCase.id ? { ...sc, ...data.scotus_case } : sc));
+                    toast?.addToast('Rejected. Will be re-enriched on next agent run (weekdays 4PM UTC).', 'success');
+                    setShowRejectDialog(false);
+                    setRejectingCase(null);
+                    setRejectNote('');
+                } catch (err) {
+                    console.error('Reject error:', err);
+                    toast?.addToast(err.message || 'Failed to reject', 'error');
+                }
+            };
+
+            // Handle bulk publish
+            const handleBulkPublish = async () => {
+                if (selectedIds.size === 0) return;
+                if (!confirm(`Publish ${selectedIds.size} selected case(s)?`)) return;
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-update-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: {
+                                case_ids: [...selectedIds],
+                                updates: { is_public: true }
+                            }
+                        }
+                    );
+
+                    if (fnError) {
+                        let body = data;
+                        try { if (!body && fnError.context) body = await fnError.context.json(); } catch (_) {}
+                        throw new Error(body?.error || fnError.message || 'Bulk publish failed');
+                    }
+                    if (data?.error) throw new Error(data.error);
+
+                    const summary = data.summary || {};
+                    toast?.addToast(`Published ${summary.published_count || 0}, skipped ${summary.skipped_count || 0}`, 'success');
+
+                    // Update local rows for published IDs
+                    const publishedSet = new Set(data.published || []);
+                    setCases(prev => prev.map(c => publishedSet.has(c.id) ? { ...c, is_public: true, qa_status: 'approved' } : c));
+                    setSelectedIds(new Set());
+                } catch (err) {
+                    console.error('Bulk publish error:', err);
+                    toast?.addToast(err.message || 'Failed to bulk publish', 'error');
+                }
+            };
+
+            // Handle checkbox toggle
+            const toggleSelect = (id) => {
+                setSelectedIds(prev => {
+                    const next = new Set(prev);
+                    if (next.has(id)) next.delete(id);
+                    else next.add(id);
+                    return next;
+                });
+            };
+
+            // Handle master checkbox
+            const toggleSelectAll = () => {
+                if (selectedIds.size === cases.length) {
+                    setSelectedIds(new Set());
+                } else {
+                    setSelectedIds(new Set(cases.map(c => c.id)));
+                }
+            };
+
+            // Fetch run log (lazy)
+            const fetchRunLog = async () => {
+                setRunLogLoading(true);
+                try {
+                    const { data, error: fnError } = await supabase.functions.invoke(
+                        'admin-scotus',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: { action: 'run_log' }
+                        }
+                    );
+
+                    if (fnError) throw new Error(fnError.message || 'Failed to fetch run log');
+                    setRunLogData(data.enrichment_runs || []);
+                } catch (err) {
+                    console.error('Run log error:', err);
+                    toast?.addToast(err.message || 'Failed to fetch run log', 'error');
+                } finally {
+                    setRunLogLoading(false);
+                }
+            };
+
+            // Toggle run log
+            const handleToggleRunLog = () => {
+                if (!runLogExpanded) {
+                    setRunLogExpanded(true);
+                    if (!runLogData) fetchRunLog();
+                } else {
+                    setRunLogExpanded(false);
+                }
+            };
+
+            const isDraftsTab = isPublicFilter === 'false';
+
+            const subTabs = [
+                { value: '', label: 'All' },
+                { value: 'false', label: 'Drafts' },
+                { value: 'true', label: 'Published' },
+            ];
+
+            return (
+                <div>
+                    {/* Sub-tabs */}
+                    <div style={{ display: 'flex', gap: '4px', marginBottom: '16px' }}>
+                        {subTabs.map(tab => (
+                            <button
+                                key={tab.value}
+                                className={`tab-btn ${isPublicFilter === tab.value ? 'active' : ''}`}
+                                onClick={() => setIsPublicFilter(tab.value)}
+                            >
+                                {tab.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* Toolbar */}
+                    <div className="stories-toolbar">
+                        <input
+                            type="text"
+                            className="stories-search"
+                            placeholder="Search by case name or ID..."
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                        <select
+                            className="stories-select"
+                            value={termFilter}
+                            onChange={(e) => setTermFilter(e.target.value)}
+                        >
+                            <option value="">All Terms</option>
+                            {availableTerms.map(t =>
+                                <option key={t} value={t}>{t}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={enrichmentStatusFilter}
+                            onChange={(e) => setEnrichmentStatusFilter(e.target.value)}
+                        >
+                            <option value="">All Enrichment</option>
+                            {SCOTUS_ENRICHMENT_STATUSES.map(s =>
+                                <option key={s.value} value={s.value}>{s.label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={needsManualReviewFilter}
+                            onChange={(e) => setNeedsManualReviewFilter(e.target.value)}
+                        >
+                            <option value="">Manual Review: All</option>
+                            <option value="true">Needs Review</option>
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={qaStatusFilter}
+                            onChange={(e) => setQaStatusFilter(e.target.value)}
+                        >
+                            <option value="">All QA Status</option>
+                            {SCOTUS_QA_STATUSES.map(s =>
+                                <option key={s.value} value={s.value}>{s.label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={caseTypeFilter}
+                            onChange={(e) => setCaseTypeFilter(e.target.value)}
+                        >
+                            <option value="">All Case Types</option>
+                            {SCOTUS_CASE_TYPES.map(t =>
+                                <option key={t.value} value={t.value}>{t.label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={impactLevelFilter}
+                            onChange={(e) => setImpactLevelFilter(e.target.value)}
+                        >
+                            <option value="">All Impact Levels</option>
+                            {SCOTUS_IMPACT_LEVELS.map(l =>
+                                <option key={l.value} value={String(l.value)}>{l.value} - {l.label}</option>
+                            )}
+                        </select>
+                        <select
+                            className="stories-select"
+                            value={`${sortBy}-${sortDir}`}
+                            onChange={(e) => {
+                                const val = e.target.value;
+                                const lastDash = val.lastIndexOf('-');
+                                setSortBy(val.substring(0, lastDash));
+                                setSortDir(val.substring(lastDash + 1));
+                            }}
+                        >
+                            <option value="decided_at-desc">Decided (Newest)</option>
+                            <option value="decided_at-asc">Decided (Oldest)</option>
+                            <option value="ruling_impact_level-desc">Impact (High-Low)</option>
+                            <option value="ruling_impact_level-asc">Impact (Low-High)</option>
+                            <option value="id-desc">ID (Newest)</option>
+                            <option value="id-asc">ID (Oldest)</option>
+                        </select>
+                    </div>
+
+                    {/* Bulk publish bar */}
+                    {isDraftsTab && selectedIds.size > 0 && (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px', padding: '10px 16px', background: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}>
+                            <span style={{ fontSize: '14px', color: '#e2e8f0' }}>{selectedIds.size} selected</span>
+                            <button
+                                className="btn-primary"
+                                style={{ padding: '6px 16px', fontSize: '13px' }}
+                                onClick={handleBulkPublish}
+                                disabled={selectedIds.size > 50}
+                                title={selectedIds.size > 50 ? 'Max 50 per batch' : ''}
+                            >
+                                Publish Selected ({selectedIds.size})
+                            </button>
+                            <button
+                                className="btn-secondary"
+                                style={{ padding: '6px 12px', fontSize: '13px' }}
+                                onClick={() => setSelectedIds(new Set())}
+                            >
+                                Clear
+                            </button>
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className="error-banner">
+                            <strong>Error:</strong> {error}
+                        </div>
+                    )}
+
+                    {loading ? (
+                        <div className="loading">
+                            <div className="spinner"></div>
+                            Loading SCOTUS cases...
+                        </div>
+                    ) : (
+                        <div className="card">
+                            <div className="card-header">
+                                <h2 className="card-title">SCOTUS Cases</h2>
+                                <span className="stories-count">
+                                    Showing {cases.length} cases
+                                    {hasMore && ' (more available)'}
+                                </span>
+                            </div>
+                            <div style={{ overflowX: 'auto' }}>
+                                <table className="stories-table">
+                                    <thead>
+                                        <tr>
+                                            {isDraftsTab && <th><input type="checkbox" className="bulk-checkbox" checked={cases.length > 0 && selectedIds.size === cases.length} onChange={toggleSelectAll} /></th>}
+                                            <th>ID</th>
+                                            <th>Case</th>
+                                            <th>Decided</th>
+                                            <th>Impact</th>
+                                            <th>Vote</th>
+                                            <th>Status</th>
+                                            <th>Flags</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {cases.length === 0 && (
+                                            <tr>
+                                                <td colSpan={isDraftsTab ? 9 : 8} style={{ textAlign: 'center', padding: '40px', color: '#64748b' }}>
+                                                    No cases found matching your filters.
+                                                </td>
+                                            </tr>
+                                        )}
+                                        {cases.map(c => {
+                                            const impactBadge = getImpactBadge(c.ruling_impact_level);
+                                            const enrichBadge = getEnrichmentBadge(c.enrichment_status);
+
+                                            return (
+                                                <tr key={c.id} className={c.needs_manual_review ? 'scotus-needs-review' : ''}>
+                                                    {isDraftsTab && (
+                                                        <td>
+                                                            <input type="checkbox" className="bulk-checkbox" checked={selectedIds.has(c.id)} onChange={() => toggleSelect(c.id)} />
+                                                        </td>
+                                                    )}
+                                                    <td style={{ color: '#64748b', fontSize: '13px' }}>{c.id}</td>
+                                                    <td style={{ maxWidth: '250px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: '#e2e8f0' }} title={c.case_name}>
+                                                        {c.case_name || c.case_name_short || '(Unknown)'}
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {formatDate(c.decided_at)}
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${impactBadge.class}`}>{impactBadge.label}</span>
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {c.vote_split || '-'}
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${enrichBadge.class}`}>{enrichBadge.label}</span>
+                                                    </td>
+                                                    <td style={{ fontSize: '13px' }}>
+                                                        {c.needs_manual_review && <span style={{ color: '#fbbf24' }} title="Needs manual review">&#9888;</span>}
+                                                        {c.is_public && <span style={{ color: '#4ade80', marginLeft: '4px' }} title="Published">&#10003;</span>}
+                                                    </td>
+                                                    <td>
+                                                        <div className="row-actions">
+                                                            <button className="btn-icon" onClick={() => handleEdit(c)} title="Edit">
+                                                                &#9999;&#65039; Edit
+                                                            </button>
+                                                            <button
+                                                                className="btn-icon"
+                                                                onClick={() => handleReEnrich(c)}
+                                                                disabled={c.enrichment_status === 'pending'}
+                                                                title={c.enrichment_status === 'pending' ? 'Already pending' : 'Re-enrich'}
+                                                            >
+                                                                &#129302; Re-enrich
+                                                            </button>
+                                                            {c.is_public ? (
+                                                                <button className="btn-icon" onClick={() => handleUnpublish(c)} title="Unpublish">
+                                                                    &#128228; Unpublish
+                                                                </button>
+                                                            ) : (
+                                                                <button
+                                                                    className="btn-icon"
+                                                                    onClick={() => handlePublish(c)}
+                                                                    disabled={c.enrichment_status !== 'enriched'}
+                                                                    title={c.enrichment_status !== 'enriched' ? 'Must be enriched to publish' : 'Publish'}
+                                                                >
+                                                                    &#128229; Publish
+                                                                </button>
+                                                            )}
+                                                            <button className="btn-icon" onClick={() => { setRejectingCase(c); setShowRejectDialog(true); setRejectNote(''); }} title="Reject & Re-queue">
+                                                                &#128683; Reject
+                                                            </button>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                            {hasMore && (
+                                <div style={{ padding: '0 20px 20px' }}>
+                                    <button
+                                        className="load-more-btn"
+                                        onClick={handleLoadMore}
+                                        disabled={loadingMore}
+                                    >
+                                        {loadingMore ? 'Loading...' : 'Load More'}
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Reject Dialog */}
+                    {showRejectDialog && rejectingCase && (
+                        <div className="modal-overlay">
+                            <div style={{ background: '#1e293b', border: '1px solid #ef4444', borderRadius: '12px', padding: '24px', width: '100%', maxWidth: '480px' }}>
+                                <h3 style={{ margin: '0 0 12px', color: '#f8fafc', fontSize: '16px' }}>Reject & Re-queue: #{rejectingCase.id}</h3>
+                                <p style={{ color: '#94a3b8', fontSize: '13px', margin: '0 0 12px' }}>{rejectingCase.case_name}</p>
+                                <textarea
+                                    className="form-textarea"
+                                    placeholder="Reason for rejection (required)..."
+                                    value={rejectNote}
+                                    onChange={(e) => setRejectNote(e.target.value)}
+                                    rows={3}
+                                    autoFocus
+                                />
+                                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '12px' }}>
+                                    <button className="btn-secondary" onClick={() => { setShowRejectDialog(false); setRejectingCase(null); setRejectNote(''); }}>Cancel</button>
+                                    <button className="btn-primary" onClick={handleReject} disabled={!rejectNote.trim()} style={{ background: '#ef4444' }}>Reject & Re-queue</button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Agent Run Log */}
+                    <div className="card run-log-card">
+                        <div className="card-header" onClick={handleToggleRunLog}>
+                            <h2 className="card-title">
+                                <span>Agent Run Log</span>
+                                <span style={{ fontSize: '12px', color: '#64748b', marginLeft: '8px' }}>{runLogExpanded ? '▼' : '▶'}</span>
+                            </h2>
+                            {runLogExpanded && (
+                                <button
+                                    className="btn-icon"
+                                    onClick={(e) => { e.stopPropagation(); fetchRunLog(); }}
+                                    title="Refresh"
+                                    style={{ fontSize: '14px' }}
+                                >
+                                    ↻ Refresh
+                                </button>
+                            )}
+                        </div>
+                        {runLogExpanded && (
+                            <div style={{ overflowX: 'auto' }}>
+                                {runLogLoading ? (
+                                    <div className="loading" style={{ padding: '20px' }}>
+                                        <div className="spinner"></div>
+                                        Loading run log...
+                                    </div>
+                                ) : !runLogData || runLogData.length === 0 ? (
+                                    <div style={{ padding: '20px', textAlign: 'center', color: '#64748b' }}>No agent runs recorded yet.</div>
+                                ) : (
+                                    <table className="stories-table">
+                                        <thead>
+                                            <tr>
+                                                <th>ID</th>
+                                                <th>Date</th>
+                                                <th>Status</th>
+                                                <th>Model</th>
+                                                <th>Found</th>
+                                                <th>Enriched</th>
+                                                <th>Failed</th>
+                                                <th>Duration</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {runLogData.map(run => (
+                                                <tr key={run.id} style={run.status === 'failed' ? { background: 'rgba(239, 68, 68, 0.1)' } : {}}>
+                                                    <td style={{ color: '#64748b', fontSize: '13px' }}>{run.id}</td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px', whiteSpace: 'nowrap' }}>
+                                                        {run.ran_at ? new Date(run.ran_at).toLocaleString() : '-'}
+                                                    </td>
+                                                    <td>
+                                                        <span className={`badge ${run.status === 'completed' ? 'badge-active' : 'badge-failed'}`}>
+                                                            {run.status || '-'}
+                                                        </span>
+                                                    </td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px' }}>{run.agent_model || '-'}</td>
+                                                    <td style={{ color: '#e2e8f0', fontSize: '13px' }}>{run.cases_found ?? '-'}</td>
+                                                    <td style={{ color: '#4ade80', fontSize: '13px' }}>{run.cases_enriched ?? '-'}</td>
+                                                    <td style={{ color: run.cases_failed > 0 ? '#f87171' : '#64748b', fontSize: '13px' }}>{run.cases_failed ?? '-'}</td>
+                                                    <td style={{ color: '#94a3b8', fontSize: '13px' }}>
+                                                        {run.duration_seconds ? `${Math.round(run.duration_seconds)}s` : '-'}
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                )}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Edit SCOTUS Modal */}
+                    {editingCase && (
+                        <EditScotusModal
+                            scotusCase={editingCase}
+                            onClose={() => setEditingCase(null)}
+                            onSave={handleSaveEdit}
+                            onRefresh={() => fetchCases(false, null)}
                             supabase={supabase}
                             password={password}
                         />
@@ -3076,7 +4311,7 @@
                     supabase.from('articles').select('id', { count: 'exact', head: true }),
                     supabase.from('feed_registry').select('id,is_active,failure_count'),
                     supabase.from('pardons').select('id,is_public,needs_review'),
-                    supabase.from('scotus_cases').select('id,is_public'),
+                    supabase.from('scotus_cases').select('id,is_public,needs_manual_review'),
                     supabase.from('executive_orders').select('id', { count: 'exact', head: true }),
                     supabase.from('budgets').select('*').eq('day', today).single(),
                     supabase.from('feed_registry').select('last_fetched_at').not('last_fetched_at', 'is', null).order('last_fetched_at', { ascending: false }).limit(1).single()
@@ -3095,6 +4330,7 @@
                 // Process SCOTUS
                 const scotus = scotusData.data || [];
                 const scotusDraft = scotus.filter(s => !s.is_public).length;
+                const scotusNeedsReview = scotus.filter(s => s.needs_manual_review).length;
 
                 // Pipeline status
                 let pipelineStatus = 'unknown';
@@ -3168,13 +4404,14 @@
                         minutes_since_last_run: minutesSinceLastRun
                     },
                     needs_attention: {
-                        total: (storiesEnrichFailed.count ?? 0) + pardonsDraft + scotusDraft + feedsFailed + pardonsNeedsReview,
+                        total: (storiesEnrichFailed.count ?? 0) + pardonsDraft + scotusDraft + feedsFailed + pardonsNeedsReview + scotusNeedsReview,
                         breakdown: {
                             stories_need_review: 0,
                             stories_enrichment_failed: storiesEnrichFailed.count ?? 0,
                             pardons_need_review: pardonsNeedsReview,
                             pardons_unpublished: pardonsDraft,
                             scotus_unpublished: scotusDraft,
+                            scotus_needs_review: scotusNeedsReview,
                             feeds_failed: feedsFailed
                         }
                     },
@@ -3232,7 +4469,7 @@
                 { id: 'home', label: 'Home' },
                 { id: 'stories', label: 'Stories' },
                 { id: 'pardons', label: 'Pardons' },
-                { id: 'scotus', label: 'SCOTUS', disabled: true },
+                { id: 'scotus', label: 'SCOTUS' },
                 { id: 'eos', label: 'Exec Orders', disabled: true },
                 { id: 'feeds', label: 'Feeds', disabled: true }
             ];
@@ -3402,6 +4639,12 @@
                                                 {stats.needs_attention.breakdown.scotus_unpublished}
                                             </span>
                                         </div>
+                                        <div className="attention-item" title="SCOTUS cases needing manual review" onClick={() => setActiveTab('scotus')}>
+                                            <span>SCOTUS needs review</span>
+                                            <span className={`attention-count ${(stats.needs_attention?.breakdown?.scotus_needs_review ?? 0) === 0 ? 'zero' : ''}`}>
+                                                {stats.needs_attention?.breakdown?.scotus_needs_review ?? 0}
+                                            </span>
+                                        </div>
                                         <div className="attention-item" title="Feeds with 5+ consecutive failures">
                                             <span>Feeds failed</span>
                                             <span className={`attention-count ${stats.needs_attention.breakdown.feeds_failed === 0 ? 'zero' : ''}`}>
@@ -3522,7 +4765,11 @@
                             <PardonsTab password={password} supabase={supabase} />
                         )}
 
-                        {activeTab !== 'home' && activeTab !== 'stories' && activeTab !== 'pardons' && (
+                        {activeTab === 'scotus' && (
+                            <ScotusTab password={password} supabase={supabase} />
+                        )}
+
+                        {activeTab !== 'home' && activeTab !== 'stories' && activeTab !== 'pardons' && activeTab !== 'scotus' && (
                             <div className="card">
                                 <div className="card-body" style={{ textAlign: 'center', padding: '60px 20px' }}>
                                     <div style={{ fontSize: '48px', marginBottom: '16px' }}>🚧</div>

--- a/public/admin.html
+++ b/public/admin.html
@@ -2388,7 +2388,7 @@
             { value: 'dismissed', label: 'Dismissed' },
             { value: 'granted', label: 'Granted' },
             { value: 'denied', label: 'Denied' },
-            { value: 'GVR', label: 'GVR' },
+            { value: 'GVR', label: 'GVR (Grant, Vacate, Remand)' },
             { value: 'other', label: 'Other' },
         ];
 
@@ -2464,7 +2464,7 @@
             const [saving, setSaving] = useState(false);
             const [error, setError] = useState(null);
             const [isConflict, setIsConflict] = useState(false);
-            const [openSections, setOpenSections] = useState({ case_identity: true, vote_opinion: true, editorial: false, evidence: false, status_qa: false });
+            const [openSections, setOpenSections] = useState({ case_identity: true, vote_opinion: true, editorial: true, evidence: false, status_qa: false });
 
             const originalUpdatedAt = scotusCase?.updated_at;
 
@@ -2499,15 +2499,15 @@
                         if (newVal !== oldVal) updates[f] = newVal;
                     }
 
-                    // Enum fields
-                    for (const f of ['disposition', 'case_type', 'prevailing_party', 'qa_status', 'enrichment_status']) {
+                    // Enum fields (qa_status, enrichment_status excluded — managed by Publish/Reject/Re-enrich buttons)
+                    for (const f of ['disposition', 'case_type', 'prevailing_party']) {
                         const newVal = formData[f] || null;
                         const oldVal = scotusCase[f] || null;
                         if (newVal !== oldVal) updates[f] = newVal;
                     }
 
-                    // Boolean fields
-                    for (const f of ['is_public', 'needs_manual_review', 'merits_reached']) {
+                    // Boolean fields (is_public, needs_manual_review excluded — managed by buttons)
+                    for (const f of ['merits_reached']) {
                         if (formData[f] !== (scotusCase[f] ?? false)) updates[f] = formData[f];
                     }
 
@@ -2695,7 +2695,10 @@
                                 textField('dissent_authors', 'Dissent Authors (comma-separated)', { placeholder: 'e.g. Sotomayor, Kagan, Jackson', used: true }),
                                 h('div', { className: 'form-row' },
                                     selectField('prevailing_party', 'Prevailing Party', SCOTUS_PREVAILING_PARTIES, true),
-                                    boolField('merits_reached', 'Merits Reached', true)
+                                    h('div', { className: 'form-group', style: { display: 'flex', alignItems: 'center', gap: '8px' }, title: 'Did the court rule on the actual legal question, vs. dismissing on procedure?' },
+                                        h('input', { type: 'checkbox', checked: formData.merits_reached, onChange: (ev) => handleChange('merits_reached', ev.target.checked), style: { accentColor: '#3b82f6', width: '16px', height: '16px' } }),
+                                        h('label', { className: 'form-label', style: { marginBottom: 0 } }, 'Merits Reached ', h('span', { style: { color: '#64748b', fontSize: '12px' } }, '(hover for info)'))
+                                    )
                                 )
                             ),
 
@@ -2736,36 +2739,33 @@
                             sectionHeader('evidence', 'Evidence'),
                             openSections.evidence && h('div', null,
                                 h('div', { className: 'form-group' },
-                                    fieldLabel('Evidence Anchors (one per line)', true),
+                                    fieldLabel('Citations (one per line)', true),
                                     h('textarea', {
                                         className: 'form-textarea',
                                         value: formData.evidence_anchors,
                                         onChange: (ev) => handleChange('evidence_anchors', ev.target.value),
                                         rows: 5,
-                                        placeholder: 'One evidence anchor per line...'
+                                        placeholder: 'One citation per line...'
                                     })
                                 ),
-                                textareaField('holding', 'Holding', 3, true)
+                                textareaField('holding', "Court's Ruling", 3, true)
                             ),
 
-                            // Section 5: Status & QA (collapsed)
+                            // Section 5: Status & QA (collapsed) — fields are read-only; use Publish/Reject/Re-enrich buttons instead
                             sectionHeader('status_qa', 'Status & QA'),
                             openSections.status_qa && h('div', null,
-                                h('div', { style: { display: 'flex', gap: '24px', marginBottom: '16px' } },
-                                    boolField('is_public', 'Published', true),
-                                    boolField('needs_manual_review', 'Needs Manual Review')
+                                h('div', { className: 'form-row' },
+                                    readOnlyField('Published', scotusCase.is_public ? 'Yes' : 'No'),
+                                    readOnlyField('QA Status', SCOTUS_QA_STATUSES.find(s => s.value === scotusCase.qa_status)?.label || scotusCase.qa_status || '-')
                                 ),
                                 h('div', { className: 'form-row' },
-                                    selectField('qa_status', 'QA Status', SCOTUS_QA_STATUSES),
-                                    selectField('enrichment_status', 'Enrichment Status', SCOTUS_ENRICHMENT_STATUSES)
+                                    readOnlyField('Enrichment Status', SCOTUS_ENRICHMENT_STATUSES.find(s => s.value === scotusCase.enrichment_status)?.label || scotusCase.enrichment_status || '-'),
+                                    readOnlyField('Needs Manual Review', scotusCase.needs_manual_review ? 'Yes — AI inferred data that may need verification' : 'No')
                                 ),
-                                textareaField('qa_review_note', 'QA Review Note', 2),
-                                textareaField('manual_review_note', 'Manual Review Note', 2),
-                                readOnlyField('Low Confidence Reason', scotusCase.low_confidence_reason),
-                                h('div', { className: 'form-row' },
-                                    readOnlyField('Enriched At', scotusCase.enriched_at ? new Date(scotusCase.enriched_at).toLocaleString() : null),
-                                    readOnlyField('Prompt Version', scotusCase.prompt_version)
-                                )
+                                scotusCase.qa_review_note && readOnlyField('QA Review Note', scotusCase.qa_review_note),
+                                scotusCase.manual_review_note && readOnlyField('Manual Review Note', scotusCase.manual_review_note),
+                                scotusCase.low_confidence_reason && readOnlyField('Low Confidence Reason', scotusCase.low_confidence_reason),
+                                readOnlyField('Enriched At', scotusCase.enriched_at ? new Date(scotusCase.enriched_at).toLocaleString() : '-')
                             )
                         ),
                         h('div', { className: 'modal-footer' },
@@ -3586,19 +3586,7 @@
                     if (data?.error) throw new Error(data.error);
 
                     setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
-
-                    const changedFields = data.changed_fields || {};
-                    const firstField = Object.keys(changedFields)[0];
-                    if (firstField) {
-                        setUndoInfo({
-                            entityType: 'scotus',
-                            entityId: String(c.id),
-                            fieldName: firstField,
-                            oldValue: changedFields[firstField]?.old
-                        });
-                    } else {
-                        toast?.addToast('Published', 'success');
-                    }
+                    toast?.addToast('Published', 'success');
                 } catch (err) {
                     console.error('Publish error:', err);
                     toast?.addToast(err.message || 'Failed to publish', 'error');
@@ -3633,19 +3621,7 @@
                     if (data?.error) throw new Error(data.error);
 
                     setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
-
-                    const changedFields = data.changed_fields || {};
-                    const firstField = Object.keys(changedFields)[0];
-                    if (firstField) {
-                        setUndoInfo({
-                            entityType: 'scotus',
-                            entityId: String(c.id),
-                            fieldName: firstField,
-                            oldValue: changedFields[firstField]?.old
-                        });
-                    } else {
-                        toast?.addToast('Unpublished', 'success');
-                    }
+                    toast?.addToast('Unpublished', 'success');
                 } catch (err) {
                     console.error('Unpublish error:', err);
                     toast?.addToast(err.message || 'Failed to unpublish', 'error');
@@ -3990,17 +3966,19 @@
                                                             <button className="btn-icon" onClick={() => handleEdit(c)} title="Edit">
                                                                 &#9999;&#65039; Edit
                                                             </button>
-                                                            <button
-                                                                className={`btn-icon${enrichingIds.has(c.id) ? ' enriching' : ''}`}
-                                                                onClick={() => handleReEnrich(c)}
-                                                                disabled={c.enrichment_status === 'pending' || enrichingIds.has(c.id)}
-                                                                title={c.enrichment_status === 'pending' ? 'Already pending' : enrichingIds.has(c.id) ? 'Queuing...' : 'Re-enrich'}
-                                                            >
-                                                                {enrichingIds.has(c.id)
-                                                                    ? <><span className="spinner-sm"></span> Queuing</>
-                                                                    : '\uD83E\uDD16 Re-enrich'
-                                                                }
-                                                            </button>
+                                                            {!c.is_public && (
+                                                                <button
+                                                                    className={`btn-icon${enrichingIds.has(c.id) ? ' enriching' : ''}`}
+                                                                    onClick={() => handleReEnrich(c)}
+                                                                    disabled={c.enrichment_status === 'pending' || enrichingIds.has(c.id)}
+                                                                    title={c.enrichment_status === 'pending' ? 'Already pending' : enrichingIds.has(c.id) ? 'Queuing...' : 'Re-enrich'}
+                                                                >
+                                                                    {enrichingIds.has(c.id)
+                                                                        ? <><span className="spinner-sm"></span> Queuing</>
+                                                                        : '\uD83E\uDD16 Re-enrich'
+                                                                    }
+                                                                </button>
+                                                            )}
                                                             {c.is_public ? (
                                                                 <button className="btn-icon" onClick={() => handleUnpublish(c)} title="Unpublish">
                                                                     &#128228; Unpublish
@@ -4015,9 +3993,11 @@
                                                                     &#128229; Publish
                                                                 </button>
                                                             )}
-                                                            <button className="btn-icon" onClick={() => { setRejectingCase(c); setShowRejectDialog(true); setRejectNote(''); }} title="Reject & Re-queue">
-                                                                &#128683; Reject
-                                                            </button>
+                                                            {!c.is_public && (
+                                                                <button className="btn-icon" onClick={() => { setRejectingCase(c); setShowRejectDialog(true); setRejectNote(''); }} title="Reject & Re-queue">
+                                                                    &#128683; Reject
+                                                                </button>
+                                                            )}
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/public/admin.html
+++ b/public/admin.html
@@ -3360,6 +3360,7 @@
             // Actions
             const [editingCase, setEditingCase] = useState(null);
             const [undoInfo, setUndoInfo] = useState(null);
+            const [enrichingIds, setEnrichingIds] = useState(new Set());
             const [selectedIds, setSelectedIds] = useState(new Set());
             const [showRejectDialog, setShowRejectDialog] = useState(false);
             const [rejectingCase, setRejectingCase] = useState(null);
@@ -3419,7 +3420,11 @@
                     if (token !== fetchTokenRef.current) return;
 
                     if (loadMore) {
-                        setCases(prev => [...prev, ...(data.scotus_cases || [])]);
+                        setCases(prev => {
+                            const existingIds = new Set(prev.map(c => c.id));
+                            const newCases = (data.scotus_cases || []).filter(c => !existingIds.has(c.id));
+                            return [...prev, ...newCases];
+                        });
                     } else {
                         setCases(data.scotus_cases || []);
                     }
@@ -3518,6 +3523,8 @@
 
             // Handle re-enrich
             const handleReEnrich = async (c) => {
+                if (enrichingIds.has(c.id)) return;
+                setEnrichingIds(prev => new Set([...prev, c.id]));
                 try {
                     const { data, error: fnError } = await supabase.functions.invoke(
                         'admin-update-scotus',
@@ -3543,6 +3550,8 @@
                 } catch (err) {
                     console.error('Re-enrich error:', err);
                     toast?.addToast(err.message || 'Failed to re-enrich', 'error');
+                } finally {
+                    setEnrichingIds(prev => { const s = new Set(prev); s.delete(c.id); return s; });
                 }
             };
 
@@ -3978,12 +3987,15 @@
                                                                 &#9999;&#65039; Edit
                                                             </button>
                                                             <button
-                                                                className="btn-icon"
+                                                                className={`btn-icon${enrichingIds.has(c.id) ? ' enriching' : ''}`}
                                                                 onClick={() => handleReEnrich(c)}
-                                                                disabled={c.enrichment_status === 'pending'}
-                                                                title={c.enrichment_status === 'pending' ? 'Already pending' : 'Re-enrich'}
+                                                                disabled={c.enrichment_status === 'pending' || enrichingIds.has(c.id)}
+                                                                title={c.enrichment_status === 'pending' ? 'Already pending' : enrichingIds.has(c.id) ? 'Queuing...' : 'Re-enrich'}
                                                             >
-                                                                &#129302; Re-enrich
+                                                                {enrichingIds.has(c.id)
+                                                                    ? <><span className="spinner-sm"></span> Queuing</>
+                                                                    : '\uD83E\uDD16 Re-enrich'
+                                                                }
                                                             </button>
                                                             {c.is_public ? (
                                                                 <button className="btn-icon" onClick={() => handleUnpublish(c)} title="Unpublish">

--- a/public/admin.html
+++ b/public/admin.html
@@ -3977,19 +3977,17 @@
                                                             <button className="btn-icon" onClick={() => handleEdit(c)} title="Edit">
                                                                 &#9999;&#65039; Edit
                                                             </button>
-                                                            {!c.is_public && (
-                                                                <button
-                                                                    className={`btn-icon${enrichingIds.has(c.id) ? ' enriching' : ''}`}
-                                                                    onClick={() => handleReEnrich(c)}
-                                                                    disabled={c.enrichment_status === 'pending' || enrichingIds.has(c.id)}
-                                                                    title={c.enrichment_status === 'pending' ? 'Already pending' : enrichingIds.has(c.id) ? 'Queuing...' : 'Re-enrich'}
-                                                                >
-                                                                    {enrichingIds.has(c.id)
-                                                                        ? <><span className="spinner-sm"></span> Queuing</>
-                                                                        : '\uD83E\uDD16 Re-enrich'
-                                                                    }
-                                                                </button>
-                                                            )}
+                                                            <button
+                                                                className={`btn-icon${enrichingIds.has(c.id) ? ' enriching' : ''}`}
+                                                                onClick={() => handleReEnrich(c)}
+                                                                disabled={c.enrichment_status === 'pending' || enrichingIds.has(c.id)}
+                                                                title={c.enrichment_status === 'pending' ? 'Already pending' : enrichingIds.has(c.id) ? 'Queuing...' : 'Re-enrich'}
+                                                            >
+                                                                {enrichingIds.has(c.id)
+                                                                    ? <><span className="spinner-sm"></span> Queuing</>
+                                                                    : '\uD83E\uDD16 Re-enrich'
+                                                                }
+                                                            </button>
                                                             {c.is_public ? (
                                                                 <button className="btn-icon" onClick={() => handleUnpublish(c)} title="Unpublish">
                                                                     &#128228; Unpublish

--- a/public/admin.html
+++ b/public/admin.html
@@ -3545,7 +3545,11 @@
                     }
                     if (data?.error) throw new Error(data.error);
 
-                    setCases(prev => prev.map(sc => sc.id === c.id ? { ...sc, ...data.scotus_case } : sc));
+                    setCases(prev => prev.map(sc =>
+                        sc.id === c.id
+                            ? { ...sc, ...(data?.scotus_case ?? { enrichment_status: 'pending' }) }
+                            : sc
+                    ));
                     toast?.addToast('Queued for re-enrichment. Will be enriched on next agent run (weekdays 4PM UTC).', 'success');
                 } catch (err) {
                     console.error('Re-enrich error:', err);

--- a/supabase/functions/admin-scotus/index.ts
+++ b/supabase/functions/admin-scotus/index.ts
@@ -18,7 +18,7 @@ const SORT_MAP: Record<string, string> = {
 // Cursor validation patterns per sort column type
 const CURSOR_VALIDATORS: Record<string, RegExp> = {
   id: /^\d+$/,
-  decided_at: /^\d{4}-\d{2}-\d{2}$/,
+  decided_at: /^\d{4}-\d{2}-\d{2}(T[\d:.+Z-]{1,25})?$/,
   ruling_impact_level: /^[0-5]$/,
   case_name_short: /^[\w .'\-]+$/,
 }
@@ -240,11 +240,7 @@ Deno.serve(async (req) => {
       if (sortCol === 'id') {
         nextCursor = String(last.id)
       } else {
-        let sortValue = String(last[sortCol] ?? '')
-        // Trim timestamps to date-only to match CURSOR_VALIDATORS pattern
-        if (sortCol === 'decided_at' && sortValue.includes('T')) {
-          sortValue = sortValue.substring(0, 10)
-        }
+        const sortValue = String(last[sortCol] ?? '')
         nextCursor = `${sortValue}::${last.id}`
       }
     }

--- a/supabase/functions/admin-scotus/index.ts
+++ b/supabase/functions/admin-scotus/index.ts
@@ -1,0 +1,255 @@
+// Edge Function: admin-scotus
+// Returns paginated SCOTUS cases list with search/filter for Admin Dashboard
+// Also supports action: 'run_log' for enrichment agent run history
+// ADO: Story 340
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Sort column whitelist — never interpolate raw input
+const SORT_MAP: Record<string, string> = {
+  id: 'id',
+  decided_at: 'decided_at',
+  ruling_impact_level: 'ruling_impact_level',
+  case_name: 'case_name_short',
+}
+
+// Cursor validation patterns per sort column type
+const CURSOR_VALIDATORS: Record<string, RegExp> = {
+  id: /^\d+$/,
+  decided_at: /^\d{4}-\d{2}-\d{2}$/,
+  ruling_impact_level: /^[0-5]$/,
+  case_name_short: /^[\w .'\-]+$/,
+}
+
+// Filter value whitelists
+const VALID_ENRICHMENT_STATUSES = ['pending', 'enriched', 'flagged', 'failed']
+const VALID_QA_STATUSES = ['pending_qa', 'approved', 'flagged', 'rejected', 'human_override']
+const VALID_CASE_TYPES = ['merits', 'procedural', 'shadow_docket', 'cert_stage', 'unclear']
+
+const SELECT_FIELDS = `
+  id, case_name, case_name_short, case_name_full, docket_number, term, decided_at, argued_at, citation,
+  vote_split, majority_author, dissent_authors, dissent_exists,
+  disposition, case_type, merits_reached, is_merits_decision, prevailing_party, issue_area, holding,
+  ruling_impact_level, ruling_label, summary_spicy, who_wins, who_loses,
+  why_it_matters, dissent_highlights, practical_effect, media_says, actually_means,
+  evidence_anchors, substantive_winner,
+  fact_extraction_confidence, low_confidence_reason, needs_manual_review,
+  enrichment_status, is_public, qa_status, qa_verdict, qa_review_note, qa_reviewed_at,
+  manual_reviewed_at, manual_review_note,
+  enriched_at, prompt_version, source_data_version, created_at, updated_at
+`
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+  })
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return jsonResponse({ error: 'Unauthorized' }, 401)
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405)
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Parse params from POST body
+    let body: Record<string, unknown> = {}
+    try {
+      body = await req.json()
+    } catch {
+      // Empty body defaults to no filters
+    }
+
+    const action = String(body.action ?? 'list')
+
+    // --- Run Log Mode ---
+    if (action === 'run_log') {
+      const { data: runs, error: runError } = await supabase
+        .from('scotus_enrichment_log')
+        .select('id, ran_at, completed_at, status, agent_model, prompt_version, cases_found, cases_enriched, cases_failed, cases_skipped, duration_seconds, run_source, errors')
+        .order('ran_at', { ascending: false })
+        .limit(10)
+
+      if (runError) {
+        console.error('Run log query error:', runError)
+        return jsonResponse({ error: 'Failed to fetch enrichment runs' }, 500)
+      }
+
+      return jsonResponse({ enrichment_runs: runs || [] }, 200)
+    }
+
+    // --- List Mode (default) ---
+    const search = String(body.search ?? '').trim()
+    const isPublic = String(body.isPublic ?? '')
+    const term = String(body.term ?? '')
+    const enrichmentStatus = String(body.enrichmentStatus ?? '')
+    const needsManualReview = String(body.needsManualReview ?? '')
+    const qaStatus = String(body.qaStatus ?? '')
+    const caseType = String(body.caseType ?? '')
+    const impactLevel = String(body.impactLevel ?? '')
+    const sortBy = String(body.sortBy ?? 'decided_at')
+    const sortDir = String(body.sortDir ?? 'desc')
+    const cursor = String(body.cursor ?? '')
+
+    const limitParam = parseInt(String(body.limit ?? '25'), 10)
+    const limit = Math.min(Math.max(isNaN(limitParam) ? 25 : limitParam, 1), 100)
+
+    // --- Fetch available terms (lightweight metadata) ---
+    const { data: termsData } = await supabase
+      .from('scotus_cases')
+      .select('term')
+      .neq('enrichment_status', 'flagged')
+      .not('term', 'is', null)
+      .order('term', { ascending: false })
+
+    const availableTerms = [...new Set((termsData || []).map((t: { term: string }) => t.term).filter(Boolean))]
+
+    // --- Build main query ---
+    let query = supabase
+      .from('scotus_cases')
+      .select(SELECT_FIELDS)
+
+    // Sorting — only whitelisted columns
+    const sortCol = SORT_MAP[sortBy] ?? 'decided_at'
+    const ascending = sortDir === 'asc'
+    query = query.order(sortCol, { ascending, nullsFirst: false })
+
+    // Deterministic tiebreaker: secondary sort on id in same direction
+    if (sortCol !== 'id') {
+      query = query.order('id', { ascending })
+    }
+
+    // Exclude null sort values when sorting by text column (prevents cursor issues)
+    if (sortCol === 'case_name_short') {
+      query = query.not('case_name_short', 'is', null)
+    }
+
+    // --- Keyset cursor pagination ---
+    const op = ascending ? 'gt' : 'lt'
+
+    if (cursor) {
+      if (sortCol === 'id') {
+        if (/^\d+$/.test(cursor)) {
+          query = query[op]('id', cursor)
+        }
+        // else: malformed → ignore (returns first page)
+      } else {
+        const sepIdx = cursor.lastIndexOf('::')
+        if (sepIdx > 0) {
+          const cursorSortValue = cursor.substring(0, sepIdx)
+          const cursorId = cursor.substring(sepIdx + 2)
+          const sortValidator = CURSOR_VALIDATORS[sortCol]
+          if (/^\d+$/.test(cursorId) && sortValidator?.test(cursorSortValue)) {
+            query = query.or(
+              `${sortCol}.${op}.${cursorSortValue},and(${sortCol}.eq.${cursorSortValue},id.${op}.${cursorId})`
+            )
+          }
+          // else: malformed → ignore
+        }
+        // else: malformed → ignore
+      }
+    }
+
+    // Fetch limit + 1 for has_more detection
+    query = query.limit(limit + 1)
+
+    // --- Filters ---
+
+    // isPublic (sub-tab)
+    if (isPublic === 'true') {
+      query = query.eq('is_public', true)
+    } else if (isPublic === 'false') {
+      query = query.eq('is_public', false)
+    }
+
+    // term — validated against available terms
+    if (term && availableTerms.includes(term)) {
+      query = query.eq('term', term)
+    }
+
+    // enrichmentStatus
+    if (enrichmentStatus && VALID_ENRICHMENT_STATUSES.includes(enrichmentStatus)) {
+      query = query.eq('enrichment_status', enrichmentStatus)
+    }
+
+    // needsManualReview
+    if (needsManualReview === 'true') {
+      query = query.eq('needs_manual_review', true)
+    }
+
+    // qaStatus
+    if (qaStatus && VALID_QA_STATUSES.includes(qaStatus)) {
+      query = query.eq('qa_status', qaStatus)
+    }
+
+    // caseType
+    if (caseType && VALID_CASE_TYPES.includes(caseType)) {
+      query = query.eq('case_type', caseType)
+    }
+
+    // impactLevel (0-5)
+    const impactLevelNum = parseInt(impactLevel, 10)
+    if (!isNaN(impactLevelNum) && impactLevelNum >= 0 && impactLevelNum <= 5) {
+      query = query.eq('ruling_impact_level', impactLevelNum)
+    }
+
+    // Search — split numeric and text paths
+    if (search.length > 0) {
+      if (/^\d+$/.test(search) && search.length <= 10) {
+        // Numeric-only input → search by ID exclusively
+        query = query.eq('id', parseInt(search, 10))
+      } else {
+        // Text input → search by case_name only (never passed to id.eq)
+        const escaped = search.replace(/[%_\\]/g, '\\$&')
+        query = query.ilike('case_name_short', `%${escaped}%`)
+      }
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error('Query error:', error)
+      return jsonResponse({ error: 'Failed to fetch SCOTUS cases' }, 500)
+    }
+
+    // has_more detection: if we got limit+1 rows, there are more
+    const hasMore = (data || []).length > limit
+    const cases = hasMore ? (data || []).slice(0, limit) : (data || [])
+
+    // Next cursor generation
+    let nextCursor: string | null = null
+    if (hasMore && cases.length > 0) {
+      const last = cases[cases.length - 1] as Record<string, unknown>
+      nextCursor = sortCol === 'id'
+        ? String(last.id)
+        : `${last[sortCol]}::${last.id}`
+    }
+
+    return jsonResponse({
+      scotus_cases: cases,
+      pagination: { next_cursor: nextCursor, has_more: hasMore },
+      available_terms: availableTerms
+    }, 200)
+
+  } catch (error) {
+    console.error('Error in admin-scotus:', error)
+    return jsonResponse({ error: 'Internal server error' }, 500)
+  }
+})

--- a/supabase/functions/admin-scotus/index.ts
+++ b/supabase/functions/admin-scotus/index.ts
@@ -237,9 +237,16 @@ Deno.serve(async (req) => {
     let nextCursor: string | null = null
     if (hasMore && cases.length > 0) {
       const last = cases[cases.length - 1] as Record<string, unknown>
-      nextCursor = sortCol === 'id'
-        ? String(last.id)
-        : `${last[sortCol]}::${last.id}`
+      if (sortCol === 'id') {
+        nextCursor = String(last.id)
+      } else {
+        let sortValue = String(last[sortCol] ?? '')
+        // Trim timestamps to date-only to match CURSOR_VALIDATORS pattern
+        if (sortCol === 'decided_at' && sortValue.includes('T')) {
+          sortValue = sortValue.substring(0, 10)
+        }
+        nextCursor = `${sortValue}::${last.id}`
+      }
     }
 
     return jsonResponse({

--- a/supabase/functions/admin-stats/index.ts
+++ b/supabase/functions/admin-stats/index.ts
@@ -96,7 +96,7 @@ Deno.serve(async (req) => {
       // SCOTUS: all stats
       supabase
         .from('scotus_cases')
-        .select('id,is_public'),
+        .select('id,is_public,needs_manual_review,enrichment_status'),
 
       // Executive Orders: total
       supabase
@@ -139,6 +139,8 @@ Deno.serve(async (req) => {
     const scotusTotal = scotus.length
     const scotusPublished = scotus.filter(s => s.is_public).length
     const scotusDraft = scotus.filter(s => !s.is_public).length
+    const scotusNeedsReview = scotus.filter(s => s.needs_manual_review).length
+    const scotusPending = scotus.filter(s => s.enrichment_status === 'pending').length
 
     // Determine pipeline status
     const lastFetchedAt = lastFeedFetchResult.data?.last_fetched_at
@@ -195,7 +197,9 @@ Deno.serve(async (req) => {
       scotus: {
         total: scotusTotal,
         published: scotusPublished,
-        draft: scotusDraft
+        draft: scotusDraft,
+        needs_review: scotusNeedsReview,
+        pending: scotusPending
       },
       executive_orders: {
         total: eosResult.count ?? 0
@@ -227,6 +231,7 @@ Deno.serve(async (req) => {
                pardonsNeedsReview +
                pardonsDraft +
                scotusDraft +
+               scotusNeedsReview +
                feedsFailed,
         breakdown: {
           stories_need_review: storiesNeedsReviewCount,
@@ -234,6 +239,7 @@ Deno.serve(async (req) => {
           pardons_need_review: pardonsNeedsReview,
           pardons_unpublished: pardonsDraft,
           scotus_unpublished: scotusDraft,
+          scotus_needs_review: scotusNeedsReview,
           feeds_failed: feedsFailed
         }
       },

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -260,10 +260,11 @@ Deno.serve(async (req) => {
 
     // Step 3: Apply coupled workflows
 
-    // Publish: is_public false→true → also set qa_status, qa_reviewed_at
+    // Publish: is_public false→true → also set qa_status, qa_reviewed_at, clear needs_manual_review
     if (sanitizedUpdates.is_public === true && !currentCase.is_public) {
       sanitizedUpdates.qa_status = 'approved'
       sanitizedUpdates.qa_reviewed_at = new Date().toISOString()
+      sanitizedUpdates.needs_manual_review = false
     }
 
     // Unpublish: is_public true→false → reset qa_status, clear qa_reviewed_at
@@ -425,6 +426,7 @@ async function handleBulkPublish(caseIds: unknown[], req: Request): Promise<Resp
         is_public: true,
         qa_status: 'approved',
         qa_reviewed_at: now,
+        needs_manual_review: false,
       })
       .eq('id', id)
       .eq('updated_at', currentCase.updated_at)

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -9,6 +9,8 @@ import { checkAdminPassword } from '../_shared/auth.ts'
 
 // Allowed fields that can be updated (whitelist for security) — 28 fields
 const ALLOWED_FIELDS = [
+  // Case Identity (4)
+  'case_name', 'docket_number', 'term', 'decided_at',
   // Vote (3)
   'vote_split', 'majority_author', 'dissent_authors',
   // Classification (6)

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -275,7 +275,17 @@ Deno.serve(async (req) => {
       sanitizedUpdates.qa_reviewed_at = null
     }
 
-    // Reject: qa_status→'rejected' → reset enrichment for re-queue
+    // Re-enrich: enrichment_status→'pending' → also unpublish and reset QA
+    if (sanitizedUpdates.enrichment_status === 'pending' && currentCase.enrichment_status !== 'pending') {
+      sanitizedUpdates.enriched_at = null
+      if (currentCase.is_public) {
+        sanitizedUpdates.is_public = false
+        sanitizedUpdates.qa_status = 'pending_qa'
+        sanitizedUpdates.qa_reviewed_at = null
+      }
+    }
+
+    // Reject (legacy — kept for API compat but no longer used by frontend)
     if (sanitizedUpdates.qa_status === 'rejected') {
       if (!sanitizedUpdates.qa_review_note) {
         return jsonResponse({ error: 'qa_review_note is required when rejecting a case' }, 400)

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -1,0 +1,475 @@
+// Edge Function: admin-update-scotus
+// Updates SCOTUS case fields with admin authentication, optimistic locking, and audit logging
+// Supports single updates, publish/unpublish, reject, and bulk publish
+// ADO: Story 340
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+// Allowed fields that can be updated (whitelist for security) — 28 fields
+const ALLOWED_FIELDS = [
+  // Vote (3)
+  'vote_split', 'majority_author', 'dissent_authors',
+  // Classification (6)
+  'disposition', 'case_type', 'merits_reached', 'prevailing_party', 'issue_area', 'holding',
+  // Editorial (11)
+  'ruling_impact_level', 'ruling_label', 'summary_spicy', 'who_wins', 'who_loses',
+  'why_it_matters', 'dissent_highlights', 'practical_effect', 'media_says', 'actually_means',
+  'evidence_anchors',
+  // Review (3)
+  'needs_manual_review', 'manual_review_note', 'low_confidence_reason',
+  // Status/QA (5)
+  'is_public', 'qa_status', 'qa_review_note', 'enrichment_status', 'enriched_at',
+]
+
+// Valid enum values (mirrored from DB CHECK constraints)
+const VALID_DISPOSITIONS = [
+  'affirmed', 'reversed', 'vacated', 'remanded',
+  'reversed_and_remanded', 'vacated_and_remanded', 'affirmed_and_remanded',
+  'dismissed', 'granted', 'denied', 'GVR', 'other',
+]
+const VALID_CASE_TYPES = ['merits', 'procedural', 'shadow_docket', 'cert_stage', 'unclear']
+const VALID_PREVAILING_PARTIES = ['petitioner', 'respondent', 'partial', 'unclear']
+const VALID_QA_STATUSES = ['pending_qa', 'approved', 'flagged', 'rejected', 'human_override']
+const VALID_ENRICHMENT_STATUSES = ['pending', 'enriched', 'flagged', 'failed']
+
+const VOTE_SPLIT_RE = /^\d+-\d+$/
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+  })
+}
+
+// Validate and sanitize a single updates object. Returns error string or null.
+function validateUpdates(sanitized: Record<string, unknown>): string | null {
+  // Enum: disposition
+  if ('disposition' in sanitized) {
+    const v = sanitized.disposition
+    if (v !== null && !VALID_DISPOSITIONS.includes(v as string)) {
+      return `Invalid disposition. Must be one of: ${VALID_DISPOSITIONS.join(', ')}`
+    }
+  }
+
+  // Enum: case_type
+  if ('case_type' in sanitized) {
+    const v = sanitized.case_type
+    if (v !== null && !VALID_CASE_TYPES.includes(v as string)) {
+      return `Invalid case_type. Must be one of: ${VALID_CASE_TYPES.join(', ')}`
+    }
+  }
+
+  // Enum: prevailing_party
+  if ('prevailing_party' in sanitized) {
+    const v = sanitized.prevailing_party
+    if (v !== null && !VALID_PREVAILING_PARTIES.includes(v as string)) {
+      return `Invalid prevailing_party. Must be one of: ${VALID_PREVAILING_PARTIES.join(', ')}`
+    }
+  }
+
+  // Enum: qa_status
+  if ('qa_status' in sanitized) {
+    const v = sanitized.qa_status
+    if (v !== null && !VALID_QA_STATUSES.includes(v as string)) {
+      return `Invalid qa_status. Must be one of: ${VALID_QA_STATUSES.join(', ')}`
+    }
+  }
+
+  // Enum: enrichment_status
+  if ('enrichment_status' in sanitized) {
+    const v = sanitized.enrichment_status
+    if (v !== null && !VALID_ENRICHMENT_STATUSES.includes(v as string)) {
+      return `Invalid enrichment_status. Must be one of: ${VALID_ENRICHMENT_STATUSES.join(', ')}`
+    }
+  }
+
+  // Integer 0-5: ruling_impact_level
+  if ('ruling_impact_level' in sanitized) {
+    const v = sanitized.ruling_impact_level
+    if (v !== null) {
+      const level = parseInt(String(v), 10)
+      if (isNaN(level) || level < 0 || level > 5) {
+        return 'ruling_impact_level must be an integer between 0 and 5'
+      }
+      sanitized.ruling_impact_level = level
+    }
+  }
+
+  // Text pattern: vote_split
+  if ('vote_split' in sanitized) {
+    const v = sanitized.vote_split
+    if (v !== null && v !== '') {
+      if (typeof v !== 'string' || !VOTE_SPLIT_RE.test(v)) {
+        return 'vote_split must match pattern "N-N" (e.g., "6-3") or be null'
+      }
+    } else {
+      sanitized.vote_split = null
+    }
+  }
+
+  // Booleans: merits_reached, needs_manual_review, is_public
+  for (const field of ['merits_reached', 'needs_manual_review', 'is_public']) {
+    if (field in sanitized) {
+      if (typeof sanitized[field] !== 'boolean') {
+        return `${field} must be a boolean`
+      }
+    }
+  }
+
+  // Text arrays: dissent_authors, evidence_anchors
+  for (const field of ['dissent_authors', 'evidence_anchors']) {
+    if (field in sanitized) {
+      const v = sanitized[field]
+      if (v !== null) {
+        if (!Array.isArray(v)) {
+          return `${field} must be an array of strings`
+        }
+        const cleaned = (v as unknown[])
+          .filter(item => typeof item === 'string' && item.trim().length > 0)
+          .map(item => (item as string).trim())
+        sanitized[field] = cleaned
+      }
+    }
+  }
+
+  // Timestamp: enriched_at
+  if ('enriched_at' in sanitized) {
+    const v = sanitized.enriched_at
+    if (v !== null && v !== '') {
+      if (typeof v !== 'string' || !ISO_DATETIME_RE.test(v)) {
+        return 'enriched_at must be an ISO 8601 timestamp or null'
+      }
+    } else {
+      sanitized.enriched_at = null
+    }
+  }
+
+  // Text fields: allow null or string (no extra validation needed)
+  const textFields = [
+    'majority_author', 'issue_area', 'holding',
+    'ruling_label', 'summary_spicy', 'who_wins', 'who_loses',
+    'why_it_matters', 'dissent_highlights', 'practical_effect',
+    'media_says', 'actually_means', 'manual_review_note',
+    'low_confidence_reason', 'qa_review_note',
+  ]
+  for (const field of textFields) {
+    if (field in sanitized) {
+      const v = sanitized[field]
+      if (v !== null && typeof v !== 'string') {
+        return `${field} must be a string or null`
+      }
+    }
+  }
+
+  return null
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authentication check
+    if (!checkAdminPassword(req)) {
+      return jsonResponse({ error: 'Unauthorized' }, 401)
+    }
+
+    // Only accept POST
+    if (req.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405)
+    }
+
+    // Parse request body
+    const body = await req.json()
+    const { case_id, case_ids, updates, original_updated_at } = body
+
+    // --- Bulk Update Path ---
+    if (Array.isArray(case_ids)) {
+      return await handleBulkPublish(case_ids, req)
+    }
+
+    // --- Single Update Path ---
+    if (!case_id) {
+      return jsonResponse({ error: 'Missing required field: case_id or case_ids' }, 400)
+    }
+
+    const caseId = parseInt(String(case_id), 10)
+    if (isNaN(caseId) || caseId <= 0) {
+      return jsonResponse({ error: 'case_id must be a positive integer' }, 400)
+    }
+
+    // Validate updates object
+    if (!updates || typeof updates !== 'object' || Object.keys(updates).length === 0) {
+      return jsonResponse({ error: 'No updates provided' }, 400)
+    }
+
+    // Filter to only allowed fields
+    const sanitizedUpdates: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(updates)) {
+      if (ALLOWED_FIELDS.includes(key)) {
+        sanitizedUpdates[key] = value
+      }
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      return jsonResponse({ error: 'No valid fields to update' }, 400)
+    }
+
+    // Type-specific validation
+    const validationError = validateUpdates(sanitizedUpdates)
+    if (validationError) {
+      return jsonResponse({ error: validationError }, 400)
+    }
+
+    // --- Database operations ---
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Step 1: Fetch current row for old values
+    const { data: currentCase, error: fetchError } = await supabase
+      .from('scotus_cases')
+      .select([...ALLOWED_FIELDS, 'updated_at', 'enrichment_status', 'is_public', 'qa_status'].join(','))
+      .eq('id', caseId)
+      .single()
+
+    if (fetchError || !currentCase) {
+      console.error('Fetch error:', fetchError)
+      return jsonResponse({ error: 'SCOTUS case not found' }, 404)
+    }
+
+    // Step 2: Publish gate — enforce enrichment_status = 'enriched' before publishing
+    if (sanitizedUpdates.is_public === true && !currentCase.is_public) {
+      // Block setting enrichment_status and is_public in the same request (bypass attempt)
+      if ('enrichment_status' in sanitizedUpdates) {
+        return jsonResponse({
+          error: 'Cannot set enrichment_status and is_public in the same request'
+        }, 400)
+      }
+      if (currentCase.enrichment_status !== 'enriched') {
+        return jsonResponse({
+          error: `Cannot publish: case has enrichment_status '${currentCase.enrichment_status}', must be 'enriched'`
+        }, 400)
+      }
+    }
+
+    // Step 3: Apply coupled workflows
+
+    // Publish: is_public false→true → also set qa_status, qa_reviewed_at
+    if (sanitizedUpdates.is_public === true && !currentCase.is_public) {
+      sanitizedUpdates.qa_status = 'approved'
+      sanitizedUpdates.qa_reviewed_at = new Date().toISOString()
+    }
+
+    // Unpublish: is_public true→false → reset qa_status, clear qa_reviewed_at
+    if (sanitizedUpdates.is_public === false && currentCase.is_public) {
+      sanitizedUpdates.qa_status = 'pending_qa'
+      sanitizedUpdates.qa_reviewed_at = null
+    }
+
+    // Reject: qa_status→'rejected' → reset enrichment for re-queue
+    if (sanitizedUpdates.qa_status === 'rejected') {
+      if (!sanitizedUpdates.qa_review_note) {
+        return jsonResponse({ error: 'qa_review_note is required when rejecting a case' }, 400)
+      }
+      sanitizedUpdates.enrichment_status = 'pending'
+      sanitizedUpdates.enriched_at = null
+    }
+
+    // Step 4: Guarded UPDATE — atomic lock at DB level
+    let query = supabase
+      .from('scotus_cases')
+      .update(sanitizedUpdates)
+      .eq('id', caseId)
+
+    // Apply optimistic locking if original_updated_at provided
+    if (original_updated_at) {
+      query = query.eq('updated_at', original_updated_at)
+    }
+
+    const { data, error } = await query.select().single()
+
+    if (error) {
+      console.error('Update error:', error)
+      if (error.code === 'PGRST116') {
+        // 0 rows matched — either not found or concurrent edit
+        if (original_updated_at) {
+          const { data: current } = await supabase
+            .from('scotus_cases')
+            .select('updated_at')
+            .eq('id', caseId)
+            .single()
+
+          return jsonResponse({
+            error: 'This record was modified by another process while you were editing. Please refresh and try again.',
+            conflict: true,
+            current_updated_at: current?.updated_at
+          }, 409)
+        }
+        return jsonResponse({ error: 'SCOTUS case not found' }, 404)
+      }
+      throw new Error(`Failed to update SCOTUS case: ${error.message}`)
+    }
+
+    // Step 5: Log diffs (only fields that actually changed)
+    const changedFields: Record<string, { old: string | null; new: string | null }> = {}
+    for (const [field, newValue] of Object.entries(sanitizedUpdates)) {
+      const oldValue = currentCase[field]
+      const oldStr = oldValue != null ? String(typeof oldValue === 'object' ? JSON.stringify(oldValue) : oldValue) : null
+      const newStr = newValue != null ? String(typeof newValue === 'object' ? JSON.stringify(newValue) : newValue) : null
+
+      if (oldStr !== newStr) {
+        changedFields[field] = { old: oldStr, new: newStr }
+
+        try {
+          await supabase.rpc('log_content_change', {
+            p_entity_type: 'scotus',
+            p_entity_id: String(caseId),
+            p_field_name: field,
+            p_old_value: oldStr,
+            p_new_value: newStr,
+            p_changed_by: 'admin',
+            p_change_source: 'admin'
+          })
+        } catch (historyError) {
+          console.error(`Failed to log history for field ${field}:`, historyError)
+        }
+      }
+    }
+
+    console.log(`admin_action: update_scotus case_id=${caseId} fields=${Object.keys(sanitizedUpdates).join(',')}`)
+
+    return jsonResponse({
+      success: true,
+      scotus_case: data,
+      changed_fields: changedFields
+    }, 200)
+
+  } catch (error) {
+    console.error('Error in admin-update-scotus:', error)
+    return jsonResponse({ error: (error as Error).message || 'Internal server error' }, 500)
+  }
+})
+
+// --- Bulk Publish Handler ---
+async function handleBulkPublish(caseIds: unknown[], req: Request): Promise<Response> {
+  // Validate case_ids
+  if (!Array.isArray(caseIds) || caseIds.length === 0) {
+    return jsonResponse({ error: 'case_ids must be a non-empty array' }, 400)
+  }
+
+  if (caseIds.length > 50) {
+    return jsonResponse({ error: 'Bulk publish limited to 50 cases per request' }, 400)
+  }
+
+  // Parse and validate all IDs
+  const ids: number[] = []
+  for (const id of caseIds) {
+    const parsed = parseInt(String(id), 10)
+    if (isNaN(parsed) || parsed <= 0) {
+      return jsonResponse({ error: `Invalid case_id in array: ${id}` }, 400)
+    }
+    ids.push(parsed)
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+  const published: number[] = []
+  const skipped: { id: number; reason: string }[] = []
+  const failed: { id: number; error: string }[] = []
+
+  // Fetch all cases in one query
+  const { data: cases, error: fetchError } = await supabase
+    .from('scotus_cases')
+    .select('id, is_public, enrichment_status, updated_at')
+    .in('id', ids)
+
+  if (fetchError) {
+    console.error('Bulk fetch error:', fetchError)
+    return jsonResponse({ error: 'Failed to fetch cases for bulk publish' }, 500)
+  }
+
+  const caseMap = new Map((cases || []).map((c: Record<string, unknown>) => [c.id as number, c]))
+
+  // Process each case
+  const now = new Date().toISOString()
+  for (const id of ids) {
+    const currentCase = caseMap.get(id)
+
+    if (!currentCase) {
+      skipped.push({ id, reason: 'Case not found' })
+      continue
+    }
+
+    if (currentCase.is_public) {
+      skipped.push({ id, reason: 'Already published' })
+      continue
+    }
+
+    if (currentCase.enrichment_status !== 'enriched') {
+      skipped.push({ id, reason: `enrichment_status is '${currentCase.enrichment_status}', must be 'enriched'` })
+      continue
+    }
+
+    // Optimistic lock per case
+    const { data: updated, error: updateError } = await supabase
+      .from('scotus_cases')
+      .update({
+        is_public: true,
+        qa_status: 'approved',
+        qa_reviewed_at: now,
+      })
+      .eq('id', id)
+      .eq('updated_at', currentCase.updated_at)
+      .select('id')
+      .single()
+
+    if (updateError) {
+      if (updateError.code === 'PGRST116') {
+        skipped.push({ id, reason: 'Concurrent modification — refresh and retry' })
+      } else {
+        failed.push({ id, error: updateError.message })
+      }
+      continue
+    }
+
+    published.push(id)
+
+    // Audit log for each published case
+    try {
+      await supabase.rpc('log_content_change', {
+        p_entity_type: 'scotus',
+        p_entity_id: String(id),
+        p_field_name: 'is_public',
+        p_old_value: 'false',
+        p_new_value: 'true',
+        p_changed_by: 'admin',
+        p_change_source: 'admin_bulk_publish'
+      })
+    } catch (historyError) {
+      console.error(`Failed to log bulk publish history for case ${id}:`, historyError)
+    }
+  }
+
+  console.log(`admin_action: bulk_publish published=${published.length} skipped=${skipped.length} failed=${failed.length}`)
+
+  return jsonResponse({
+    success: true,
+    published,
+    skipped,
+    failed,
+    summary: {
+      total: ids.length,
+      published_count: published.length,
+      skipped_count: skipped.length,
+      failed_count: failed.length,
+    }
+  }, 200)
+}


### PR DESCRIPTION
## Summary
- **Session 1 (backend):** New `admin-scotus` and `admin-update-scotus` edge functions — paginated list with 8 filters, cursor pagination, bulk publish, reject workflow, optimistic locking, audit logging. Updated `admin-stats` with SCOTUS needs_review count.
- **Session 2 (frontend):** SCOTUS tab in `admin.html` — EditScotusModal (5 collapsible sections, field-by-field change detection), ScotusTab (sub-tabs, filters, bulk publish with 50 cap, lazy-loaded run log, cursor pagination). Home tab attention item for scotus_needs_review.
- **UX refinements:** Reject button removed (re-enrich covers it), re-enrich auto-unpublishes, status fields read-only, case identity editable, cursor pagination fix, sort-split bug fix (also fixed latent bug in PardonsTab).

## Files changed
- `public/admin.html` — full frontend implementation
- `supabase/functions/admin-scotus/index.ts` — list + filters + run log endpoint
- `supabase/functions/admin-update-scotus/index.ts` — update/publish/bulk endpoint
- `supabase/functions/admin-stats/index.ts` — SCOTUS needs_review count

## Test plan
- [x] Tested on TEST environment with live data
- [x] Live UX review with Josh (6 iterative fix commits)
- [x] Cursor pagination verified (full timestamps)
- [x] Bulk publish with 50-cap verified
- [ ] After merge: deploy edge functions to PROD (`admin-scotus`, `admin-update-scotus`, `admin-stats`)
- [ ] Verify SCOTUS tab loads on trumpytracker.com/admin.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)