### PR TITLE
fix: milliseconds in Stories agent RUN_ID (avoid heartbeat collision)

### DIFF
--- a/docs/features/stories-claude-agent/prompt-v1.md
+++ b/docs/features/stories-claude-agent/prompt-v1.md
@@ -147,10 +147,10 @@ Read `scripts/lib/entity-normalization.js` in full before extracting any entitie
 
 ### Step 1: Generate Run ID + Coarse Concurrency Check
 
-Create a single run identifier for this entire run:
+Create a single run identifier for this entire run. Millisecond precision (not just seconds) matters here: `stories_enrichment_log` has a unique index on `run_id` for heartbeat rows (`story_id IS NULL`), so two runs launched in the same second (e.g. a manual trigger firing moments before/after the scheduled cron) must not collide on `run_id`, or one run's heartbeat insert would fail outright instead of being caught gracefully by Step 1's concurrency check below.
 
 ```bash
-RUN_ID="stories-$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+RUN_ID="stories-$(date -u +%Y-%m-%dT%H-%M-%S.%3NZ)"
 ```
 
 Every per-story log row this run inserts shares this `run_id` — that's how the admin dashboard groups a run's activity.

--- a/docs/features/stories-claude-agent/prompt-v1.md
+++ b/docs/features/stories-claude-agent/prompt-v1.md
@@ -147,7 +147,7 @@ Read `scripts/lib/entity-normalization.js` in full before extracting any entitie
 
 ### Step 1: Generate Run ID + Coarse Concurrency Check
 
-Create a single run identifier for this entire run. Millisecond precision (not just seconds) matters here: `stories_enrichment_log` has a unique index on `run_id` for heartbeat rows (`story_id IS NULL`), so two runs launched in the same second (e.g. a manual trigger firing moments before/after the scheduled cron) must not collide on `run_id`, or one run's heartbeat insert would fail outright instead of being caught gracefully by Step 1's concurrency check below.
+Create a single run identifier for this entire run. Millisecond precision (not just seconds) matters here: `stories_enrichment_log` has a unique index on `run_id` for heartbeat rows (`story_id IS NULL`), so two runs launched in the same second (e.g. a manual trigger firing moments before/after the scheduled cron) must not collide on `run_id`, or one run's heartbeat insert would fail outright instead of being caught gracefully by Step 1's concurrency check below. `%3N` requires GNU coreutils `date` — this is safe because this prompt only ever runs inside the Anthropic cloud agent's Linux container (never a local/macOS shell), and `%3N` is already relied on unmodified elsewhere in this file (Step 3A's `duration_ms` timing).
 
 ```bash
 RUN_ID="stories-$(date -u +%Y-%m-%dT%H-%M-%S.%3NZ)"


### PR DESCRIPTION
## Summary
- Fast-follow to #103 (merged earlier today): an independent production-readiness review caught a narrow collision risk in the heartbeat unique index that PR added to `stories_enrichment_log`
- Two runs launching in the same second (manual trigger + scheduled cron, for example) would generate an identical `run_id`, which could fail the new unique-index insert instead of being caught gracefully by the existing coarse concurrency check
- Bumped `RUN_ID` generation to millisecond precision — cheap fix, `%3N` is already used elsewhere in this same prompt for `duration_ms`

## Test plan
- [x] Doc-only change (prompt file the cloud agent reads at runtime), no schema/code impact
- [x] Reviewed by an independent production-readiness pass this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)