### PR TITLE
feat(ADO-481): bump EO prompt to v1.1 + disable legacy GPT enrichment

### DIFF
--- a/.github/workflows/executive-orders-tracker.yml
+++ b/.github/workflows/executive-orders-tracker.yml
@@ -63,14 +63,13 @@ jobs:
         SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_SERVICE_KEY || secrets.SUPABASE_SERVICE_KEY }}
       run: node scripts/executive-orders-tracker-supabase.js
 
-    - name: Phase 2 - Enrich Executive Orders (GPT)
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        SUPABASE_URL: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_URL || secrets.SUPABASE_URL }}
-        SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_SERVICE_KEY || secrets.SUPABASE_SERVICE_KEY }}
-      run: |
-        echo "Phase 2: Enrich unenriched executive orders"
-        node scripts/enrichment/enrich-executive-orders.js 50
+    # GPT enrichment step DISABLED 2026-04-19 (ADO-481).
+    # Reason: Claude Code cloud agent now handles EO enrichment, writing prompt_version='v1.1'.
+    # The legacy GPT enricher writes 'v4-ado273' which would corrupt v1.1 rows back to v4-ado273
+    # (the prevent_enriched_at_update trigger lets that direction pass since 'v4-ado273' > 'v1.1'
+    # lexicographically), so this step must NOT run while the Claude agent is the source of truth.
+    # Import step above is preserved so new EOs from Federal Register continue to land in PROD
+    # for the Claude agent to enrich. Full retirement is tracked in ADO-482.
 
     - name: Commit any changes (minimal, since data is in Supabase)
       run: |

--- a/docs/features/eo-claude-agent/prompt-v1.md
+++ b/docs/features/eo-claude-agent/prompt-v1.md
@@ -1,4 +1,6 @@
-# Executive Order Enrichment Agent — Prompt v1
+# Executive Order Enrichment Agent — Prompt v1.1
+
+> **Version note (2026-04-19, ADO-481):** Bumped from `v1` → `v1.1` to break the prompt_version string collision with the retired GPT-4o-mini pipeline (which also wrote `'v1'` to the same column). Prompt content is unchanged — this is a cosmetic version-string fix so the existing queue filter (`prompt_version.neq.v1.1`) auto-re-queues the 251-row PROD backlog without manual SQL.
 
 You are the Executive Order Enrichment Agent. You run daily on Anthropic cloud infrastructure. Your job: read newly published Executive Orders and produce structured, on-brand enrichment data for each one.
 
@@ -60,7 +62,7 @@ curl -s "${SUPABASE_URL}/rest/v1/executive_orders?select=id,order_number,title&l
 - Filter: `?enriched_at=is.null`
 - Multiple values: `?id=in.(1,2,3)`
 - NULL check: `?enriched_at=is.null`
-- Multi-condition: `?or=(enriched_at.is.null,prompt_version.neq.v1)`
+- Multi-condition: `?or=(enriched_at.is.null,prompt_version.neq.v1.1)`
 - Ordering: `&order=date.desc`
 - Limit: `&limit=10`
 
@@ -72,7 +74,7 @@ curl -s -X POST "${SUPABASE_URL}/rest/v1/executive_orders_enrichment_log" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d '{"prompt_version": "v1", "run_id": "eo-2026-04-15T16:00:00Z", "status": "running"}'
+  -d '{"prompt_version": "v1.1", "run_id": "eo-2026-04-15T16:00:00Z", "status": "running"}'
 ```
 
 **Important:** `Prefer: return=representation` makes the response include the created/modified row(s). Always use this for POST and PATCH so you can verify the write succeeded.
@@ -178,7 +180,7 @@ Rows with `run_id` matching yours are leftover from a previous crashed run of th
 ### Step 2: Find Unenriched EOs
 
 ```bash
-curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1)&select=id,order_number,title,date,source_url,category,description&order=date.asc&limit=5" \
+curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1.1)&select=id,order_number,title,date,source_url,category,description&order=date.asc&limit=5" \
   -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
 ```
@@ -189,7 +191,7 @@ curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt
 
 **Order = `date.asc`:** Process oldest first so backlog drains in signing order.
 
-**Trigger awareness — `prevent_enriched_at_update`:** The `executive_orders` table has a `BEFORE UPDATE` trigger (migration 023) that rejects any update to `enriched_at` unless `prompt_version` strictly increases. This means you can never re-enrich an EO at the same prompt version once it has been enriched. The filter above already avoids this: rows with `enriched_at != NULL` AND `prompt_version = 'v1'` are excluded. If you ever need to re-enrich an already-enriched EO (e.g., to fix a bad output), a human must either (a) increase `prompt_version` to `v1.1+` in a prompt revision, or (b) manually null the row's `enriched_at` in the database first. Do not work around the trigger.
+**Trigger awareness — `prevent_enriched_at_update`:** The `executive_orders` table has a `BEFORE UPDATE` trigger (migration 023) that rejects any update to `enriched_at` unless `prompt_version` strictly increases. This means you can never re-enrich an EO at the same prompt version once it has been enriched. The filter above already avoids this: rows with `enriched_at != NULL` AND `prompt_version = 'v1.1'` are excluded. If you ever need to re-enrich an already-enriched EO (e.g., to fix a bad output), a human must either (a) increase `prompt_version` to `v1.2+` in a prompt revision, or (b) manually null the row's `enriched_at` in the database first. Do not work around the trigger.
 
 ### Step 3: Read EO Text
 
@@ -207,7 +209,7 @@ LOG_ROW=$(curl -s -X POST "${SUPABASE_URL}/rest/v1/executive_orders_enrichment_l
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d "{\"eo_id\": \"${EO_ID}\", \"prompt_version\": \"v1\", \"run_id\": \"${RUN_ID}\", \"status\": \"running\"}")
+  -d "{\"eo_id\": \"${EO_ID}\", \"prompt_version\": \"v1.1\", \"run_id\": \"${RUN_ID}\", \"status\": \"running\"}")
 
 LOG_ID=$(echo "$LOG_ROW" | jq -r '.[0].id' 2>/dev/null || echo "$LOG_ROW" | grep -oE '"id":[0-9]+' | head -1 | cut -d: -f2)
 ```
@@ -373,7 +375,7 @@ For each EO, run this mental checklist before writing:
 - [ ] `is_public` is NOT being set?
 - [ ] If `alarm_level = 0`: `needs_manual_review = true` on the log row (see Level 0 policy below)?
 
-**Level 0 policy:** For v1, treat level-0 candidates as needing human review. Write the enrichment with your best analysis, but set `needs_manual_review = true` with `notes = 'Level 0 enrichment — flagging for review per v1 policy'`. Level 0 means "Actually Helpful" — the tone is the hardest to calibrate without drift into performative skepticism, and there is no gold-set example at this level. Human review confirms the level is actually earned before it goes to any public view.
+**Level 0 policy:** For v1.1, treat level-0 candidates as needing human review. Write the enrichment with your best analysis, but set `needs_manual_review = true` with `notes = 'Level 0 enrichment — flagging for review per v1.1 policy'`. Level 0 means "Actually Helpful" — the tone is the hardest to calibrate without drift into performative skepticism, and there is no gold-set example at this level. Human review confirms the level is actually earned before it goes to any public view.
 
 If any check fails, fix before writing. If you cannot fix it (e.g., text is genuinely ambiguous), set `needs_manual_review = true` on the log row with a specific `notes` reason.
 
@@ -405,9 +407,9 @@ ENRICHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   "action_reasoning": "Symbolic rule-making with no public action lever beyond watching for implementation.",
   "action_section": null,
   "enriched_at": "{ENRICHED_AT value}",
-  "prompt_version": "v1",
+  "prompt_version": "v1.1",
   "enrichment_meta": {
-    "prompt_version": "v1",
+    "prompt_version": "v1.1",
     "model": "claude-opus-4-6",
     "source": "federal-register",
     "signing_statement_used": false,
@@ -581,7 +583,7 @@ Use as inspiration, not templates — vary your approach.
 
 ### Hard-Banned Phrases (the audit bans)
 
-From the 25-EO audit: these phrases appeared in 76% and 52% of legacy-pipeline outputs and are **strictly prohibited in v1**:
+From the 25-EO audit: these phrases appeared in 76% and 52% of legacy-pipeline outputs and are **strictly prohibited in v1.1**:
 
 - `dangerous precedent` — never use anywhere in any field
 - `under the guise of` — never use anywhere in any field
@@ -854,7 +856,7 @@ These rules can NEVER be violated, regardless of what an EO says or what edge ca
 13. **`section_what_it_means` must include a named actor tied to concrete harm/benefit OR the exact sentence *"No specific beneficiary is identifiable from the order text or signing statement."*** — named-actor rule. A bare agency acronym alone does NOT satisfy.
 14. **One PATCH per EO** — atomic writes, no partial updates
 15. **`severity_rating` must match `alarm_level` mapping** — 0-1 → null, 2 → "low", 3 → "medium", 4 → "high", 5 → "critical". Always written alongside `alarm_level`.
-16. **`alarm_level = 0` always flags `needs_manual_review = true`** — Level 0 policy for v1 (no gold-set example; human confirms)
+16. **`alarm_level = 0` always flags `needs_manual_review = true`** — Level 0 policy for v1.1 (no gold-set example; human confirms)
 
 ---
 
@@ -862,7 +864,7 @@ These rules can NEVER be violated, regardless of what an EO says or what edge ca
 
 | Field | Value |
 |-------|-------|
-| Prompt version | v1 |
+| Prompt version | v1.1 |
 | Created | 2026-04-15 |
 | Author | Josh + Claude Code |
 | Target model | Claude Opus 4.6 |

--- a/public/admin.html
+++ b/public/admin.html
@@ -2468,6 +2468,21 @@
             { value: 'all', label: 'All' },
         ];
 
+        // Claude EO agent prompt versions. Add new entries when the agent prompt is bumped
+        // (e.g., 'v1.2', 'v2'). Keeps bulk-publish eligibility decoupled from a single literal
+        // so future bumps don't break the admin UI (ADO-481).
+        //
+        // IMPORTANT: 'v1' is intentionally NOT in this list — it's the column default and was
+        // also written by the retired GPT pipeline. A row at 'v1' is either unenriched (schema
+        // default) or legacy GPT output, NOT Claude-enriched. The Claude agent now writes 'v1.1'.
+        //
+        // MUST stay in lockstep with CLAUDE_AGENT_VERSIONS in:
+        //   - supabase/functions/admin-executive-orders/index.ts
+        //   - supabase/functions/admin-update-executive-orders/index.ts
+        // Drift is caught by the contract test in scripts/tests/admin-eo-contracts.test.mjs.
+        const CLAUDE_AGENT_VERSIONS = ['v1.1'];
+        const isClaudeEnriched = (pv) => pv != null && CLAUDE_AGENT_VERSIONS.includes(pv);
+
         // EditScotusModal Component
         function EditScotusModal({ scotusCase, onClose, onSave, onRefresh, supabase, password }) {
             const h = React.createElement;
@@ -4673,7 +4688,7 @@
                     // catches it too, but this trims the request and keeps the
                     // count-they-see vs count-they-submit expectation tight.
                     const itemsPayload = items
-                        .filter(i => selectedIds.has(i.id) && !i.is_public && i.prompt_version === 'v1')
+                        .filter(i => selectedIds.has(i.id) && !i.is_public && isClaudeEnriched(i.prompt_version))
                         .map(i => ({ id: i.id, if_updated_at: i.updated_at }));
                     if (itemsPayload.length === 0) {
                         toast?.addToast('No eligible items to publish (all already published or unenriched)', 'error');
@@ -4741,7 +4756,7 @@
                 });
             };
             const toggleSelectAll = () => {
-                const eligible = items.filter(i => !i.is_public && i.prompt_version === 'v1').map(i => i.id);
+                const eligible = items.filter(i => !i.is_public && isClaudeEnriched(i.prompt_version)).map(i => i.id);
                 if (selectedIds.size === eligible.length && eligible.length > 0) {
                     setSelectedIds(new Set());
                 } else {
@@ -4907,7 +4922,7 @@
                                                         type="checkbox"
                                                         className="bulk-checkbox"
                                                         checked={(() => {
-                                                            const eligible = items.filter(i => !i.is_public && i.prompt_version === 'v1');
+                                                            const eligible = items.filter(i => !i.is_public && isClaudeEnriched(i.prompt_version));
                                                             return eligible.length > 0 && selectedIds.size === eligible.length;
                                                         })()}
                                                         onChange={toggleSelectAll}
@@ -4934,7 +4949,7 @@
                                         )}
                                         {items.map(eo => {
                                             const alarmBadge = getAlarmBadge(eo.alarm_level);
-                                            const isEnriched = eo.prompt_version === 'v1';
+                                            const isEnriched = isClaudeEnriched(eo.prompt_version);
                                             const isBusy = busyIds.has(eo.id);
                                             const eligibleForSelect = !eo.is_public && isEnriched;
 

--- a/scripts/tests/admin-eo-contracts.test.mjs
+++ b/scripts/tests/admin-eo-contracts.test.mjs
@@ -108,11 +108,19 @@ test('list with subtab=published returns only is_public=true items', async () =>
   }
 });
 
-test('list with subtab=unenriched returns only prompt_version != v1', async () => {
+// CLAUDE_AGENT_VERSIONS — kept in lockstep with edge-function constants. ADO-481.
+// 'v1' deliberately excluded (column default + legacy GPT output, never Claude).
+const CLAUDE_AGENT_VERSIONS = ['v1.1'];
+
+test('list with subtab=unenriched returns only items NOT in CLAUDE_AGENT_VERSIONS', async () => {
   const { status, data } = await call(FN_LIST, { action: 'list', subtab: 'unenriched', limit: 10 });
   assert.equal(status, 200);
   for (const item of data.items) {
-    assert.notEqual(item.prompt_version, 'v1', `unenriched item ${item.id} has prompt_version=v1`);
+    assert.equal(
+      CLAUDE_AGENT_VERSIONS.includes(item.prompt_version),
+      false,
+      `unenriched item ${item.id} has prompt_version=${item.prompt_version} which IS in Claude versions`,
+    );
   }
 });
 

--- a/scripts/tests/admin-eo-unit.test.mjs
+++ b/scripts/tests/admin-eo-unit.test.mjs
@@ -10,6 +10,7 @@
  */
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 // ─── Helper mirrors (kept in sync with edge function source) ───────────────
 
@@ -95,19 +96,25 @@ function encodeCursor(payload) {
   return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
 }
 
+// Mirror of CLAUDE_AGENT_VERSIONS in admin-executive-orders / admin-update-executive-orders.
+// Bump entries here in lockstep with the edge-function constants when the agent prompt is bumped.
+// 'v1' is intentionally NOT in this list — see the constant comment in the edge functions.
+const CLAUDE_AGENT_VERSIONS = ['v1.1'];
+const isClaudeEnriched = (pv) => pv != null && CLAUDE_AGENT_VERSIONS.includes(pv);
+
 // admin-executive-orders / index.ts — tab predicate.
 function matchesSubtab(eo, latestLogStatus, subtab) {
   switch (subtab) {
     case 'needs_review':
-      return eo.prompt_version === 'v1' && !eo.is_public && eo.needs_manual_review;
+      return isClaudeEnriched(eo.prompt_version) && !eo.is_public && eo.needs_manual_review;
     case 'unenriched':
-      return eo.prompt_version !== 'v1';
+      return !isClaudeEnriched(eo.prompt_version);
     case 'unpublished':
-      return eo.prompt_version === 'v1' && !eo.is_public;
+      return isClaudeEnriched(eo.prompt_version) && !eo.is_public;
     case 'published':
       return eo.is_public === true;
     case 'failed':
-      return eo.prompt_version !== 'v1' && latestLogStatus === 'failed';
+      return !isClaudeEnriched(eo.prompt_version) && latestLogStatus === 'failed';
     case 'all':
     default:
       return true;
@@ -384,40 +391,93 @@ test('validateSearch rejects wrong type', () => {
 // ─── Tab predicate (plan §6.1: every "List returns only matching predicate" row) ──
 
 test('matchesSubtab — needs_review predicate', () => {
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: true }, null, 'needs_review'), true);
-  // Wrong prompt version
+  // v1.1 (current Claude agent output) counts as enriched
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: true }, null, 'needs_review'), true);
+  // v1 is column default / legacy GPT output → NOT a Claude version → never in needs_review
+  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: true }, null, 'needs_review'), false);
+  // Wrong prompt version (null = unenriched)
   assert.equal(matchesSubtab({ prompt_version: null, is_public: false, needs_manual_review: true }, null, 'needs_review'), false);
   // Already public
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: true, needs_manual_review: true }, null, 'needs_review'), false);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: true, needs_manual_review: true }, null, 'needs_review'), false);
   // Not flagged
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'needs_review'), false);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: false }, null, 'needs_review'), false);
 });
 
 test('matchesSubtab — unenriched predicate', () => {
   assert.equal(matchesSubtab({ prompt_version: null, is_public: false, needs_manual_review: false }, null, 'unenriched'), true);
   assert.equal(matchesSubtab({ prompt_version: 'v0', is_public: false, needs_manual_review: false }, null, 'unenriched'), true);
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'unenriched'), false);
+  // Old GPT pipeline output (v4-ado273) is NOT a Claude version → "unenriched" from admin POV
+  assert.equal(matchesSubtab({ prompt_version: 'v4-ado273', is_public: false, needs_manual_review: false }, null, 'unenriched'), true);
+  // v1 (column default OR retired GPT output) is NOT Claude-enriched
+  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'unenriched'), true);
+  // Only v1.1 (current Claude agent) counts as enriched
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: false }, null, 'unenriched'), false);
 });
 
 test('matchesSubtab — unpublished predicate', () => {
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'unpublished'), true);
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: true }, null, 'unpublished'), true); // also unpublished if flagged
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: true, needs_manual_review: false }, null, 'unpublished'), false);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: false }, null, 'unpublished'), true);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: true }, null, 'unpublished'), true); // also unpublished if flagged
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: true, needs_manual_review: false }, null, 'unpublished'), false);
+  // v1 is NOT Claude-enriched → not in unpublished tab
+  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'unpublished'), false);
   assert.equal(matchesSubtab({ prompt_version: null, is_public: false, needs_manual_review: false }, null, 'unpublished'), false);
 });
 
 test('matchesSubtab — published predicate', () => {
+  // Published is orthogonal to enrichment — purely is_public=true
   assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: true, needs_manual_review: false }, null, 'published'), true);
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, null, 'published'), false);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: true, needs_manual_review: false }, null, 'published'), true);
+  assert.equal(matchesSubtab({ prompt_version: 'v4-ado273', is_public: true, needs_manual_review: false }, null, 'published'), true);
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: false }, null, 'published'), false);
 });
 
 test('matchesSubtab — failed predicate uses LATEST log status (plan §6.1 "Failed sub-tab uses latest log")', () => {
-  // Latest log = failed → IS in Failed
+  // Latest log = failed AND not Claude-enriched → IS in Failed
   assert.equal(matchesSubtab({ prompt_version: null, is_public: false, needs_manual_review: false }, 'failed', 'failed'), true);
+  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, 'failed', 'failed'), true); // v1 = unenriched per ADO-481
   // Latest log = completed → NOT in Failed (even if any older log was failed; caller passes only the latest)
   assert.equal(matchesSubtab({ prompt_version: null, is_public: false, needs_manual_review: false }, 'completed', 'failed'), false);
-  // Already enriched (v1) → NOT in Failed regardless of log
-  assert.equal(matchesSubtab({ prompt_version: 'v1', is_public: false, needs_manual_review: false }, 'failed', 'failed'), false);
+  // Already Claude-enriched (v1.1) → NOT in Failed regardless of log
+  assert.equal(matchesSubtab({ prompt_version: 'v1.1', is_public: false, needs_manual_review: false }, 'failed', 'failed'), false);
+});
+
+test('isClaudeEnriched predicate (ADO-481 version-collision fix)', () => {
+  // Only v1.1 is in CLAUDE_AGENT_VERSIONS — v1 deliberately excluded (column default + legacy GPT)
+  assert.equal(isClaudeEnriched('v1.1'), true);
+  // Versions NOT in list
+  assert.equal(isClaudeEnriched('v1'), false);
+  assert.equal(isClaudeEnriched('v4-ado273'), false);
+  assert.equal(isClaudeEnriched('v0'), false);
+  assert.equal(isClaudeEnriched('v2'), false);
+  // Null and undefined
+  assert.equal(isClaudeEnriched(null), false);
+  assert.equal(isClaudeEnriched(undefined), false);
+});
+
+// ─── Drift detection (ADO-481 I1) ──────────────────────────────────────────
+// CLAUDE_AGENT_VERSIONS lives in 3 source files (2 edge functions + admin.html).
+// They MUST stay byte-identical or the publish flow silently desyncs (UI shows
+// rows the edge function then rejects, or vice versa). This test greps each
+// source file and asserts the array literals match.
+test('CLAUDE_AGENT_VERSIONS is in lockstep across edge functions and admin.html', () => {
+  const repoRoot = new URL('../../', import.meta.url).pathname.replace(/^\/([A-Za-z]):/, '$1:');
+  const files = [
+    [`${repoRoot}supabase/functions/admin-executive-orders/index.ts`, /CLAUDE_AGENT_VERSIONS\s*=\s*(\[[^\]]+\])/],
+    [`${repoRoot}supabase/functions/admin-update-executive-orders/index.ts`, /CLAUDE_AGENT_VERSIONS\s*=\s*(\[[^\]]+\])/],
+    [`${repoRoot}public/admin.html`, /CLAUDE_AGENT_VERSIONS\s*=\s*(\[[^\]]+\])/],
+  ];
+  const lists = files.map(([path, re]) => {
+    const content = readFileSync(path, 'utf8');
+    const match = content.match(re);
+    assert.ok(match, `CLAUDE_AGENT_VERSIONS not found in ${path}`);
+    // Normalize whitespace + trailing commas so cross-language formatting differences don't cause false drift
+    return match[1].replace(/\s+/g, '').replace(/,\]/g, ']');
+  });
+  assert.equal(lists[0], lists[1], `Drift between admin-executive-orders and admin-update-executive-orders: ${lists[0]} vs ${lists[1]}`);
+  assert.equal(lists[0], lists[2], `Drift between edge functions and admin.html: ${lists[0]} vs ${lists[2]}`);
+  // Also assert the test mirror at top of THIS file matches
+  const testMirror = JSON.stringify(CLAUDE_AGENT_VERSIONS).replace(/"/g, "'");
+  assert.equal(lists[0], testMirror, `Drift between sources and unit-test mirror: ${lists[0]} vs ${testMirror}`);
 });
 
 test('matchesSubtab — all predicate matches everything', () => {

--- a/supabase/functions/admin-executive-orders/index.ts
+++ b/supabase/functions/admin-executive-orders/index.ts
@@ -35,6 +35,23 @@ const VALID_CATEGORIES = [
 ]
 const VALID_SUBTABS = ['needs_review', 'unenriched', 'unpublished', 'published', 'failed', 'all']
 
+// Claude agent prompt versions — versions written by the new Claude EO agent.
+// Add new versions here when the agent prompt is bumped (e.g., 'v1.2', 'v2').
+// Predicate `isClaudeEnriched` decouples admin filters/gates from a single literal,
+// so future bumps don't break the admin UI (ADO-481).
+//
+// IMPORTANT: 'v1' is intentionally NOT in this list — it's the column default and was
+// also written by the retired GPT pipeline. A row at 'v1' is either unenriched (schema
+// default) or legacy GPT output, NOT Claude-enriched. The Claude agent now writes 'v1.1'.
+//
+// MUST stay in lockstep with the same constant in:
+//   - supabase/functions/admin-update-executive-orders/index.ts
+//   - public/admin.html
+// Drift is caught by the contract test in scripts/tests/admin-eo-contracts.test.mjs.
+const CLAUDE_AGENT_VERSIONS = ['v1.1']
+const isClaudeEnriched = (pv: string | null | undefined): boolean =>
+  pv != null && CLAUDE_AGENT_VERSIONS.includes(pv)
+
 // Cursor/date validators
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/  // strict YYYY-MM-DD; rejects ISO timestamps
 
@@ -223,15 +240,15 @@ function matchesSubtab(
 ): boolean {
   switch (subtab) {
     case 'needs_review':
-      return eo.prompt_version === 'v1' && !eo.is_public && eo.needs_manual_review
+      return isClaudeEnriched(eo.prompt_version) && !eo.is_public && eo.needs_manual_review
     case 'unenriched':
-      return eo.prompt_version !== 'v1'
+      return !isClaudeEnriched(eo.prompt_version)
     case 'unpublished':
-      return eo.prompt_version === 'v1' && !eo.is_public
+      return isClaudeEnriched(eo.prompt_version) && !eo.is_public
     case 'published':
       return eo.is_public === true
     case 'failed':
-      return eo.prompt_version !== 'v1' && latestLogStatus === 'failed'
+      return !isClaudeEnriched(eo.prompt_version) && latestLogStatus === 'failed'
     case 'all':
     default:
       return true

--- a/supabase/functions/admin-update-executive-orders/index.ts
+++ b/supabase/functions/admin-update-executive-orders/index.ts
@@ -26,6 +26,22 @@ const ALLOWED_FIELDS = [
   'action_tier', 'action_confidence', 'action_reasoning', 'action_section',
 ]
 
+// Claude agent prompt versions — versions written by the new Claude EO agent.
+// Add new versions here when the agent prompt is bumped (e.g., 'v1.2', 'v2').
+// Used by publish gates so future prompt bumps don't break the admin publish flow (ADO-481).
+//
+// IMPORTANT: 'v1' is intentionally NOT in this list — it's the column default and was
+// also written by the retired GPT pipeline. A row at 'v1' is either unenriched (schema
+// default) or legacy GPT output, NOT Claude-enriched. The Claude agent now writes 'v1.1'.
+//
+// MUST stay in lockstep with the same constant in:
+//   - supabase/functions/admin-executive-orders/index.ts
+//   - public/admin.html
+// Drift is caught by the contract test in scripts/tests/admin-eo-contracts.test.mjs.
+const CLAUDE_AGENT_VERSIONS = ['v1.1']
+const isClaudeEnriched = (pv: string | null | undefined): boolean =>
+  pv != null && CLAUDE_AGENT_VERSIONS.includes(pv)
+
 // Server-managed fields — explicit reject if client tries to set them via update
 const REJECTED_FIELDS_IN_UPDATE = [
   'severity_rating',  // server-derived from alarm_level
@@ -345,11 +361,11 @@ async function handlePublish(supabase: any, body: Record<string, unknown>) {
   const current = await fetchEoForCAS(supabase, id)
   if (!current) return jsonResponse({ error: 'EO not found' }, 404)
 
-  if (current.prompt_version !== 'v1') {
+  if (!isClaudeEnriched(current.prompt_version)) {
     return jsonResponse({
       ok: false,
       error: 'not_enriched',
-      message: `Cannot publish: EO has prompt_version '${current.prompt_version ?? 'NULL'}', must be 'v1'`,
+      message: `Cannot publish: EO has prompt_version '${current.prompt_version ?? 'NULL'}', must be one of [${CLAUDE_AGENT_VERSIONS.join(', ')}]`,
     }, 400)
   }
 
@@ -530,11 +546,11 @@ async function handleBulkPublish(supabase: any, body: Record<string, unknown>) {
       skipped.push({ id: item.id, current_updated_at: cur.updated_at, reason: 'already_published' })
       continue
     }
-    if (cur.prompt_version !== 'v1') {
+    if (!isClaudeEnriched(cur.prompt_version)) {
       failed.push({
         id: item.id,
         reason: 'not_enriched',
-        message: `prompt_version is '${cur.prompt_version ?? 'NULL'}', must be 'v1'`,
+        message: `prompt_version is '${cur.prompt_version ?? 'NULL'}', must be one of [${CLAUDE_AGENT_VERSIONS.join(', ')}]`,
       })
       continue
     }


### PR DESCRIPTION
## Summary
- Bumps EO agent prompt_version from `v1` to `v1.1` to break collision with retired GPT pipeline
- Drops `v1` from `CLAUDE_AGENT_VERSIONS` admit-list (prevents bulk-publishing schema-default unenriched rows)
- Disables legacy GPT enrichment step in `executive-orders-tracker.yml` (prevents v1.1 → v4-ado273 corruption)
- Adds `isClaudeEnriched()` predicate + drift-detection unit test across 3 source files

## Context
ADO-481 PROD deployment. The Claude Code cloud agent writes `prompt_version='v1.1'`. The old GPT pipeline writes `v4-ado273`. The `prevent_enriched_at_update` trigger allows higher version strings, so `v4-ado273 > v1.1` would pass — this PR prevents that corruption path.

## Test plan
- [x] 35/35 admin-eo unit tests pass (including new drift-detection test)
- [x] Canary enrichment on PROD: EO 14358 at v1.1, alarm_level=2, quality approved by Josh
- [x] Cherry-picked from test branch commit 509ffd4 (tested + reviewed there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)