### PR TITLE
fix: fail pipeline on OpenAI auth/payment errors

### DIFF
--- a/scripts/enrich-stories-backfill.mjs
+++ b/scripts/enrich-stories-backfill.mjs
@@ -11,6 +11,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import OpenAI from 'openai';
 import { enrichStory } from './enrichment/enrich-stories-inline.js';
+import { isFatalOpenAIError } from './lib/openai-errors.js';
 
 // Validate environment
 if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
@@ -125,6 +126,10 @@ async function main() {
     } catch (err) {
       failed++;
       console.error(`[FAIL] Story ${story.id}: ${err.message}`);
+      if (isFatalOpenAIError(err)) {
+        console.error(`🚨 FATAL: OpenAI auth/payment error (${err.status}). Stopping backfill.`);
+        process.exit(1);
+      }
     }
   }
 

--- a/scripts/enrichment/extract-article-entities-inline.js
+++ b/scripts/enrichment/extract-article-entities-inline.js
@@ -15,6 +15,7 @@
 
 import { normalizeEntities } from '../lib/entity-normalization.js';
 import { recordSkip, PIPELINES, REASONS } from '../lib/skip-reasons.js';
+import { isFatalOpenAIError } from '../lib/openai-errors.js';
 
 // ============================================================================
 // Entity Extraction Prompt
@@ -196,6 +197,7 @@ export async function extractArticleEntities(title, content, openaiClient, optio
       entity_id: articleId,
       metadata: { message: err.message }
     });
+    if (isFatalOpenAIError(err)) throw err;
     return { entities: [], tokens: null };
   }
 }

--- a/scripts/lib/openai-errors.js
+++ b/scripts/lib/openai-errors.js
@@ -1,0 +1,20 @@
+/**
+ * Shared OpenAI error classification for fatal auth/payment failures.
+ * Used by rss-tracker, entity extraction, topic extraction, and backfill scripts.
+ */
+
+export function isFatalOpenAIError(error) {
+  const status = error?.status;
+  const type = error?.type || '';
+
+  if (status === 401 || status === 402 || status === 403) return true;
+
+  if (['authentication_error', 'permission_error', 'insufficient_quota',
+       'organization_invalid'].includes(type)) return true;
+
+  const msg = (error?.message || '').toLowerCase();
+  if (msg.includes('exceeded your current quota') ||
+      msg.includes('insufficient_quota')) return true;
+
+  return false;
+}

--- a/scripts/rss-tracker-supabase.js
+++ b/scripts/rss-tracker-supabase.js
@@ -13,6 +13,7 @@ import { handleFetchFeed } from './rss/fetch_feed.js';
 import { clusterArticle, resetRunState, getRunStats } from './rss/hybrid-clustering.js';
 import { EMBEDDING_MODEL_V1 } from './lib/embedding-config.js';
 import { recordSkip, PIPELINES, REASONS } from './lib/skip-reasons.js';
+import { isFatalOpenAIError } from './lib/openai-errors.js';
 import {
   enrichStory as enrichStoryImpl,
   shouldEnrichStory,
@@ -288,6 +289,20 @@ export class RSSTracker {
         } catch (err) {
           console.error(`❌ Embedding failed for ${article.id}:`, err.message);
           this.stats.embedding_failures++;
+
+          if (isFatalOpenAIError(err)) {
+            await recordSkip(this.supabase, {
+              pipeline: PIPELINES.EMBEDDINGS,
+              reason: REASONS.API_ERROR,
+              entity_type: 'article',
+              entity_id: article.id,
+              metadata: { error_status: err.status, error_type: err.type, message: err.message?.slice(0, 200) }
+            });
+            this.runStatus = 'failed';
+            console.error(`🚨 FATAL: OpenAI auth/payment error (${err.status}). Aborting embeddings.`);
+            throw err;
+          }
+
           await recordSkip(this.supabase, {
             pipeline: PIPELINES.EMBEDDINGS,
             reason: REASONS.EMBEDDING_FAILURE,
@@ -295,13 +310,13 @@ export class RSSTracker {
             entity_id: article.id,
             metadata: { cause: 'api_exception', message: err.message }
           });
-          // Continue with next article - this one will retry next run
         }
       }
 
       console.log(`✅ Embeddings complete: ${this.stats.embeddings_generated} generated, ${this.stats.embedding_failures} failed`);
 
     } catch (err) {
+      if (isFatalOpenAIError(err)) throw err;
       console.error('❌ enrichArticles() failed:', err.message);
     }
   }
@@ -421,6 +436,7 @@ export class RSSTracker {
       this.stats.slugs_extracted = slugsExtracted;
 
     } catch (err) {
+      if (isFatalOpenAIError(err)) throw err;
       console.error('[RSS] extractArticleEntitiesPhase() failed:', err.message);
     }
   }
@@ -581,15 +597,32 @@ export class RSSTracker {
             break; // Budget cap reached
           }
         } catch (enrichErr) {
-          // Log error
           console.error(`❌ Enrichment failed for story ${story.id}:`, enrichErr.message);
-          
-          // Track failure
           this.stats.enrichment_failed++;
+
+          if (isFatalOpenAIError(enrichErr)) {
+            await recordSkip(this.supabase, {
+              pipeline: PIPELINES.STORY_ENRICHMENT,
+              reason: REASONS.API_ERROR,
+              entity_type: 'story',
+              entity_id: story.id,
+              metadata: { error_status: enrichErr.status, error_type: enrichErr.type, message: enrichErr.message?.slice(0, 200) }
+            });
+            this.runStatus = 'failed';
+            console.error(`🚨 FATAL: OpenAI auth/payment error (${enrichErr.status}). Aborting enrichment.`);
+            throw enrichErr;
+          }
+
+          await recordSkip(this.supabase, {
+            pipeline: PIPELINES.STORY_ENRICHMENT,
+            reason: REASONS.API_ERROR,
+            entity_type: 'story',
+            entity_id: story.id,
+            metadata: { message: enrichErr.message?.slice(0, 200) }
+          });
+
           this.runStatus = 'partial_success';
-          
-          // Set cooldown timestamp (nested try-catch for safety)
-          // CRITICAL: Don't let DB errors crash the run
+
           try {
             await this.supabase
               .from('stories')
@@ -597,11 +630,8 @@ export class RSSTracker {
               .eq('id', story.id);
           } catch (updateErr) {
             console.error(`⚠️ Failed to update last_enriched_at for story ${story.id}:`, updateErr.message);
-            // Swallow error - don't crash run if DB update fails
-            // Story will retry next run (acceptable)
           }
-          
-          // Continue to next story
+
           continue;
         }
       }
@@ -609,6 +639,7 @@ export class RSSTracker {
       console.log(`✅ Enriched ${this.stats.stories_enriched} stories (cost: $${this.stats.total_openai_cost_usd.toFixed(4)})`);
 
     } catch (err) {
+      if (isFatalOpenAIError(err)) throw err;
       console.error('❌ Enrichment failed:', err.message);
     }
   }

--- a/scripts/rss/topic-extraction.js
+++ b/scripts/rss/topic-extraction.js
@@ -8,6 +8,8 @@
  * The LLM output is NOT trusted directly - it's cleaned and validated.
  */
 
+import { isFatalOpenAIError } from '../lib/openai-errors.js';
+
 // ============================================================================
 // Synonym Canonicalization (TTRC-302)
 // ============================================================================
@@ -168,6 +170,7 @@ export async function extractTopicSlug(title, content = '', excerpt = '', openai
     return canonicalSlug;
   } catch (error) {
     console.error(`[topic-extraction] Error extracting slug:`, error.message);
+    if (isFatalOpenAIError(error)) throw error;
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Pipeline now fails immediately (exit 1) on OpenAI 401/402/403 errors, triggering the existing Discord alert
- All enrichment failures now record `pipeline_skips` rows for observability
- Helper functions (entity extraction, topic extraction) rethrow fatal errors instead of swallowing them
- Backfill script exits immediately on auth/payment errors

## Context
OpenAI ran out of funds ~33 days ago. The pipeline silently skipped enrichment because errors were caught and swallowed — the run exited 0 and Discord alert never fired. **PROD has 134 unenriched stories** that need backfilling once this merges.

## Test plan
- [x] `isFatalOpenAIError()` unit tested locally (402, 401, 403, insufficient_quota all return true; 500, 429 return false)
- [x] All modified files pass `node --check` syntax validation
- [x] Backfill smoke test succeeded on TEST (86 stories enriched)
- [ ] After merge: run `node scripts/enrich-stories-backfill.mjs --limit=150` against PROD

🤖 Generated with [Claude Code](https://claude.com/claude-code)