### PR TITLE
chore: increase agent batch size to 20 per run

### DIFF
--- a/docs/features/eo-claude-agent/prompt-v1.md
+++ b/docs/features/eo-claude-agent/prompt-v1.md
@@ -179,7 +179,7 @@ Rows with `run_id` matching yours are leftover from a previous crashed run of th
 ### Step 2: Find Unenriched EOs
 
 ```bash
-curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1.1)&select=id,order_number,title,date,source_url,category,description&order=date.asc&limit=5" \
+curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1.1)&select=id,order_number,title,date,source_url,category,description&order=date.asc&limit=20" \
   -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
 ```

--- a/docs/features/pardons-claude-agent/prompt-v1.md
+++ b/docs/features/pardons-claude-agent/prompt-v1.md
@@ -197,7 +197,7 @@ If **more than 1 row** is returned (the one you just created counts as 1), anoth
 ### Step 2: Find Unenriched Pardons
 
 ```bash
-curl -s "${SUPABASE_URL}/rest/v1/pardons?enriched_at=is.null&select=id,recipient_name,recipient_type,recipient_count,recipient_criteria,clemency_type,pardon_date,offense_raw,conviction_district,case_number,original_sentence,conviction_date,crime_category,primary_connection_type,corruption_level&order=pardon_date.asc&limit=5" \
+curl -s "${SUPABASE_URL}/rest/v1/pardons?enriched_at=is.null&select=id,recipient_name,recipient_type,recipient_count,recipient_criteria,clemency_type,pardon_date,offense_raw,conviction_district,case_number,original_sentence,conviction_date,crime_category,primary_connection_type,corruption_level&order=pardon_date.asc&limit=20" \
   -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
 ```

--- a/docs/features/scotus-claude-agent/prompt-v1.md
+++ b/docs/features/scotus-claude-agent/prompt-v1.md
@@ -174,14 +174,14 @@ If **more than 1 row** is returned (the one you just created counts as 1), anoth
 ### Step 2: Find Unenriched Cases
 
 ```bash
-curl -s "${SUPABASE_URL}/rest/v1/scotus_cases?enrichment_status=in.(pending,failed)&select=id,case_name,case_name_short,docket_number,term,decided_at,syllabus,opinion_excerpt,source_data_version&order=decided_at.asc&limit=10" \
+curl -s "${SUPABASE_URL}/rest/v1/scotus_cases?enrichment_status=in.(pending,failed)&select=id,case_name,case_name_short,docket_number,term,decided_at,syllabus,opinion_excerpt,source_data_version&order=decided_at.asc&limit=20" \
   -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
 ```
 
 **If 0 cases returned:** This is normal (especially during SCOTUS recess July–September). Log completion with `cases_found = 0` and stop. This is a healthy run, not a failure.
 
-**Limit = 10:** Handles end-of-term surges in June. Typical days have 0–5 cases.
+**Limit = 20:** Clears backlogs faster. Typical days have 0-5 new cases but backlog can be larger.
 
 **Order = `decided_at.asc`:** Process oldest cases first (clears any backlog before new cases).
 


### PR DESCRIPTION
## Summary
- Increases enrichment batch size from 5-10 to 20 per run across all three agents (SCOTUS, EO, Pardons)
- Clears backlogs 3-4x faster: SCOTUS 107 cases, EOs 45, Pardons 88

## Context
Agent triggers blocked by DB version trigger (`v1` < `v4-ado273` lexicographically). Reset all old-GPT items for re-enrichment. Larger batch size prevents multi-week drain times.

## Test plan
- [x] Batch agents already fired with limit=20 override and running on PROD
- [x] No schema changes, only prompt file limit parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)