### PR TITLE
fix: EO detail pages broken on PROD (string IDs)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -119,9 +119,8 @@ export async function fetchStoryDetail(
 }
 
 export async function fetchEoDetail(id: string | number, signal?: AbortSignal): Promise<DisplayItem | null> {
-  const numId = validateId(id);
-  if (!numId) return null;
-  const query = `executive_orders?select=id,order_number,title,date,category,alarm_level,action_tier,section_what_it_means,section_what_they_say,section_reality_check,section_why_it_matters,source_url&id=eq.${numId}&is_public=eq.true`;
+  const safeId = encodeURIComponent(String(id));
+  const query = `executive_orders?select=id,order_number,title,date,category,alarm_level,action_tier,section_what_it_means,section_what_they_say,section_reality_check,section_why_it_matters,source_url&id=eq.${safeId}&is_public=eq.true`;
   const res = await fetch(`${url}/rest/v1/${query}`, { headers: baseHeaders, signal });
   if (!res.ok) return null;
   const data: Record<string, unknown>[] = await res.json();


### PR DESCRIPTION
## Summary
- PROD EO IDs are strings (`eo_1755289236225_...`) but `validateId()` only accepted integers → detail page always showed "Story not found"
- Replaced `validateId` with `encodeURIComponent` for safe string ID handling
- Also redeployed `stories-detail` edge function to PROD (was referencing stale `articles.headline` column)

## Root cause
The React frontend was developed against TEST which uses integer IDs for EOs. PROD uses the schema-agnostic string IDs from the EO Claude Agent deployment (ADO-481).

## Test plan
- [x] Verified EO PostgREST query returns data with string ID on PROD
- [x] Verified stories-detail edge function returns data after redeploy
- [x] 104 unit tests passing
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)