### PR TITLE
ADO-537: admin Judge tab manual merge + unmerge (PROD)

### DIFF
--- a/docs/features/clustering-judge/prod-deployment-manifest.md
+++ b/docs/features/clustering-judge/prod-deployment-manifest.md
@@ -59,9 +59,17 @@ could re-attach to a tombstone via the ANN block or the hash-collision path).
 | 3.2 | `stories-detail` | multi-hop tombstone → survivor redirect | ⬜ | ⬜ |
 | 3.3 | `stories-search` | exclude `status='merged_into'`; narrowed select | ⬜ | ⬜ |
 | 3.4 | `admin-judge-log` | NEW — service_role backend for the admin Judge tab | ⬜ | ⬜ |
+| 3.5 | `admin-judge-merge` | NEW (ADO-537) — manual merge, password-gated | ✅ | ⬜ |
 
 Deploy: `npx supabase functions deploy <fn> --project-ref osjbulmltfpcoldydexg` (migration 100 must be
 applied first — it is, on PROD). TEST ref is `wnrjrywpcadwutfykflu`.
+
+**ADO-537 manual-merge PROD ordering (load-bearing, in this order):**
+1. Apply migration **104** (adds `'manual'` to the `clustering_judge_log` source CHECK)
+2. Deploy `admin-judge-merge` AND **redeploy `admin-judge-log`** (its `VALID_SOURCES` gained `'manual'`)
+3. Ship `admin.html`
+Violating 1→2: manual merges execute but their Judge-tab log row fails the CHECK (audit only in
+`story_merge_audit`). Violating 2→3: the tab's `manual` source filter is silently ignored (returns all sources).
 
 ---
 

--- a/migrations/104_manual_merge_source.sql
+++ b/migrations/104_manual_merge_source.sql
@@ -1,0 +1,38 @@
+-- Migration: 104_manual_merge_source.sql
+-- Purpose: ADO-537 — admin-initiated ("manual") story merges, logged to clustering_judge_log so the
+--   admin Judge tab shows them alongside agent verdicts. The merge itself reuses the hardened
+--   merge_stories RPC (migrations 100/101/102) via a new password-gated service_role edge function
+--   (admin-judge-merge); no new merge machinery is added here.
+--
+-- NOTE ON NUMBERING: 103 is reserved by the approved ADO-531 backfill plan
+--   (docs/features/clustering-judge/backfill-plan.md — judge_backfill_state + 5-arg candidate RPC).
+--   ADO-537 ships first, so it takes 104. Apply order between 103/104 does not matter — they touch
+--   different objects except the source CHECK, which 103 must extend ADDITIVELY (keep 'manual').
+--
+-- Applied to TEST first (Supabase SQL Editor), then PROD alongside the admin-judge-merge edge function.
+--
+-- ⚠️ DEPLOY ORDER: apply THIS MIGRATION BEFORE deploying the admin-judge-merge edge function to an env.
+--   If the function ships first, a manual merge still SUCCEEDS but its clustering_judge_log insert
+--   violates the old source CHECK — the merge executes with no Judge-tab record (only story_merge_audit
+--   and judge_run_merge_count capture it, and the UI shows only a soft log_error warning).
+
+-- Extend the allowed sources: 'manual' = merge executed from the admin Judge tab (ADO-537).
+-- The inline CHECK in migration 100's CREATE TABLE was auto-named clustering_judge_log_source_check.
+ALTER TABLE clustering_judge_log DROP CONSTRAINT IF EXISTS clustering_judge_log_source_check;
+ALTER TABLE clustering_judge_log
+  ADD CONSTRAINT clustering_judge_log_source_check
+    CHECK (source IN ('inline', 'judge-agent', 'manual'));
+
+COMMENT ON COLUMN clustering_judge_log.source IS
+  'inline = RSS clustering path; judge-agent = scheduled Clustering Judge agent; manual = admin Judge tab merge (ADO-537)';
+
+-- ============================================================================
+-- VERIFICATION (run separately AFTER applying; read-only)
+-- ============================================================================
+-- 1) CHECK now includes manual:
+--    SELECT pg_get_constraintdef(oid) FROM pg_constraint
+--    WHERE conname = 'clustering_judge_log_source_check';
+--    -- expect: CHECK ((source = ANY (ARRAY['inline'::text, 'judge-agent'::text, 'manual'::text])))
+-- 2) Existing rows still valid (constraint added without NOT VALID, so this must return 0):
+--    SELECT COUNT(*) FROM clustering_judge_log
+--    WHERE source NOT IN ('inline', 'judge-agent', 'manual');

--- a/migrations/105_unmerge_story.sql
+++ b/migrations/105_unmerge_story.sql
@@ -1,0 +1,256 @@
+-- Migration: 105_unmerge_story.sql
+-- Purpose: ADO-537 phase 2 — reverse a wrong story merge from the admin Judge tab.
+--   merge_stories (100/101/102) snapshots the loser's article membership to story_merge_audit before
+--   repointing. This migration adds the reverse path:
+--     A) story_merge_audit.unmerged_at — marks a snapshot as consumed (prevents double-unmerge)
+--     B) clustering_judge_log verdict CHECK gains 'unmerge' (audit trail rows for reversals)
+--     C) recompute_story_from_members(p_story_id) — shared stats recompute (centroid, entities,
+--        source_count, recency) used for BOTH stories after an unmerge
+--     D) unmerge_story(p_loser_id, p_run_id) — restores the loser from its latest unconsumed snapshot
+--
+-- KNOWN IRREVERSIBLES (accepted, documented): merge_stories widened the survivor's
+--   first_seen_at/last_updated_at (LEAST/GREATEST) and unioned the loser's topic_slugs into it.
+--   Those cannot be cleanly reversed (originals not snapshotted) and are left as-is on unmerge;
+--   they are cosmetic and self-heal on the survivor's next enrichment. Articles attached to the
+--   survivor AFTER the merge stay on the survivor — only the snapshot articles move back.
+--
+-- ⚠️ DEPLOY ORDER (same rule as 104): apply THIS MIGRATION before deploying the updated
+--   admin-judge-merge edge function, or unmerge requests fail with "function not found".
+--
+-- SECURITY: both new functions are SECURITY DEFINER, locked search_path, EXECUTE revoked from
+--   PUBLIC/anon/authenticated, granted only to service_role (migration 095/096 pattern).
+
+-- ============================================================================
+-- PART A: story_merge_audit.unmerged_at
+-- ============================================================================
+
+ALTER TABLE story_merge_audit
+  ADD COLUMN IF NOT EXISTS unmerged_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN story_merge_audit.unmerged_at IS
+  'ADO-537: set when unmerge_story consumed this snapshot to reverse the merge. NULL = merge still in effect (or loser re-merged later under a newer snapshot).';
+
+-- ============================================================================
+-- PART B: allow 'unmerge' in clustering_judge_log.verdict
+-- ============================================================================
+-- Inline CHECK from migration 100's CREATE TABLE was auto-named clustering_judge_log_verdict_check.
+
+ALTER TABLE clustering_judge_log DROP CONSTRAINT IF EXISTS clustering_judge_log_verdict_check;
+ALTER TABLE clustering_judge_log
+  ADD CONSTRAINT clustering_judge_log_verdict_check
+    CHECK (verdict IN ('merge', 'keep', 'uncertain', 'unmerge'));
+
+-- ============================================================================
+-- PART C: recompute_story_from_members(p_story_id)
+-- ============================================================================
+-- Same recompute recipe as merge_stories steps 3/4/5/P2 (centroid AVG, entity counter + top-5,
+-- source recount, latest_article_published_at), extracted so unmerge can apply it to BOTH the
+-- restored loser and the shrunken survivor. Does NOT touch first_seen_at/last_updated_at/topic_slugs
+-- (see IRREVERSIBLES note above).
+
+CREATE OR REPLACE FUNCTION public.recompute_story_from_members(p_story_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, extensions
+AS $$
+BEGIN
+  WITH sa AS (
+    SELECT a.embedding_v1, a.published_at
+    FROM article_story asg
+    JOIN articles a ON a.id = asg.article_id
+    WHERE asg.story_id = p_story_id
+  ),
+  ctr AS (
+    SELECT AVG(embedding_v1) AS exact_centroid
+    FROM sa WHERE embedding_v1 IS NOT NULL
+  ),
+  recency AS (
+    SELECT MAX(published_at) AS max_pub FROM sa
+  ),
+  ent_counts AS (
+    SELECT (ent->>'id') AS entity_id, COUNT(*)::int AS cnt
+    FROM article_story asg
+    JOIN articles a ON a.id = asg.article_id
+    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(a.entities, '[]'::jsonb)) ent
+    WHERE asg.story_id = p_story_id
+      AND (ent->>'id') IS NOT NULL AND (ent->>'id') <> ''
+    GROUP BY (ent->>'id')
+  ),
+  counter AS (
+    SELECT
+      COALESCE(jsonb_object_agg(entity_id, cnt), '{}'::jsonb) AS counter_json,
+      COALESCE(ARRAY(
+        SELECT entity_id FROM ent_counts
+        ORDER BY cnt DESC, entity_id ASC
+        LIMIT 5
+      ), ARRAY[]::text[]) AS top5
+    FROM ent_counts
+  ),
+  cnt AS (
+    SELECT COUNT(*)::int AS n FROM article_story WHERE story_id = p_story_id
+  )
+  UPDATE stories s
+  SET centroid_embedding_v1       = COALESCE((SELECT exact_centroid FROM ctr), s.centroid_embedding_v1),
+      entity_counter              = (SELECT counter_json FROM counter),
+      top_entities                = (SELECT top5 FROM counter),
+      latest_article_published_at = COALESCE((SELECT max_pub FROM recency), s.latest_article_published_at),
+      source_count                = (SELECT n FROM cnt)
+  WHERE s.id = p_story_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recompute_story_from_members(BIGINT) IS
+  'ADO-537: recompute centroid/entity_counter/top_entities/latest_article_published_at/source_count from current article_story members (merge_stories recipe). Used by unmerge_story on both stories. service_role only.';
+
+-- ============================================================================
+-- PART D: unmerge_story(p_loser_id, p_run_id)
+-- ============================================================================
+-- Restores the most recent un-consumed merge of p_loser_id: repoints the snapshot articles back
+-- from the survivor, clears the tombstone, recomputes both stories, marks the snapshot consumed.
+-- Concurrency: locks both story rows FOR UPDATE in ascending id order (same as merge_stories 102).
+-- Idempotent-safe: a loser that is not currently tombstoned returns not_merged (no-op).
+
+CREATE OR REPLACE FUNCTION public.unmerge_story(
+  p_loser_id BIGINT,
+  p_run_id   TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, extensions
+AS $$
+DECLARE
+  v_audit_id     BIGINT;
+  v_survivor_id  BIGINT;
+  v_article_ids  TEXT[];
+  v_loser_status TEXT;
+  v_loser_merged BIGINT;
+  v_surv_status  TEXT;
+  v_surv_merged  BIGINT;
+  v_moved        INT := 0;
+BEGIN
+  IF p_loser_id IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_ids');
+  END IF;
+  IF p_run_id IS NULL OR p_run_id = '' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'missing_run_id');
+  END IF;
+
+  -- Latest un-consumed snapshot for this loser.
+  SELECT id, survivor_id, loser_article_ids
+    INTO v_audit_id, v_survivor_id, v_article_ids
+    FROM story_merge_audit
+    WHERE loser_id = p_loser_id AND unmerged_at IS NULL
+    ORDER BY merged_at DESC, id DESC
+    LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'no_merge_snapshot');
+  END IF;
+
+  -- Lock both story rows in ascending id order (deadlock-safe, serializes vs merge_stories).
+  PERFORM 1 FROM stories WHERE id IN (p_loser_id, v_survivor_id) ORDER BY id FOR UPDATE;
+
+  SELECT status, merged_into_story_id
+    INTO v_loser_status, v_loser_merged
+    FROM stories WHERE id = p_loser_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'loser_not_found');
+  END IF;
+
+  -- Only reverse a merge that is actually in effect and matches the snapshot.
+  IF v_loser_status <> 'merged_into' OR v_loser_merged IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'not_merged');
+  END IF;
+  IF v_loser_merged <> v_survivor_id THEN
+    -- Tombstone points somewhere the snapshot doesn't know about (shouldn't happen; refuse).
+    RETURN jsonb_build_object('ok', false, 'reason', 'snapshot_mismatch',
+                              'tombstone_points_to', v_loser_merged,
+                              'snapshot_survivor', v_survivor_id);
+  END IF;
+
+  -- The survivor must still be a live story. If it was itself merged away after the original merge
+  -- (live Judge keeps running), the snapshot articles have moved on to a NEWER survivor — restoring
+  -- here would resurrect an empty shell and report success. Refuse with the forwarding pointer so
+  -- the operator can unmerge at the current survivor level instead.
+  SELECT status, merged_into_story_id
+    INTO v_surv_status, v_surv_merged
+    FROM stories WHERE id = v_survivor_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'survivor_not_found');
+  END IF;
+  IF v_surv_status = 'merged_into' OR v_surv_merged IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'survivor_moved',
+                              'survivor_points_to', v_surv_merged);
+  END IF;
+
+  -- Move the snapshot articles back. Only rows still sitting on the survivor move; articles
+  -- deleted or re-clustered elsewhere since the merge are skipped (article_story is UNIQUE(article_id)).
+  UPDATE article_story
+  SET story_id = p_loser_id
+  WHERE story_id = v_survivor_id
+    AND article_id = ANY(COALESCE(v_article_ids, ARRAY[]::text[]));
+  GET DIAGNOSTICS v_moved = ROW_COUNT;
+
+  -- Restore the loser as a live story.
+  UPDATE stories
+  SET status = 'active',
+      merged_into_story_id = NULL
+  WHERE id = p_loser_id;
+
+  -- Recompute both sides from their current members.
+  PERFORM recompute_story_from_members(p_loser_id);
+  PERFORM recompute_story_from_members(v_survivor_id);
+
+  -- Consume the snapshot.
+  UPDATE story_merge_audit SET unmerged_at = NOW() WHERE id = v_audit_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'loser_id', p_loser_id,
+    'survivor_id', v_survivor_id,
+    'articles_restored', v_moved,
+    'audit_id', v_audit_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.unmerge_story(BIGINT, TEXT) IS
+  'ADO-537: reverse the latest merge of p_loser_id using its story_merge_audit snapshot. Repoints snapshot articles back, clears the tombstone, recomputes both stories, marks the snapshot consumed. Row-locked, idempotent-safe. service_role only.';
+
+-- ============================================================================
+-- PART E: security lockdown (migration 095/096 pattern)
+-- ============================================================================
+
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT p.oid
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND (
+      (p.proname = 'unmerge_story'                AND p.pronargs = 2) OR
+      (p.proname = 'recompute_story_from_members' AND p.pronargs = 1)
+    )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.oid::regprocedure);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', r.oid::regprocedure);
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- VERIFICATION (run separately AFTER applying; read-only)
+-- ============================================================================
+-- 1) Column + constraint:
+--    SELECT column_name FROM information_schema.columns
+--    WHERE table_name='story_merge_audit' AND column_name='unmerged_at';
+--    SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='clustering_judge_log_verdict_check';
+--    -- expect 'unmerge' in the verdict list
+-- 2) Grants (expect anon=f, authenticated=f, service_role=t for both):
+--    SELECT p.proname,
+--           has_function_privilege('anon',          p.oid, 'EXECUTE') AS anon,
+--           has_function_privilege('authenticated', p.oid, 'EXECUTE') AS authenticated,
+--           has_function_privilege('service_role',  p.oid, 'EXECUTE') AS service_role
+--    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--    WHERE n.nspname='public' AND p.proname IN ('unmerge_story','recompute_story_from_members');

--- a/migrations/105_unmerge_story.sql
+++ b/migrations/105_unmerge_story.sql
@@ -14,6 +14,14 @@
 --   they are cosmetic and self-heal on the survivor's next enrichment. Articles attached to the
 --   survivor AFTER the merge stay on the survivor — only the snapshot articles move back.
 --
+-- KNOWN LIMITATION (codex P1 on PR #109, accepted 2026-08-03): the loser's PRE-MERGE status is
+--   not snapshotted, so unmerge always restores status='active' — a loser that was 'closed' or
+--   'archived' when merged would come back published. Zero live exposure today: story lifecycle
+--   transitions are intentionally disabled (every PROD story is 'active', Josh's 2026-07 decision),
+--   the ADO-531 backfill merges active stories only, and the merge preview shows the admin the
+--   loser's status before confirming. Revisit (snapshot loser status in story_merge_audit) if the
+--   archive lifecycle ever turns on.
+--
 -- ⚠️ DEPLOY ORDER (same rule as 104): apply THIS MIGRATION before deploying the updated
 --   admin-judge-merge edge function, or unmerge requests fail with "function not found".
 --
@@ -121,14 +129,15 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public, extensions
 AS $$
 DECLARE
-  v_audit_id     BIGINT;
-  v_survivor_id  BIGINT;
-  v_article_ids  TEXT[];
-  v_loser_status TEXT;
-  v_loser_merged BIGINT;
-  v_surv_status  TEXT;
-  v_surv_merged  BIGINT;
-  v_moved        INT := 0;
+  v_audit_id        BIGINT;
+  v_survivor_id     BIGINT;
+  v_article_ids     TEXT[];
+  v_locked_survivor BIGINT;
+  v_loser_status    TEXT;
+  v_loser_merged    BIGINT;
+  v_surv_status     TEXT;
+  v_surv_merged     BIGINT;
+  v_moved           INT := 0;
 BEGIN
   IF p_loser_id IS NULL THEN
     RETURN jsonb_build_object('ok', false, 'reason', 'invalid_ids');
@@ -137,7 +146,8 @@ BEGIN
     RETURN jsonb_build_object('ok', false, 'reason', 'missing_run_id');
   END IF;
 
-  -- Latest un-consumed snapshot for this loser.
+  -- Latest un-consumed snapshot for this loser. PRE-LOCK pass: this only identifies which
+  -- survivor row to lock — the authoritative read happens again below, under the locks.
   SELECT id, survivor_id, loser_article_ids
     INTO v_audit_id, v_survivor_id, v_article_ids
     FROM story_merge_audit
@@ -150,6 +160,27 @@ BEGIN
 
   -- Lock both story rows in ascending id order (deadlock-safe, serializes vs merge_stories).
   PERFORM 1 FROM stories WHERE id IN (p_loser_id, v_survivor_id) ORDER BY id FOR UPDATE;
+
+  -- Re-read the snapshot now that we hold the locks (codex P2 on PR #109): in the pre-lock
+  -- window a concurrent unmerge could have consumed the row we selected and a re-merge written
+  -- a fresh one — acting on the stale copy would restore an outdated article set and leave the
+  -- new snapshot unconsumed. unmerge_story/merge_stories callers serialize on these story-row
+  -- locks, so this second read is authoritative.
+  v_locked_survivor := v_survivor_id;
+  SELECT id, survivor_id, loser_article_ids
+    INTO v_audit_id, v_survivor_id, v_article_ids
+    FROM story_merge_audit
+    WHERE loser_id = p_loser_id AND unmerged_at IS NULL
+    ORDER BY merged_at DESC, id DESC
+    LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'no_merge_snapshot');
+  END IF;
+  IF v_survivor_id <> v_locked_survivor THEN
+    -- The pair changed while we waited for the locks — we hold locks on the wrong survivor row.
+    -- Refuse rather than proceed; the caller just retries against the current state.
+    RETURN jsonb_build_object('ok', false, 'reason', 'snapshot_changed');
+  END IF;
 
   SELECT status, merged_into_story_id
     INTO v_loser_status, v_loser_merged

--- a/migrations/105_unmerge_story.sql
+++ b/migrations/105_unmerge_story.sql
@@ -240,6 +240,16 @@ BEGIN
 END $$;
 
 -- ============================================================================
+-- PART F: reload PostgREST schema cache
+-- ============================================================================
+-- The admin-judge-merge edge function calls unmerge_story via POST /rpc/, and verification reads
+-- select the new unmerged_at column — both need PostgREST's schema cache to know about this DDL.
+-- Hosted Supabase usually auto-reloads via the pgrst_ddl_watch event trigger, but be explicit
+-- rather than rely on it (same P1 rule as the ADO-531 backfill plan).
+
+NOTIFY pgrst, 'reload schema';
+
+-- ============================================================================
 -- VERIFICATION (run separately AFTER applying; read-only)
 -- ============================================================================
 -- 1) Column + constraint:

--- a/public/admin.html
+++ b/public/admin.html
@@ -5696,17 +5696,17 @@
                         </div>
                         <div className="card-body">
                             <div style={{ background: '#111827', border: '1px solid #374151', borderRadius: '6px', padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#d1d5db', lineHeight: '1.5' }}>
-                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). The loser's articles move to the survivor and the loser becomes a redirect — nothing is deleted. Use the <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row below to prefill, then Preview → Confirm.
+                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). <strong style={{ color: '#4ade80' }}>The survivor is KEPT</strong> — its headline stays and it gains the other story's articles; <strong style={{ color: '#f87171' }}>the loser becomes a redirect</strong> to it (nothing is deleted). The <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row prefills Story A as the survivor — hit <strong style={{ color: '#e5e7eb' }}>⇄</strong> if you want to keep Story B instead. Then Preview → Confirm.
                             </div>
                             <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: '0.75rem' }}>
-                                <label style={{ fontSize: '0.8rem', color: '#9ca3af', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                                    Survivor story id
+                                <label style={{ fontSize: '0.8rem', color: '#4ade80', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontWeight: 600 }}>
+                                    KEEP — survivor id
                                     <input type="number" min="1" value={manualSurvivor} style={manualInputStyle}
                                         onChange={(e) => { setManualSurvivor(e.target.value); setManualPreview(null); setManualResult(null); }} />
                                 </label>
                                 <button onClick={swapManualIds} disabled={manualBusy} title="Swap survivor and loser" className="tab-btn" style={{ padding: '0.4rem 0.6rem', fontSize: '0.85rem' }}>⇄</button>
-                                <label style={{ fontSize: '0.8rem', color: '#9ca3af', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                                    Loser story id
+                                <label style={{ fontSize: '0.8rem', color: '#f87171', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontWeight: 600 }}>
+                                    ABSORB — loser id
                                     <input type="number" min="1" value={manualLoser} style={manualInputStyle}
                                         onChange={(e) => { setManualLoser(e.target.value); setManualPreview(null); setManualResult(null); }} />
                                 </label>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5677,6 +5677,7 @@
                             <div style={{ color: '#9ca3af', fontSize: '0.8rem' }}>
                                 status: <strong style={{ color: story.status === 'active' ? '#4ade80' : '#fbbf24' }}>{story.status}</strong>
                                 {' · '}{story.source_count ?? 0} source{story.source_count === 1 ? '' : 's'}
+                                {story.first_seen_at ? ` · first seen ${new Date(story.first_seen_at).toLocaleDateString()}` : ''}
                                 {story.merged_into_story_id ? <span style={{ color: '#f87171' }}> · already merged into #{story.merged_into_story_id}</span> : null}
                             </div>
                         </>
@@ -5712,7 +5713,7 @@
                                 <button onClick={handleManualPreview} disabled={manualBusy || !manualSurvivor || !manualLoser} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>
                                     {manualBusy ? '...' : 'Preview'}
                                 </button>
-                                {manualPreview && manualPreview.ok && (
+                                {manualPreview && manualPreview.ok && manualPreview.survivor?.status !== 'merged_into' && (
                                     <button onClick={handleManualMerge} disabled={manualBusy}
                                         style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: 'pointer' }}>
                                         {manualBusy ? '...' : `Confirm merge #${manualLoser} → #${manualSurvivor}`}

--- a/public/admin.html
+++ b/public/admin.html
@@ -5513,6 +5513,7 @@
             const [manualBusy, setManualBusy] = useState(false);
             const [manualError, setManualError] = useState(null);
             const [manualResult, setManualResult] = useState(null);
+            const [showMergeModal, setShowMergeModal] = useState(false);
             const manualBusyRef = useRef(false);
 
             const TIME_RANGES = [
@@ -5564,9 +5565,9 @@
                 setSourceFilter('');
             };
 
-            const parseManualIds = () => {
-                const survivor = Number(manualSurvivor);
-                const loser = Number(manualLoser);
+            const validateManualIds = (survivorVal, loserVal) => {
+                const survivor = Number(survivorVal);
+                const loser = Number(loserVal);
                 if (!Number.isSafeInteger(survivor) || survivor <= 0 || !Number.isSafeInteger(loser) || loser <= 0) {
                     return { error: 'Both story ids must be positive integers.' };
                 }
@@ -5576,12 +5577,7 @@
                 return { survivor, loser };
             };
 
-            const callJudgeMerge = async (action) => {
-                const ids = parseManualIds();
-                if (ids.error) {
-                    setManualError(ids.error);
-                    return null;
-                }
+            const callJudgeMerge = async (action, survivorId, loserId) => {
                 manualBusyRef.current = true;
                 setManualBusy(true);
                 setManualError(null);
@@ -5590,7 +5586,7 @@
                         'admin-judge-merge',
                         {
                             headers: { 'x-admin-password': password },
-                            body: { action, survivor_id: ids.survivor, loser_id: ids.loser }
+                            body: { action, survivor_id: survivorId, loser_id: loserId }
                         }
                     );
                     if (fnError) throw new Error(fnError.message || 'Request failed');
@@ -5604,26 +5600,45 @@
                 }
             };
 
-            const handleManualPreview = async () => {
+            // Fetches the two stories and opens the confirm popup. survivorVal/loserVal are passed
+            // explicitly (not read from state) so prefillManual can open it in the same tick.
+            const openMergeModal = async (survivorVal, loserVal) => {
+                const ids = validateManualIds(survivorVal, loserVal);
+                if (ids.error) {
+                    setManualError(ids.error);
+                    return;
+                }
                 setManualResult(null);
-                const result = await callJudgeMerge('preview');
-                if (result) setManualPreview(result);
+                const result = await callJudgeMerge('preview', ids.survivor, ids.loser);
+                if (result) {
+                    setManualPreview(result);
+                    setShowMergeModal(true);
+                }
+            };
+
+            const closeMergeModal = () => {
+                setShowMergeModal(false);
+                setManualPreview(null);
             };
 
             const handleManualMerge = async () => {
                 if (manualBusyRef.current) return; // sync double-click guard (state update is async)
-                const result = await callJudgeMerge('merge');
-                if (!result) return;
+                const ids = validateManualIds(manualSurvivor, manualLoser);
+                if (ids.error) {
+                    setManualError(ids.error);
+                    return;
+                }
+                const result = await callJudgeMerge('merge', ids.survivor, ids.loser);
+                if (!result) return; // error already shown; keep the popup open for retry/cancel
+                closeMergeModal();
                 if (result.ok && result.skipped) {
                     // Double-submit or already-merged loser: the merge already happened — report as done, not as an error.
                     setManualResult(`Story was already merged${result.survivor_id ? ` into #${result.survivor_id}` : ''} — nothing to do.`);
-                    setManualPreview(null);
                     fetchVerdicts();
                     return;
                 }
                 if (result.ok && !result.skipped) {
                     setManualResult(`Merged #${result.loser_id} into #${result.survivor_id} — ${result.articles_moved} article${result.articles_moved === 1 ? '' : 's'} moved, survivor now has ${result.survivor_source_count} source${result.survivor_source_count === 1 ? '' : 's'}.${result.log_error ? ' (Warning: Judge log write failed — merge itself succeeded.)' : ''}`);
-                    setManualPreview(null);
                     setManualSurvivor('');
                     setManualLoser('');
                     fetchVerdicts();
@@ -5632,21 +5647,35 @@
                 }
             };
 
+            // Swap keep/absorb roles; if the popup is open, re-preview with the swapped roles.
             const swapManualIds = () => {
-                setManualSurvivor(manualLoser);
-                setManualLoser(manualSurvivor);
-                setManualPreview(null);
+                const s = manualSurvivor;
+                const l = manualLoser;
+                setManualSurvivor(l);
+                setManualLoser(s);
                 setManualError(null);
+                if (showMergeModal) {
+                    openMergeModal(l, s);
+                } else {
+                    setManualPreview(null);
+                }
             };
 
             const prefillManual = (row) => {
                 setManualSurvivor(String(row.story_id_a));
                 setManualLoser(String(row.story_id_b));
-                setManualPreview(null);
                 setManualResult(null);
                 setManualError(null);
-                window.scrollTo({ top: 0, behavior: 'smooth' });
+                openMergeModal(row.story_id_a, row.story_id_b);
             };
+
+            // Escape closes the confirm popup (matches the Edit modals)
+            useEffect(() => {
+                if (!showMergeModal) return;
+                const onKey = (e) => { if (e.key === 'Escape') closeMergeModal(); };
+                window.addEventListener('keydown', onKey);
+                return () => window.removeEventListener('keydown', onKey);
+            }, [showMergeModal]);
 
             const formatTimestamp = (iso) => {
                 if (!iso) return '—';
@@ -5696,7 +5725,7 @@
                         </div>
                         <div className="card-body">
                             <div style={{ background: '#111827', border: '1px solid #374151', borderRadius: '6px', padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#d1d5db', lineHeight: '1.5' }}>
-                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). <strong style={{ color: '#4ade80' }}>The survivor is KEPT</strong> — its headline stays and it gains the other story's articles; <strong style={{ color: '#f87171' }}>the loser becomes a redirect</strong> to it (nothing is deleted). The <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row prefills Story A as the survivor — hit <strong style={{ color: '#e5e7eb' }}>⇄</strong> if you want to keep Story B instead. Then Preview → Confirm.
+                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). <strong style={{ color: '#4ade80' }}>The survivor is KEPT</strong> — its headline stays and it gains the other story's articles; <strong style={{ color: '#f87171' }}>the loser becomes a redirect</strong> to it (nothing is deleted). The <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row prefills Story A as the survivor — hit <strong style={{ color: '#e5e7eb' }}>⇄</strong> if you want to keep Story B instead. A confirmation popup shows both stories before anything happens.
                             </div>
                             <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: '0.75rem' }}>
                                 <label style={{ fontSize: '0.8rem', color: '#4ade80', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontWeight: 600 }}>
@@ -5710,34 +5739,51 @@
                                     <input type="number" min="1" value={manualLoser} style={manualInputStyle}
                                         onChange={(e) => { setManualLoser(e.target.value); setManualPreview(null); setManualResult(null); }} />
                                 </label>
-                                <button onClick={handleManualPreview} disabled={manualBusy || !manualSurvivor || !manualLoser} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>
-                                    {manualBusy ? '...' : 'Preview'}
+                                <button onClick={() => openMergeModal(manualSurvivor, manualLoser)} disabled={manualBusy || !manualSurvivor || !manualLoser}
+                                    style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: (manualBusy || !manualSurvivor || !manualLoser) ? 'not-allowed' : 'pointer', opacity: (manualBusy || !manualSurvivor || !manualLoser) ? 0.5 : 1 }}>
+                                    {manualBusy ? '...' : 'Review & merge…'}
                                 </button>
-                                {manualPreview && manualPreview.ok && manualPreview.survivor?.status !== 'merged_into' && (
-                                    <button onClick={handleManualMerge} disabled={manualBusy}
-                                        style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: 'pointer' }}>
-                                        {manualBusy ? '...' : `Confirm merge #${manualLoser} → #${manualSurvivor}`}
-                                    </button>
-                                )}
                             </div>
-                            {manualError && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
+                            {manualError && !showMergeModal && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
                             {manualResult && (
                                 <div style={{ background: 'rgba(74,222,128,0.1)', border: '1px solid #4ade80', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#4ade80', fontSize: '0.9rem' }}>
                                     {manualResult}
                                 </div>
                             )}
-                            {manualPreview && (
-                                <>
-                                    {manualPreview.warnings && manualPreview.warnings.length > 0 && (
-                                        <div style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid #fbbf24', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#fbbf24', fontSize: '0.85rem' }}>
-                                            {manualPreview.warnings.map((w, i) => <div key={i}>{w}</div>)}
+                            {showMergeModal && manualPreview && (
+                                <div className="modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) closeMergeModal(); }}>
+                                    <div className="modal-content">
+                                        <div className="modal-header">
+                                            <h3 className="modal-title">Confirm story merge</h3>
+                                            <button className="modal-close" onClick={closeMergeModal}>×</button>
                                         </div>
-                                    )}
-                                    <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
-                                        {renderPreviewStory(manualPreview.survivor, 'survivor', manualSurvivor)}
-                                        {renderPreviewStory(manualPreview.loser, 'loser', manualLoser)}
+                                        <div className="modal-body">
+                                            {manualError && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
+                                            {manualPreview.warnings && manualPreview.warnings.length > 0 && (
+                                                <div style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid #fbbf24', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#fbbf24', fontSize: '0.85rem' }}>
+                                                    {manualPreview.warnings.map((w, i) => <div key={i}>{w}</div>)}
+                                                </div>
+                                            )}
+                                            <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+                                                {renderPreviewStory(manualPreview.survivor, 'survivor', manualSurvivor)}
+                                                {renderPreviewStory(manualPreview.loser, 'loser', manualLoser)}
+                                            </div>
+                                            <div style={{ marginTop: '0.75rem', fontSize: '0.85rem', color: '#9ca3af' }}>
+                                                The <span style={{ color: '#f87171' }}>red</span> story's articles move into the <span style={{ color: '#4ade80' }}>green</span> story, and the red one becomes a redirect. There's no undo from the UI yet — double-check before confirming.
+                                            </div>
+                                        </div>
+                                        <div className="modal-footer">
+                                            <button onClick={swapManualIds} disabled={manualBusy} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>⇄ Swap keep/absorb</button>
+                                            <button onClick={closeMergeModal} disabled={manualBusy} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>Cancel</button>
+                                            {manualPreview.ok && manualPreview.survivor?.status !== 'merged_into' && (
+                                                <button onClick={handleManualMerge} disabled={manualBusy}
+                                                    style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: 'pointer' }}>
+                                                    {manualBusy ? 'Merging…' : `Merge #${manualLoser} into #${manualSurvivor}`}
+                                                </button>
+                                            )}
+                                        </div>
                                     </div>
-                                </>
+                                </div>
                             )}
                         </div>
                     </div>
@@ -5862,7 +5908,7 @@
                                                             <td style={{ padding: '0.5rem', whiteSpace: 'nowrap' }}>
                                                                 {!isHeartbeat(row) && !row.merged && (
                                                                     <button onClick={() => prefillManual(row)}
-                                                                        title="Prefill the Manual Merge form with this pair (A = survivor, B = loser)"
+                                                                        title="Open the merge popup with this pair (A = kept, B = absorbed — swappable in the popup)"
                                                                         style={{ background: '#374151', color: '#e5e7eb', border: 'none', padding: '0.2rem 0.5rem', borderRadius: '4px', fontSize: '0.75rem', cursor: 'pointer' }}>
                                                                         use
                                                                     </button>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5514,6 +5514,7 @@
             const [manualError, setManualError] = useState(null);
             const [manualResult, setManualResult] = useState(null);
             const [showMergeModal, setShowMergeModal] = useState(false);
+            const [unmergeRow, setUnmergeRow] = useState(null);
             const manualBusyRef = useRef(false);
 
             const TIME_RANGES = [
@@ -5521,13 +5522,14 @@
                 { label: '7d', value: 168 },
                 { label: '30d', value: 720 }
             ];
-            const VERDICTS = ['merge', 'keep', 'uncertain'];
+            const VERDICTS = ['merge', 'keep', 'uncertain', 'unmerge'];
             const SOURCES = ['judge-agent', 'inline', 'manual'];
 
             const VERDICT_COLOR = {
                 merge: '#f87171',      // red — a merge changes the record, worth the eye
                 keep: '#4ade80',       // green — left as-is
-                uncertain: '#fbbf24'   // amber — flagged
+                uncertain: '#fbbf24',  // amber — flagged
+                unmerge: '#60a5fa'     // blue — a merge was reversed
             };
 
             const fetchVerdicts = useCallback(async () => {
@@ -5669,13 +5671,34 @@
                 openMergeModal(row.story_id_a, row.story_id_b);
             };
 
-            // Escape closes the confirm popup (matches the Edit modals)
+            const handleUnmerge = async () => {
+                if (manualBusyRef.current || !unmergeRow) return;
+                const row = unmergeRow;
+                const result = await callJudgeMerge('unmerge', row.story_id_a, row.story_id_b);
+                if (!result) return; // error shown; popup stays open for cancel
+                setUnmergeRow(null);
+                if (result.ok) {
+                    setManualResult(`Unmerged #${result.loser_id} from #${result.survivor_id} — ${result.articles_restored} article${result.articles_restored === 1 ? '' : 's'} restored, story is live again.${result.log_error ? ' (Warning: Judge log write failed — unmerge itself succeeded.)' : ''}`);
+                    fetchVerdicts();
+                } else {
+                    const reasons = {
+                        not_merged_pair: 'Neither story is currently merged into the other (maybe already unmerged?)',
+                        no_merge_snapshot: 'No reversible snapshot exists for this merge',
+                        not_merged: 'That story is not currently merged away',
+                        snapshot_mismatch: 'The merge snapshot does not match the current tombstone — needs a manual look',
+                        survivor_moved: 'The surviving story was later merged into another story — undo that newer merge first'
+                    };
+                    setManualError(`Unmerge not executed: ${reasons[result.reason] || result.reason || 'unknown reason'}`);
+                }
+            };
+
+            // Escape closes whichever confirm popup is open (matches the Edit modals)
             useEffect(() => {
-                if (!showMergeModal) return;
-                const onKey = (e) => { if (e.key === 'Escape') closeMergeModal(); };
+                if (!showMergeModal && !unmergeRow) return;
+                const onKey = (e) => { if (e.key === 'Escape') { closeMergeModal(); setUnmergeRow(null); } };
                 window.addEventListener('keydown', onKey);
                 return () => window.removeEventListener('keydown', onKey);
-            }, [showMergeModal]);
+            }, [showMergeModal, unmergeRow]);
 
             const formatTimestamp = (iso) => {
                 if (!iso) return '—';
@@ -5743,7 +5766,7 @@
                                     {manualBusy ? '...' : 'Review & merge…'}
                                 </button>
                             </div>
-                            {manualError && !showMergeModal && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
+                            {manualError && !showMergeModal && !unmergeRow && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
                             {manualResult && (
                                 <div style={{ background: 'rgba(74,222,128,0.1)', border: '1px solid #4ade80', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#4ade80', fontSize: '0.9rem' }}>
                                     {manualResult}
@@ -5784,6 +5807,31 @@
                                     </div>
                                 </div>
                             )}
+                            {unmergeRow && (
+                                <div className="modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) setUnmergeRow(null); }}>
+                                    <div className="modal-content">
+                                        <div className="modal-header">
+                                            <h3 className="modal-title">Undo this merge?</h3>
+                                            <button className="modal-close" onClick={() => setUnmergeRow(null)}>×</button>
+                                        </div>
+                                        <div className="modal-body">
+                                            {manualError && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
+                                            <div style={{ color: '#d1d5db', fontSize: '0.9rem', lineHeight: '1.6' }}>
+                                                <div style={{ marginBottom: '0.5rem' }}><span style={{ color: '#6b7280', fontSize: '0.75rem' }}>#{unmergeRow.story_id_a}</span> <strong style={{ color: '#e5e7eb' }}>{unmergeRow.headline_a || '—'}</strong></div>
+                                                <div style={{ marginBottom: '0.75rem' }}><span style={{ color: '#6b7280', fontSize: '0.75rem' }}>#{unmergeRow.story_id_b}</span> <strong style={{ color: '#e5e7eb' }}>{unmergeRow.headline_b || '—'}</strong></div>
+                                                The absorbed story gets its articles back and becomes its own live story again. The stats of both stories are recalculated.
+                                            </div>
+                                        </div>
+                                        <div className="modal-footer">
+                                            <button onClick={() => setUnmergeRow(null)} disabled={manualBusy} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>Cancel</button>
+                                            <button onClick={handleUnmerge} disabled={manualBusy}
+                                                style={{ background: '#2563eb', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: 'pointer' }}>
+                                                {manualBusy ? 'Unmerging…' : 'Unmerge these stories'}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     </div>
 
@@ -5808,7 +5856,7 @@
                         </div>
                         <div className="card-body">
                             <div style={{ background: '#111827', border: '1px solid #374151', borderRadius: '6px', padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#d1d5db', lineHeight: '1.5' }}>
-                                <strong style={{ color: '#e5e7eb' }}>What is this?</strong> Every "same real-world event?" verdict from the Clustering Judge. <strong style={{ color: '#e5e7eb' }}>merge</strong> = fragments combined into one story (reversible — losers are tombstoned, never deleted), <strong style={{ color: '#e5e7eb' }}>keep</strong> = left as separate, <strong style={{ color: '#e5e7eb' }}>uncertain</strong> = flagged, not merged. <code>dry_run</code> rows are validation-only (no story was changed). Read headline A vs B side-by-side; if a merge looks wrong, note the story ids for a manual unwind.
+                                <strong style={{ color: '#e5e7eb' }}>What is this?</strong> Every "same real-world event?" verdict from the Clustering Judge. <strong style={{ color: '#e5e7eb' }}>merge</strong> = fragments combined into one story (reversible — losers are tombstoned, never deleted), <strong style={{ color: '#e5e7eb' }}>keep</strong> = left as separate, <strong style={{ color: '#e5e7eb' }}>uncertain</strong> = flagged, not merged. <code>dry_run</code> rows are validation-only (no story was changed). Read headline A vs B side-by-side; if a merge looks wrong, hit <strong style={{ color: '#60a5fa' }}>unmerge</strong> on that row to reverse it.
                             </div>
 
                             {/* filter chips */}
@@ -5905,7 +5953,14 @@
                                                             <td style={{ padding: '0.5rem', color: '#9ca3af' }}>{row.centroid_sim != null ? Number(row.centroid_sim).toFixed(3) : '—'}</td>
                                                             <td style={{ padding: '0.5rem', color: '#d1d5db', maxWidth: '340px' }}>{row.rationale || '—'}</td>
                                                             <td style={{ padding: '0.5rem', whiteSpace: 'nowrap' }}>
-                                                                {!isHeartbeat(row) && !row.merged && (
+                                                                {!isHeartbeat(row) && row.merged && (
+                                                                    <button onClick={() => { setManualError(null); setManualResult(null); setUnmergeRow(row); }}
+                                                                        title="Reverse this merge — restores the absorbed story as its own story"
+                                                                        style={{ background: '#1e3a5f', color: '#60a5fa', border: 'none', padding: '0.2rem 0.5rem', borderRadius: '4px', fontSize: '0.75rem', cursor: 'pointer' }}>
+                                                                        unmerge
+                                                                    </button>
+                                                                )}
+                                                                {!isHeartbeat(row) && !row.merged && row.verdict !== 'unmerge' && (
                                                                     <button onClick={() => prefillManual(row)}
                                                                         title="Open the merge popup with this pair (A = kept, B = absorbed — swappable in the popup)"
                                                                         style={{ background: '#374151', color: '#e5e7eb', border: 'none', padding: '0.2rem 0.5rem', borderRadius: '4px', fontSize: '0.75rem', cursor: 'pointer' }}>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5725,19 +5725,18 @@
                         </div>
                         <div className="card-body">
                             <div style={{ background: '#111827', border: '1px solid #374151', borderRadius: '6px', padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#d1d5db', lineHeight: '1.5' }}>
-                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). <strong style={{ color: '#4ade80' }}>The survivor is KEPT</strong> — its headline stays and it gains the other story's articles; <strong style={{ color: '#f87171' }}>the loser becomes a redirect</strong> to it (nothing is deleted). The <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row prefills Story A as the survivor — hit <strong style={{ color: '#e5e7eb' }}>⇄</strong> if you want to keep Story B instead. A confirmation popup shows both stories before anything happens.
+                                Merge any two stories: click <strong style={{ color: '#e5e7eb' }}>use</strong> on a verdict row below (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> one you've reviewed), or type two story ids. A confirmation popup shows exactly what will happen — nothing changes until you confirm there.
                             </div>
                             <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: '0.75rem' }}>
                                 <label style={{ fontSize: '0.8rem', color: '#4ade80', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontWeight: 600 }}>
-                                    KEEP — survivor id
-                                    <input type="number" min="1" value={manualSurvivor} style={manualInputStyle}
-                                        onChange={(e) => { setManualSurvivor(e.target.value); setManualPreview(null); setManualResult(null); }} />
+                                    Keep
+                                    <input type="number" min="1" value={manualSurvivor} style={manualInputStyle} placeholder="story id"
+                                        onChange={(e) => { setManualSurvivor(e.target.value); setManualResult(null); }} />
                                 </label>
-                                <button onClick={swapManualIds} disabled={manualBusy} title="Swap survivor and loser" className="tab-btn" style={{ padding: '0.4rem 0.6rem', fontSize: '0.85rem' }}>⇄</button>
                                 <label style={{ fontSize: '0.8rem', color: '#f87171', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontWeight: 600 }}>
-                                    ABSORB — loser id
-                                    <input type="number" min="1" value={manualLoser} style={manualInputStyle}
-                                        onChange={(e) => { setManualLoser(e.target.value); setManualPreview(null); setManualResult(null); }} />
+                                    Absorb
+                                    <input type="number" min="1" value={manualLoser} style={manualInputStyle} placeholder="story id"
+                                        onChange={(e) => { setManualLoser(e.target.value); setManualResult(null); }} />
                                 </label>
                                 <button onClick={() => openMergeModal(manualSurvivor, manualLoser)} disabled={manualBusy || !manualSurvivor || !manualLoser}
                                     style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: (manualBusy || !manualSurvivor || !manualLoser) ? 'not-allowed' : 'pointer', opacity: (manualBusy || !manualSurvivor || !manualLoser) ? 0.5 : 1 }}>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5506,13 +5506,22 @@
             const [sourceFilter, setSourceFilter] = useState('');
             const fetchTokenRef = useRef(0);
 
+            // Manual merge state (ADO-537) — human override for uncertain/missed Judge verdicts
+            const [manualSurvivor, setManualSurvivor] = useState('');
+            const [manualLoser, setManualLoser] = useState('');
+            const [manualPreview, setManualPreview] = useState(null);
+            const [manualBusy, setManualBusy] = useState(false);
+            const [manualError, setManualError] = useState(null);
+            const [manualResult, setManualResult] = useState(null);
+            const manualBusyRef = useRef(false);
+
             const TIME_RANGES = [
                 { label: '24h', value: 24 },
                 { label: '7d', value: 168 },
                 { label: '30d', value: 720 }
             ];
             const VERDICTS = ['merge', 'keep', 'uncertain'];
-            const SOURCES = ['judge-agent', 'inline'];
+            const SOURCES = ['judge-agent', 'inline', 'manual'];
 
             const VERDICT_COLOR = {
                 merge: '#f87171',      // red — a merge changes the record, worth the eye
@@ -5555,6 +5564,90 @@
                 setSourceFilter('');
             };
 
+            const parseManualIds = () => {
+                const survivor = Number(manualSurvivor);
+                const loser = Number(manualLoser);
+                if (!Number.isSafeInteger(survivor) || survivor <= 0 || !Number.isSafeInteger(loser) || loser <= 0) {
+                    return { error: 'Both story ids must be positive integers.' };
+                }
+                if (survivor === loser) {
+                    return { error: 'Survivor and loser must be different stories.' };
+                }
+                return { survivor, loser };
+            };
+
+            const callJudgeMerge = async (action) => {
+                const ids = parseManualIds();
+                if (ids.error) {
+                    setManualError(ids.error);
+                    return null;
+                }
+                manualBusyRef.current = true;
+                setManualBusy(true);
+                setManualError(null);
+                try {
+                    const { data: result, error: fnError } = await supabase.functions.invoke(
+                        'admin-judge-merge',
+                        {
+                            headers: { 'x-admin-password': password },
+                            body: { action, survivor_id: ids.survivor, loser_id: ids.loser }
+                        }
+                    );
+                    if (fnError) throw new Error(fnError.message || 'Request failed');
+                    return result;
+                } catch (err) {
+                    setManualError(err.message);
+                    return null;
+                } finally {
+                    manualBusyRef.current = false;
+                    setManualBusy(false);
+                }
+            };
+
+            const handleManualPreview = async () => {
+                setManualResult(null);
+                const result = await callJudgeMerge('preview');
+                if (result) setManualPreview(result);
+            };
+
+            const handleManualMerge = async () => {
+                if (manualBusyRef.current) return; // sync double-click guard (state update is async)
+                const result = await callJudgeMerge('merge');
+                if (!result) return;
+                if (result.ok && result.skipped) {
+                    // Double-submit or already-merged loser: the merge already happened — report as done, not as an error.
+                    setManualResult(`Story was already merged${result.survivor_id ? ` into #${result.survivor_id}` : ''} — nothing to do.`);
+                    setManualPreview(null);
+                    fetchVerdicts();
+                    return;
+                }
+                if (result.ok && !result.skipped) {
+                    setManualResult(`Merged #${result.loser_id} into #${result.survivor_id} — ${result.articles_moved} article${result.articles_moved === 1 ? '' : 's'} moved, survivor now has ${result.survivor_source_count} source${result.survivor_source_count === 1 ? '' : 's'}.${result.log_error ? ' (Warning: Judge log write failed — merge itself succeeded.)' : ''}`);
+                    setManualPreview(null);
+                    setManualSurvivor('');
+                    setManualLoser('');
+                    fetchVerdicts();
+                } else {
+                    setManualError(`Merge not executed: ${result.reason || 'unknown reason'}${result.survivor_points_to ? ` (that story is merged into #${result.survivor_points_to})` : ''}`);
+                }
+            };
+
+            const swapManualIds = () => {
+                setManualSurvivor(manualLoser);
+                setManualLoser(manualSurvivor);
+                setManualPreview(null);
+                setManualError(null);
+            };
+
+            const prefillManual = (row) => {
+                setManualSurvivor(String(row.story_id_a));
+                setManualLoser(String(row.story_id_b));
+                setManualPreview(null);
+                setManualResult(null);
+                setManualError(null);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            };
+
             const formatTimestamp = (iso) => {
                 if (!iso) return '—';
                 const d = new Date(iso);
@@ -5569,8 +5662,85 @@
 
             const isHeartbeat = (row) => row.story_id_a == null && row.story_id_b == null;
 
+            const manualInputStyle = { background: '#111827', border: '1px solid #374151', borderRadius: '6px', color: '#e5e7eb', padding: '0.4rem 0.6rem', width: '130px', fontSize: '0.9rem' };
+
+            const renderPreviewStory = (story, role, missingId) => (
+                <div style={{ flex: '1 1 260px', background: '#111827', border: `1px solid ${role === 'survivor' ? '#4ade80' : '#f87171'}`, borderRadius: '6px', padding: '0.75rem' }}>
+                    <div style={{ fontSize: '0.75rem', fontWeight: 700, color: role === 'survivor' ? '#4ade80' : '#f87171', textTransform: 'uppercase', marginBottom: '0.35rem' }}>
+                        {role === 'survivor' ? 'Survivor (keeps articles)' : 'Loser (tombstoned)'}
+                    </div>
+                    {story ? (
+                        <>
+                            <div style={{ color: '#e5e7eb', marginBottom: '0.35rem' }}>
+                                <span style={{ color: '#6b7280', fontSize: '0.8rem' }}>#{story.id}</span> {story.primary_headline || '—'}
+                            </div>
+                            <div style={{ color: '#9ca3af', fontSize: '0.8rem' }}>
+                                status: <strong style={{ color: story.status === 'active' ? '#4ade80' : '#fbbf24' }}>{story.status}</strong>
+                                {' · '}{story.source_count ?? 0} source{story.source_count === 1 ? '' : 's'}
+                                {story.merged_into_story_id ? <span style={{ color: '#f87171' }}> · already merged into #{story.merged_into_story_id}</span> : null}
+                            </div>
+                        </>
+                    ) : (
+                        <div style={{ color: '#f87171' }}>Story #{missingId} not found</div>
+                    )}
+                </div>
+            );
+
             return (
                 <div className="dashboard-grid" style={{ gridTemplateColumns: '1fr' }}>
+                    {/* Manual merge card — ADO-537: human override for uncertain/missed Judge verdicts */}
+                    <div className="card">
+                        <div className="card-header">
+                            <h2 className="card-title"><span>Manual Merge</span></h2>
+                        </div>
+                        <div className="card-body">
+                            <div style={{ background: '#111827', border: '1px solid #374151', borderRadius: '6px', padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#d1d5db', lineHeight: '1.5' }}>
+                                Merge two stories the Judge left separate (e.g. an <strong style={{ color: '#fbbf24' }}>uncertain</strong> verdict you've reviewed). The loser's articles move to the survivor and the loser becomes a redirect — nothing is deleted. Use the <strong style={{ color: '#e5e7eb' }}>use</strong> button on a verdict row below to prefill, then Preview → Confirm.
+                            </div>
+                            <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: '0.75rem' }}>
+                                <label style={{ fontSize: '0.8rem', color: '#9ca3af', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                                    Survivor story id
+                                    <input type="number" min="1" value={manualSurvivor} style={manualInputStyle}
+                                        onChange={(e) => { setManualSurvivor(e.target.value); setManualPreview(null); setManualResult(null); }} />
+                                </label>
+                                <button onClick={swapManualIds} disabled={manualBusy} title="Swap survivor and loser" className="tab-btn" style={{ padding: '0.4rem 0.6rem', fontSize: '0.85rem' }}>⇄</button>
+                                <label style={{ fontSize: '0.8rem', color: '#9ca3af', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                                    Loser story id
+                                    <input type="number" min="1" value={manualLoser} style={manualInputStyle}
+                                        onChange={(e) => { setManualLoser(e.target.value); setManualPreview(null); setManualResult(null); }} />
+                                </label>
+                                <button onClick={handleManualPreview} disabled={manualBusy || !manualSurvivor || !manualLoser} className="tab-btn" style={{ padding: '0.4rem 0.9rem', fontSize: '0.85rem' }}>
+                                    {manualBusy ? '...' : 'Preview'}
+                                </button>
+                                {manualPreview && manualPreview.ok && (
+                                    <button onClick={handleManualMerge} disabled={manualBusy}
+                                        style={{ background: '#dc2626', color: '#fff', border: 'none', padding: '0.4rem 0.9rem', borderRadius: '6px', fontSize: '0.85rem', fontWeight: 700, cursor: 'pointer' }}>
+                                        {manualBusy ? '...' : `Confirm merge #${manualLoser} → #${manualSurvivor}`}
+                                    </button>
+                                )}
+                            </div>
+                            {manualError && <div className="error-banner"><strong>Error:</strong> {manualError}</div>}
+                            {manualResult && (
+                                <div style={{ background: 'rgba(74,222,128,0.1)', border: '1px solid #4ade80', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#4ade80', fontSize: '0.9rem' }}>
+                                    {manualResult}
+                                </div>
+                            )}
+                            {manualPreview && (
+                                <>
+                                    {manualPreview.warnings && manualPreview.warnings.length > 0 && (
+                                        <div style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid #fbbf24', borderRadius: '6px', padding: '0.6rem 1rem', marginBottom: '0.75rem', color: '#fbbf24', fontSize: '0.85rem' }}>
+                                            {manualPreview.warnings.map((w, i) => <div key={i}>{w}</div>)}
+                                        </div>
+                                    )}
+                                    <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+                                        {renderPreviewStory(manualPreview.survivor, 'survivor', manualSurvivor)}
+                                        {renderPreviewStory(manualPreview.loser, 'loser', manualLoser)}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+
                     <div className="card">
                         <div className="card-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
                             <h2 className="card-title"><span>Clustering Judge</span></h2>
@@ -5657,6 +5827,7 @@
                                                         <th style={{ padding: '0.5rem', color: '#9ca3af' }}>Conf</th>
                                                         <th style={{ padding: '0.5rem', color: '#9ca3af' }}>Sim</th>
                                                         <th style={{ padding: '0.5rem', color: '#9ca3af' }}>Rationale</th>
+                                                        <th style={{ padding: '0.5rem' }}></th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -5687,6 +5858,15 @@
                                                             <td style={{ padding: '0.5rem', color: '#9ca3af' }}>{row.confidence != null ? Number(row.confidence).toFixed(2) : '—'}</td>
                                                             <td style={{ padding: '0.5rem', color: '#9ca3af' }}>{row.centroid_sim != null ? Number(row.centroid_sim).toFixed(3) : '—'}</td>
                                                             <td style={{ padding: '0.5rem', color: '#d1d5db', maxWidth: '340px' }}>{row.rationale || '—'}</td>
+                                                            <td style={{ padding: '0.5rem', whiteSpace: 'nowrap' }}>
+                                                                {!isHeartbeat(row) && !row.merged && (
+                                                                    <button onClick={() => prefillManual(row)}
+                                                                        title="Prefill the Manual Merge form with this pair (A = survivor, B = loser)"
+                                                                        style={{ background: '#374151', color: '#e5e7eb', border: 'none', padding: '0.2rem 0.5rem', borderRadius: '4px', fontSize: '0.75rem', cursor: 'pointer' }}>
+                                                                        use
+                                                                    </button>
+                                                                )}
+                                                            </td>
                                                         </tr>
                                                     ))}
                                                 </tbody>

--- a/public/admin.html
+++ b/public/admin.html
@@ -5691,6 +5691,7 @@
                         no_merge_snapshot: 'No reversible snapshot exists for this merge',
                         not_merged: 'That story is not currently merged away',
                         snapshot_mismatch: 'The merge snapshot does not match the current tombstone — needs a manual look',
+                        snapshot_changed: 'The merge record changed mid-request — refresh and try again',
                         survivor_moved: 'The surviving story was later merged into another story — undo that newer merge first'
                     };
                     setManualError(`Unmerge not executed: ${reasons[result.reason] || result.reason || 'unknown reason'}`);

--- a/public/admin.html
+++ b/public/admin.html
@@ -5504,6 +5504,8 @@
             const [hours, setHours] = useState(168);
             const [verdictFilter, setVerdictFilter] = useState('');
             const [sourceFilter, setSourceFilter] = useState('');
+            const [storyInput, setStoryInput] = useState('');   // what's typed in the box
+            const [storyFilter, setStoryFilter] = useState('');  // applied on Enter — drives the fetch
             const fetchTokenRef = useRef(0);
 
             // Manual merge state (ADO-537) — human override for uncertain/missed Judge verdicts
@@ -5540,6 +5542,7 @@
                     const reqBody = { hours, limit: 100 };
                     if (verdictFilter) reqBody.verdict = verdictFilter;
                     if (sourceFilter) reqBody.source = sourceFilter;
+                    if (storyFilter) reqBody.story_id = Number(storyFilter); // server ignores the time window for story searches
 
                     const { data: result, error: fnError } = await supabase.functions.invoke(
                         'admin-judge-log',
@@ -5556,7 +5559,7 @@
                 } finally {
                     if (token === fetchTokenRef.current) setLoading(false);
                 }
-            }, [hours, verdictFilter, sourceFilter, password, supabase]);
+            }, [hours, verdictFilter, sourceFilter, storyFilter, password, supabase]);
 
             useEffect(() => {
                 fetchVerdicts();
@@ -5565,6 +5568,8 @@
             const clearFilters = () => {
                 setVerdictFilter('');
                 setSourceFilter('');
+                setStoryInput('');
+                setStoryFilter('');
             };
 
             const validateManualIds = (survivorVal, loserVal) => {
@@ -5877,7 +5882,13 @@
                                         {s}
                                     </button>
                                 ))}
-                                {(verdictFilter || sourceFilter) && (
+                                <span style={{ fontSize: '0.85rem', color: '#9ca3af', marginLeft: '0.5rem' }}>Story:</span>
+                                <input type="number" min="1" value={storyInput} placeholder="id + Enter"
+                                    title="Find every verdict touching this story id, any age (ignores the time range)"
+                                    onChange={(e) => setStoryInput(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === 'Enter') setStoryFilter(e.target.value.trim()); }}
+                                    style={{ background: '#111827', border: storyFilter ? '1px solid #3b82f6' : '1px solid #374151', borderRadius: '4px', color: '#e5e7eb', padding: '0.25rem 0.5rem', width: '110px', fontSize: '0.8rem' }} />
+                                {(verdictFilter || sourceFilter || storyFilter) && (
                                     <button onClick={clearFilters} style={{ background: 'none', border: 'none', color: '#60a5fa', cursor: 'pointer', textDecoration: 'underline', fontSize: '0.85rem' }}>clear</button>
                                 )}
                             </div>
@@ -5889,7 +5900,7 @@
                             ) : data ? (
                                 <>
                                     <div style={{ marginBottom: '1rem', fontSize: '0.9rem', color: '#9ca3af' }}>
-                                        <strong style={{ color: '#e5e7eb' }}>{(data.total_count ?? 0).toLocaleString()}</strong> verdict{data.total_count === 1 ? '' : 's'} in last {TIME_RANGES.find(r => r.value === data.time_range_hours)?.label || `${data.time_range_hours}h`}
+                                        <strong style={{ color: '#e5e7eb' }}>{(data.total_count ?? 0).toLocaleString()}</strong> verdict{data.total_count === 1 ? '' : 's'} {data.filters?.story_id ? <>touching story <strong style={{ color: '#e5e7eb' }}>#{data.filters.story_id}</strong> (all time)</> : <>in last {TIME_RANGES.find(r => r.value === data.time_range_hours)?.label || `${data.time_range_hours}h`}</>}
                                         {data.by_verdict && (
                                             <span style={{ marginLeft: '0.75rem' }}>
                                                 {data.by_verdict.map(v => (
@@ -5906,7 +5917,7 @@
 
                                     {(!data.rows || data.rows.length === 0) ? (
                                         <div style={{ padding: '2rem', textAlign: 'center', color: '#6b7280' }}>
-                                            No verdicts recorded in this time range.
+                                            {data.filters?.story_id ? `No verdicts touch story #${data.filters.story_id}.` : 'No verdicts recorded in this time range.'}
                                         </div>
                                     ) : (
                                         <div style={{ overflowX: 'auto' }}>

--- a/supabase/functions/admin-judge-log/index.ts
+++ b/supabase/functions/admin-judge-log/index.ts
@@ -28,7 +28,7 @@ const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 500
 const DEFAULT_HOURS = 168
 const MAX_HOURS = 720 // 30 days
-const VALID_VERDICTS = new Set(['merge', 'keep', 'uncertain'])
+const VALID_VERDICTS = new Set(['merge', 'keep', 'uncertain', 'unmerge'])
 const VALID_SOURCES = new Set(['judge-agent', 'inline', 'manual'])
 
 Deno.serve(async (req) => {

--- a/supabase/functions/admin-judge-log/index.ts
+++ b/supabase/functions/admin-judge-log/index.ts
@@ -7,7 +7,7 @@
 // Body (all optional):
 //   hours:   time window (24, 168=7d, 720=30d). Default 168. Clamped to [1, 720].
 //   verdict: filter by verdict ('merge' | 'keep' | 'uncertain').
-//   source:  filter by source ('judge-agent' | 'inline').
+//   source:  filter by source ('judge-agent' | 'inline' | 'manual').
 //   limit:   max rows returned. Default 100, max 500.
 //
 // Response:
@@ -29,7 +29,7 @@ const MAX_LIMIT = 500
 const DEFAULT_HOURS = 168
 const MAX_HOURS = 720 // 30 days
 const VALID_VERDICTS = new Set(['merge', 'keep', 'uncertain'])
-const VALID_SOURCES = new Set(['judge-agent', 'inline'])
+const VALID_SOURCES = new Set(['judge-agent', 'inline', 'manual'])
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/admin-judge-log/index.ts
+++ b/supabase/functions/admin-judge-log/index.ts
@@ -5,10 +5,12 @@
 //
 // POST /admin-judge-log
 // Body (all optional):
-//   hours:   time window (24, 168=7d, 720=30d). Default 168. Clamped to [1, 720].
-//   verdict: filter by verdict ('merge' | 'keep' | 'uncertain').
-//   source:  filter by source ('judge-agent' | 'inline' | 'manual').
-//   limit:   max rows returned. Default 100, max 500.
+//   hours:    time window (24, 168=7d, 720=30d). Default 168. Clamped to [1, 720].
+//   verdict:  filter by verdict ('merge' | 'keep' | 'uncertain' | 'unmerge').
+//   source:   filter by source ('judge-agent' | 'inline' | 'manual').
+//   story_id: return only verdicts touching this story (story_id_a OR story_id_b).
+//             Ignores the time window — an old merge must always be findable (ADO-537 UX).
+//   limit:    max rows returned. Default 100, max 500.
 //
 // Response:
 //   {
@@ -68,6 +70,9 @@ Deno.serve(async (req) => {
     const sourceFilter = sourceRaw && VALID_SOURCES.has(sourceRaw) ? sourceRaw : null
     const limitRaw = parseInt(pick('limit') || String(DEFAULT_LIMIT), 10)
     const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(MAX_LIMIT, limitRaw)) : DEFAULT_LIMIT
+    const storyIdRaw = pick('story_id')
+    const storyIdParsed = storyIdRaw != null ? parseInt(storyIdRaw, 10) : NaN
+    const storyIdFilter = Number.isSafeInteger(storyIdParsed) && storyIdParsed > 0 ? storyIdParsed : null
 
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
@@ -76,14 +81,17 @@ Deno.serve(async (req) => {
 
     const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
 
-    // Aggregation query (verdict + merged only, for fast counts)
+    // Aggregation query (verdict + merged only, for fast counts).
+    // A story_id search ignores the time cutoff: its whole point is finding the old merge
+    // that ate a story, and that merge may be far outside any selectable window.
     let aggQuery = supabase
       .from('clustering_judge_log')
       .select('verdict,merged')
-      .gte('created_at', cutoff)
       .order('created_at', { ascending: false })
       .limit(MAX_AGGREGATION_ROWS)
 
+    if (!storyIdFilter) aggQuery = aggQuery.gte('created_at', cutoff)
+    if (storyIdFilter) aggQuery = aggQuery.or(`story_id_a.eq.${storyIdFilter},story_id_b.eq.${storyIdFilter}`)
     if (verdictFilter) aggQuery = aggQuery.eq('verdict', verdictFilter)
     if (sourceFilter) aggQuery = aggQuery.eq('source', sourceFilter)
 
@@ -91,10 +99,11 @@ Deno.serve(async (req) => {
     let rowsQuery = supabase
       .from('clustering_judge_log')
       .select('id,source,story_id_a,story_id_b,headline_a,headline_b,verdict,confidence,rationale,centroid_sim,merged,dry_run,run_id,created_at')
-      .gte('created_at', cutoff)
       .order('created_at', { ascending: false })
       .limit(limit)
 
+    if (!storyIdFilter) rowsQuery = rowsQuery.gte('created_at', cutoff)
+    if (storyIdFilter) rowsQuery = rowsQuery.or(`story_id_a.eq.${storyIdFilter},story_id_b.eq.${storyIdFilter}`)
     if (verdictFilter) rowsQuery = rowsQuery.eq('verdict', verdictFilter)
     if (sourceFilter) rowsQuery = rowsQuery.eq('source', sourceFilter)
 
@@ -134,7 +143,7 @@ Deno.serve(async (req) => {
       total_count: aggRows.length,
       merged_count: mergedCount,
       truncated: aggRows.length >= MAX_AGGREGATION_ROWS,
-      filters: { verdict: verdictFilter, source: sourceFilter },
+      filters: { verdict: verdictFilter, source: sourceFilter, story_id: storyIdFilter },
       by_verdict: byVerdict,
       rows: rowsResult.data || [],
       timestamp: new Date().toISOString()

--- a/supabase/functions/admin-judge-merge/index.ts
+++ b/supabase/functions/admin-judge-merge/index.ts
@@ -1,0 +1,157 @@
+// Edge Function: admin-judge-merge
+// Executes an admin-initiated (manual) story merge from the Admin Dashboard "Judge" tab.
+// ADO-537: human override for uncertain/missed Judge verdicts. Mirrors admin-judge-log
+// (service_role, password-gated) so nothing here needs an anon grant.
+//
+// POST /admin-judge-merge
+// Body:
+//   action:      'preview' | 'merge' (required)
+//   survivor_id: story id that keeps the articles (required, positive integer)
+//   loser_id:    story id that gets tombstoned into the survivor (required, positive integer)
+//
+// preview response: { ok, survivor: {...}, loser: {...}, warnings: [...] }
+// merge response:   { ok, skipped?, reason?, run_id, articles_moved?, survivor_source_count?, log_error? }
+//
+// The merge itself is the hardened merge_stories RPC (migrations 100/101/102): row-locked,
+// per-run hard-capped, snapshotted to story_merge_audit, loser tombstoned (never deleted).
+// Each manual merge uses a fresh run_id ('manual-admin-<ts>') so the per-run cap of 10 never
+// throttles a legitimate one-off action while the DB-side guard still applies.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+import { checkAdminPassword } from '../_shared/auth.ts'
+
+const STORY_FIELDS = 'id,primary_headline,status,source_count,merged_into_story_id,first_seen_at,last_updated_at'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(
+    JSON.stringify(body),
+    { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+  )
+}
+
+function parseStoryId(value: unknown): number | null {
+  const n = Number(value)
+  if (!Number.isSafeInteger(n) || n <= 0) return null
+  return n
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    if (!checkAdminPassword(req)) {
+      return jsonResponse({ error: 'Unauthorized' }, 401)
+    }
+    if (req.method !== 'POST') {
+      return jsonResponse({ error: 'POST only' }, 405)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      const text = await req.text()
+      body = text ? JSON.parse(text) : {}
+    } catch (_) {
+      return jsonResponse({ error: 'Invalid JSON body' }, 400)
+    }
+
+    const action = String(body.action || '').trim()
+    const survivorId = parseStoryId(body.survivor_id)
+    const loserId = parseStoryId(body.loser_id)
+
+    if (action !== 'preview' && action !== 'merge') {
+      return jsonResponse({ error: "action must be 'preview' or 'merge'" }, 400)
+    }
+    if (survivorId == null || loserId == null) {
+      return jsonResponse({ error: 'survivor_id and loser_id must be positive integers' }, 400)
+    }
+    if (survivorId === loserId) {
+      return jsonResponse({ error: 'survivor_id and loser_id must be different stories' }, 400)
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    // Both actions need the two story rows: preview displays them; merge snapshots the
+    // headlines for the clustering_judge_log row (headlines survive the merge unchanged,
+    // but reading first keeps the log write independent of post-merge state).
+    const { data: stories, error: fetchError } = await supabase
+      .from('stories')
+      .select(STORY_FIELDS)
+      .in('id', [survivorId, loserId])
+
+    if (fetchError) {
+      console.error('Story fetch failed:', fetchError.message)
+      return jsonResponse({ error: 'Story lookup failed' }, 500)
+    }
+
+    const survivor = (stories || []).find((s) => s.id === survivorId) || null
+    const loser = (stories || []).find((s) => s.id === loserId) || null
+
+    if (action === 'preview') {
+      const warnings: string[] = []
+      if (!survivor) warnings.push(`Survivor story #${survivorId} not found`)
+      if (!loser) warnings.push(`Loser story #${loserId} not found`)
+      if (survivor?.status === 'merged_into') {
+        warnings.push(`Survivor #${survivorId} is already merged into #${survivor.merged_into_story_id} — merge will be refused; target that story instead`)
+      }
+      if (loser?.status === 'merged_into') {
+        warnings.push(`Loser #${loserId} was already merged into #${loser.merged_into_story_id} — merge will be a no-op`)
+      }
+      return jsonResponse({ ok: !!(survivor && loser), survivor, loser, warnings })
+    }
+
+    // action === 'merge'
+    if (!survivor || !loser) {
+      return jsonResponse({ ok: false, reason: !survivor ? 'survivor_not_found' : 'loser_not_found' })
+    }
+
+    const runId = `manual-admin-${Date.now()}`
+    const { data: result, error: rpcError } = await supabase.rpc('merge_stories', {
+      p_loser_id: loserId,
+      p_survivor_id: survivorId,
+      p_run_id: runId
+    })
+
+    if (rpcError) {
+      console.error('merge_stories RPC failed:', rpcError.message)
+      return jsonResponse({ error: 'Merge failed', detail: rpcError.message }, 500)
+    }
+
+    // merge_stories returns business failures as { ok:false, reason } — pass through untouched.
+    if (!result?.ok || result?.skipped) {
+      return jsonResponse({ ...result, run_id: runId })
+    }
+
+    // Log the executed merge so the Judge tab shows it (source='manual', migration 104).
+    // The merge is already committed; a log failure must not fail the request.
+    const { error: logError } = await supabase.from('clustering_judge_log').insert({
+      source: 'manual',
+      story_id_a: survivorId,
+      story_id_b: loserId,
+      headline_a: survivor.primary_headline,
+      headline_b: loser.primary_headline,
+      verdict: 'merge',
+      rationale: `Manual merge via admin Judge tab: #${loserId} merged into #${survivorId}`,
+      merged: true,
+      dry_run: false,
+      run_id: runId
+    })
+    if (logError) {
+      console.error('clustering_judge_log insert failed (merge already executed):', logError.message)
+    }
+
+    return jsonResponse({
+      ...result,
+      run_id: runId,
+      log_error: logError ? logError.message : undefined
+    })
+  } catch (error) {
+    console.error('Error in admin-judge-merge:', error)
+    return jsonResponse({ error: 'Internal server error' }, 500)
+  }
+})

--- a/supabase/functions/admin-judge-merge/index.ts
+++ b/supabase/functions/admin-judge-merge/index.ts
@@ -5,12 +5,17 @@
 //
 // POST /admin-judge-merge
 // Body:
-//   action:      'preview' | 'merge' (required)
+//   action:      'preview' | 'merge' | 'unmerge' (required)
 //   survivor_id: story id that keeps the articles (required, positive integer)
 //   loser_id:    story id that gets tombstoned into the survivor (required, positive integer)
 //
+// For 'unmerge' the two ids are just "the pair" — the function resolves which one is actually
+// tombstoned into the other (agent-sourced log rows don't guarantee which column was the loser)
+// and reverses that merge via the unmerge_story RPC (migration 105).
+//
 // preview response: { ok, survivor: {...}, loser: {...}, warnings: [...] }
 // merge response:   { ok, skipped?, reason?, run_id, articles_moved?, survivor_source_count?, log_error? }
+// unmerge response: { ok, reason?, run_id, loser_id?, survivor_id?, articles_restored?, log_error? }
 //
 // The merge itself is the hardened merge_stories RPC (migrations 100/101/102): row-locked,
 // per-run hard-capped, snapshotted to story_merge_audit, loser tombstoned (never deleted).
@@ -61,8 +66,8 @@ Deno.serve(async (req) => {
     const survivorId = parseStoryId(body.survivor_id)
     const loserId = parseStoryId(body.loser_id)
 
-    if (action !== 'preview' && action !== 'merge') {
-      return jsonResponse({ error: "action must be 'preview' or 'merge'" }, 400)
+    if (action !== 'preview' && action !== 'merge' && action !== 'unmerge') {
+      return jsonResponse({ error: "action must be 'preview', 'merge' or 'unmerge'" }, 400)
     }
     if (survivorId == null || loserId == null) {
       return jsonResponse({ error: 'survivor_id and loser_id must be positive integers' }, 400)
@@ -103,6 +108,55 @@ Deno.serve(async (req) => {
         warnings.push(`Loser #${loserId} was already merged into #${loser.merged_into_story_id} — merge will be a no-op`)
       }
       return jsonResponse({ ok: !!(survivor && loser), survivor, loser, warnings })
+    }
+
+    if (action === 'unmerge') {
+      // Resolve which of the pair is actually the tombstoned loser (don't trust column order).
+      const a = survivor
+      const b = loser
+      let actualLoser = null
+      if (a && a.status === 'merged_into' && a.merged_into_story_id === b?.id) actualLoser = a
+      else if (b && b.status === 'merged_into' && b.merged_into_story_id === a?.id) actualLoser = b
+      if (!actualLoser) {
+        return jsonResponse({ ok: false, reason: 'not_merged_pair' })
+      }
+      const actualSurvivor = actualLoser === a ? b : a
+
+      const runId = `manual-admin-${Date.now()}`
+      const { data: result, error: rpcError } = await supabase.rpc('unmerge_story', {
+        p_loser_id: actualLoser.id,
+        p_run_id: runId
+      })
+      if (rpcError) {
+        console.error('unmerge_story RPC failed:', rpcError.message)
+        return jsonResponse({ error: 'Unmerge failed', detail: rpcError.message }, 500)
+      }
+      if (!result?.ok) {
+        return jsonResponse({ ...result, run_id: runId })
+      }
+
+      // Log the reversal (verdict='unmerge', migration 105). Non-fatal, same as merge logging.
+      const { error: logError } = await supabase.from('clustering_judge_log').insert({
+        source: 'manual',
+        story_id_a: actualSurvivor?.id ?? result.survivor_id,
+        story_id_b: actualLoser.id,
+        headline_a: actualSurvivor?.primary_headline ?? null,
+        headline_b: actualLoser.primary_headline,
+        verdict: 'unmerge',
+        rationale: `Manual unmerge via admin Judge tab: #${actualLoser.id} restored from #${result.survivor_id}`,
+        merged: false,
+        dry_run: false,
+        run_id: runId
+      })
+      if (logError) {
+        console.error('clustering_judge_log insert failed (unmerge already executed):', logError.message)
+      }
+
+      return jsonResponse({
+        ...result,
+        run_id: runId,
+        log_error: logError ? logError.message : undefined
+      })
     }
 
     // action === 'merge'


### PR DESCRIPTION
## Summary
Promotes the ADO-537 admin Judge tab manual merge + unmerge to PROD. Human override for a wrong
Clustering Judge merge — the prerequisite safety net for the ADO-531 backfill. Also includes the
Judge-tab story-id search (find every verdict touching a story, any age).

## Deploy order (LOAD-BEARING — do not merge this PR first)
1. Apply `migrations/104_manual_merge_source.sql` in the PROD SQL Editor
2. Apply `migrations/105_unmerge_story.sql` in the PROD SQL Editor (ends with `NOTIFY pgrst, 'reload schema'`)
3. `npx supabase functions deploy admin-judge-merge --project-ref osjbulmltfpcoldydexg`
   and redeploy `admin-judge-log` (its VALID_VERDICTS gained `unmerge` + new story_id filter)
4. Merge this PR (ships `public/admin.html` via Netlify)

Merging before step 1 leaves manual merges executing with no Judge-tab audit row.

## Verified on TEST (2026-08-03)
Full merge → unmerge round trip through the admin UI on stories 17024/17022:
2 articles moved on merge, 2 restored on unmerge — `article_story` membership identical
article-for-article to the pre-merge baseline, tombstone cleared, both stories' source_count
recomputed (5→3/2), audit snapshot consumed (`unmerged_at` set), `manual`/`merge` +
`manual`/`unmerge` log rows written, double-unmerge refused (`not_merged_pair` guard).
Security: `unmerge_story` + `recompute_story_from_members` verified `anon=f, authenticated=f,
service_role=t`. `npm run qa:smoke` green (all 7 sub-suites).

## Cost
$0 — no new infra, API calls, or secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
