### PR TITLE
fix(eo-agent): remove description column from PROD query

### DIFF
--- a/docs/features/eo-claude-agent/prompt-v1.md
+++ b/docs/features/eo-claude-agent/prompt-v1.md
@@ -179,7 +179,7 @@ Rows with `run_id` matching yours are leftover from a previous crashed run of th
 ### Step 2: Find Unenriched EOs
 
 ```bash
-curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1.1)&select=id,order_number,title,date,source_url,category,description&order=date.asc&limit=20" \
+curl -s "${SUPABASE_URL}/rest/v1/executive_orders?or=(enriched_at.is.null,prompt_version.is.null,prompt_version.neq.v1.1)&select=id,order_number,title,date,source_url,category&order=date.asc&limit=20" \
   -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
 ```


### PR DESCRIPTION
## Summary
- Removes `description` from EO agent Step 2 SELECT - column doesn't exist on PROD
- Agent was failing and reporting 0 unenriched EOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)