### PR TITLE
fix: change text-selection highlight color from black to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; }
     body { font-family: 'Inter Tight', system-ui, sans-serif; -webkit-font-smoothing: antialiased; }
-    ::selection { background: #ff4d4d; color: #0a0a0b; }
+    ::selection { background: #ff4d4d; color: #ffffff; }
   </style>
 </head>
 <body>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -10,7 +10,7 @@ input { font-family: inherit; color: inherit; }
 html[data-mode="dark"] { background: #0a0a0b; color: #f5f5f4; }
 html[data-mode="light"] { background: #f8f8fa; color: #1a1a1a; }
 
-::selection { background: #ff4d4d; color: #0a0a0b; }
+::selection { background: #ff4d4d; color: #ffffff; }
 
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: #0a0a0b; }


### PR DESCRIPTION
## Summary
- Text-selection (`::selection`) color was near-black (`#0a0a0b`) against the red highlight background (`#ff4d4d`), making selected text hard to read
- Changed to white (`#ffffff`) in both `src/styles/base.css` and the inline FOUC-prevention style in `index.html`

## Test plan
- [x] Verified on TEST (`test` branch) — trivial CSS value change, no build/logic impact
- [ ] Visually confirm on trumpytracker.com after merge: select any text on the page, confirm white text on red highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)