### PR TITLE
fix(ado-551): normalize SCOTUS disposition values (GVR->gvr, stage-aware labels)

### DIFF
--- a/docs/features/scotus-claude-agent/prompt-v1.md
+++ b/docs/features/scotus-claude-agent/prompt-v1.md
@@ -233,7 +233,7 @@ For each case, read the opinion text and produce ALL of the following fields. Us
 
 | Field | Type | Constraints | How to determine |
 |-------|------|-------------|------------------|
-| `disposition` | text | Must be one of: `affirmed`, `reversed`, `vacated`, `remanded`, `reversed_and_remanded`, `vacated_and_remanded`, `affirmed_and_remanded`, `dismissed`, `granted`, `denied`, `GVR`, `other` | Read the judgment line (usually near the end of the syllabus or opinion) |
+| `disposition` | text | Must be one of: `affirmed`, `reversed`, `vacated`, `remanded`, `reversed_and_remanded`, `vacated_and_remanded`, `affirmed_and_remanded`, `dismissed`, `granted`, `denied`, `gvr`, `other` | Read the judgment line (usually near the end of the syllabus or opinion) |
 | `holding` | text | 1-3 sentences | The Court's central legal conclusion |
 | `vote_split` | text | Format: `N-N` (e.g., `9-0`, `5-4`) | Count majority vs dissenting justices |
 | `majority_author` | text or null | Last name only (e.g., `Jackson`, `Thomas`) | Listed at the top of the majority opinion. `null` for per curiam opinions. |
@@ -248,7 +248,7 @@ For each case, read the opinion text and produce ALL of the following fields. Us
 - "Reversed and remanded" → `reversed_and_remanded`
 - "Vacated and remanded" → `vacated_and_remanded`
 - "Affirmed in part, reversed in part, and remanded" → `affirmed_and_remanded`
-- "Granted, vacated, and remanded" (GVR) → `GVR`
+- "Granted, vacated, and remanded" (GVR) → `gvr`
 
 **Editorial fields** (quality matters  - these calibrate against gold set examples):
 

--- a/docs/handoffs/2026-08-19-ado-551-scotus-disposition-normalization.md
+++ b/docs/handoffs/2026-08-19-ado-551-scotus-disposition-normalization.md
@@ -14,14 +14,17 @@ Built directly on the audit in ADO-551's newest comment (2026-08-19) — did NOT
    "Cert Granted/Denied" for `case_type=cert_stage` and "Application Granted/Denied" for `shadow_docket`.
    `gvr` renders "Granted, Vacated & Remanded (GVR)". Legacy `'GVR'` input still accepted until migration 109
    is applied. Unknown values humanize (underscores → spaces) instead of leaking snake_case.
-2. **`migrations/109_scotus_disposition_gvr_normalize.sql`** — NOT APPLIED (DDL is Josh's). Drops the 087
-   CHECK, `UPDATE ... SET disposition='gvr' WHERE disposition='GVR'` (PROD ids 1906, 2051; TEST has none),
-   re-adds CHECK with `gvr` replacing `GVR`. Idempotent. Apply order matters: migration BEFORE deploying
-   'gvr'-writing code to PROD (header comment spells it out).
+2. **`migrations/109_scotus_disposition_gvr_normalize.sql`** — NOT APPLIED (DDL is Josh's). Single
+   transaction with an explicit ACCESS EXCLUSIVE lock (Codex review fix): drops the 087 CHECK,
+   `UPDATE ... SET disposition='gvr' WHERE disposition='GVR'` (PROD ids 1906, 2051; TEST has none), re-adds
+   CHECK with `gvr` replacing `GVR`. Idempotent; a failure rolls the whole swap back. Apply order matters:
+   migration BEFORE deploying 'gvr'-writing code to PROD (header comment spells it out).
 3. **`public/admin.html`** — SCOTUS disposition dropdown value `GVR` → `gvr` (label unchanged).
-4. **`supabase/functions/admin-update-scotus/index.ts`** — VALID_DISPOSITIONS now has BOTH `gvr` and legacy
-   `GVR` (transition-safe; drop `GVR` after 109 is applied on PROD). **Edge function NOT redeployed** — deploy
-   to TEST with: `supabase functions deploy admin-update-scotus --project-ref wnrjrywpcadwutfykflu`.
+4. **`supabase/functions/admin-update-scotus/index.ts`** — legacy `GVR` input is NORMALIZED to `gvr` before
+   validation/persistence (Codex review fix — accepting both would have let `GVR` pass validation then fail
+   the post-109 DB CHECK); VALID_DISPOSITIONS lists only `gvr`. **Edge function NOT redeployed** — after
+   migration 109 is applied on TEST, deploy with:
+   `supabase functions deploy admin-update-scotus --project-ref wnrjrywpcadwutfykflu`.
 5. **`scripts/scotus/syllabus-extractor.js`** + its fixture test — emits `gvr` now (Scout is dormant: no
    workflow runs it, only its own test imports it).
 6. **`docs/features/scotus-claude-agent/prompt-v1.md`** (agent allow-list, lines 236/251) +

--- a/docs/handoffs/2026-08-19-ado-551-scotus-disposition-normalization.md
+++ b/docs/handoffs/2026-08-19-ado-551-scotus-disposition-normalization.md
@@ -1,0 +1,61 @@
+# 2026-08-19 — ADO-551: SCOTUS disposition normalization (overnight autonomous run)
+
+**Ticket:** ADO-551 (User Story, moved to Testing)
+**Branch:** test (pushed)
+**Session mode:** fully autonomous overnight run (with ADO-550 in the same session)
+
+## What was done
+
+Built directly on the audit in ADO-551's newest comment (2026-08-19) — did NOT re-audit, per instruction.
+
+1. **`src/lib/adapter.ts`** — new `DISPOSITION_LABELS` map + exported `formatDisposition(disposition, caseType)`.
+   Replaces the naive first-letter-cap at the old line 350 that rendered "Reversed_and_remanded" on detail
+   pages (the bug Josh saw). Context-aware labels for the stage-mixed values: `granted`/`denied` render as
+   "Cert Granted/Denied" for `case_type=cert_stage` and "Application Granted/Denied" for `shadow_docket`.
+   `gvr` renders "Granted, Vacated & Remanded (GVR)". Legacy `'GVR'` input still accepted until migration 109
+   is applied. Unknown values humanize (underscores → spaces) instead of leaking snake_case.
+2. **`migrations/109_scotus_disposition_gvr_normalize.sql`** — NOT APPLIED (DDL is Josh's). Drops the 087
+   CHECK, `UPDATE ... SET disposition='gvr' WHERE disposition='GVR'` (PROD ids 1906, 2051; TEST has none),
+   re-adds CHECK with `gvr` replacing `GVR`. Idempotent. Apply order matters: migration BEFORE deploying
+   'gvr'-writing code to PROD (header comment spells it out).
+3. **`public/admin.html`** — SCOTUS disposition dropdown value `GVR` → `gvr` (label unchanged).
+4. **`supabase/functions/admin-update-scotus/index.ts`** — VALID_DISPOSITIONS now has BOTH `gvr` and legacy
+   `GVR` (transition-safe; drop `GVR` after 109 is applied on PROD). **Edge function NOT redeployed** — deploy
+   to TEST with: `supabase functions deploy admin-update-scotus --project-ref wnrjrywpcadwutfykflu`.
+5. **`scripts/scotus/syllabus-extractor.js`** + its fixture test — emits `gvr` now (Scout is dormant: no
+   workflow runs it, only its own test imports it).
+6. **`docs/features/scotus-claude-agent/prompt-v1.md`** (agent allow-list, lines 236/251) +
+   **`docs/reference/scotus-agent.md`** — `GVR` → `gvr`. Prompt change reaches the live PROD agent only after
+   cherry-pick to main; migration 109 must be applied on PROD FIRST (deploy-order rule in memory).
+
+## Deliberately NOT done
+
+- **The 10 PROD null-disposition rows** (ids 1, 296–304, Jan-2020 backfill artifacts incl. duplicate
+  "In re Raghubir" 297/298): untouched per audit. **Josh decides hide vs delete.**
+- **The 5 PROD `other` rows:** legitimate per audit crosstab (4 shadow_docket + 1 procedural), left as-is.
+- **`public/app.js` titleCase** (same snake_case bug): only used by `dashboard-legacy.html`, superseded page —
+  skipped, not worth touching.
+- **`docs/features/scotus-qa/gold-set-changelog.json`** mentions `GVR` in a historical inclusion-rule record —
+  it is history, not consumed by code (only referenced in old handoffs), left unmodified.
+- **TEST DML:** none needed — TEST has zero `GVR` rows (verified via supabase-test MCP). TEST's 5 bare
+  `vacated` rows are already valid enum values (087 CHECK always allowed `vacated`), kept in the enum.
+
+## Validation
+
+- Two-pass inline review done by main session (subagents banned): pattern pass + production-readiness pass.
+  Findings addressed inline (transition window handling in edge fn; idempotency of migration).
+- `npx vitest run`: 121/121 passed (incl. 6 new `formatDisposition` tests + detail-meta label assertion).
+- `node scripts/tests/scout-crosscheck-fixtures.mjs`: 20/20 passed.
+- `npm run qa:smoke`: all suites green (boundaries, integration, idempotency, concurrency, silent-skips,
+  eo-admin-unit, clustering-eval, judge-dryrun 122/122).
+
+## To verify / for Josh (morning)
+
+1. Apply `migrations/109_scotus_disposition_gvr_normalize.sql` on TEST (SQL Editor), verify
+   `SELECT count(*) FROM scotus_cases WHERE disposition='GVR'` → 0. PROD apply happens at next PROD deploy,
+   BEFORE cherry-picking this commit to main.
+2. Deploy `admin-update-scotus` edge function to TEST (command above).
+3. Decide: hide vs delete the 10 PROD null-disposition rows (they are `is_public=true` and render with no
+   disposition today).
+4. Spot-check a SCOTUS detail page on the TEST site: disposition should read "Reversed & Remanded" style,
+   and a shadow-docket granted case should read "Application Granted".

--- a/docs/reference/scotus-agent.md
+++ b/docs/reference/scotus-agent.md
@@ -33,7 +33,7 @@ cutover it has enriched **116/116 cases with 0 failures**.
 For each case it produces a full enrichment and writes it in one atomic update:
 
 - **Fact fields** (kept neutral and precise): `disposition` (from a fixed enum including compound forms
-  like `reversed_and_remanded` and `GVR`), `vote_split` (`N-N`), `majority_author`, `dissent_authors`,
+  like `reversed_and_remanded` and `gvr`), `vote_split` (`N-N`), `majority_author`, `dissent_authors`,
   `holding`, `case_type`, `prevailing_party`, and the merits/dissent booleans.
 - **Editorial fields** (written in "The Betrayal" voice): `summary_spicy`, `why_it_matters`,
   `who_wins` / `who_loses`, `ruling_label`, `ruling_impact_level` (0-5), `dissent_highlights`,

--- a/migrations/109_scotus_disposition_gvr_normalize.sql
+++ b/migrations/109_scotus_disposition_gvr_normalize.sql
@@ -1,0 +1,31 @@
+-- Migration 109: Normalize SCOTUS disposition 'GVR' -> 'gvr' (ADO-551)
+-- GVR broke the snake_case convention used by every other disposition value.
+-- Data fix + CHECK constraint swap. Idempotent — safe to re-run.
+--
+-- APPLY ORDER (matters on PROD):
+--   1. Apply this migration FIRST (SQL Editor, TEST then PROD).
+--   2. Then deploy code that writes 'gvr' (admin.html dropdown, admin-update-scotus
+--      edge function, SCOTUS agent prompt allow-list) — the old CHECK rejects 'gvr'.
+-- PROD rows affected by the UPDATE: ids 1906, 2051 (audited 2026-08-19). TEST: none.
+-- The 10 PROD null-disposition rows (ids 1, 296-304) are deliberately NOT touched —
+-- Josh decides hide vs delete separately.
+
+-- Step 1: drop the old constraint so the data update can't race it
+ALTER TABLE scotus_cases
+DROP CONSTRAINT IF EXISTS scotus_cases_disposition_check;
+
+-- Step 2: normalize existing data
+UPDATE scotus_cases SET disposition = 'gvr' WHERE disposition = 'GVR';
+
+-- Step 3: re-add the constraint with the canonical snake_case enum
+-- (same values as migration 087 except 'GVR' -> 'gvr'; NULL still allowed)
+ALTER TABLE scotus_cases
+ADD CONSTRAINT scotus_cases_disposition_check
+  CHECK (disposition IS NULL OR disposition IN (
+    'affirmed', 'reversed', 'vacated', 'remanded',
+    'reversed_and_remanded', 'vacated_and_remanded', 'affirmed_and_remanded',
+    'dismissed', 'granted', 'denied', 'gvr', 'other'
+  ));
+
+-- Verify (expect 0):
+-- SELECT count(*) FROM scotus_cases WHERE disposition = 'GVR';

--- a/migrations/109_scotus_disposition_gvr_normalize.sql
+++ b/migrations/109_scotus_disposition_gvr_normalize.sql
@@ -10,6 +10,13 @@
 -- The 10 PROD null-disposition rows (ids 1, 296-304) are deliberately NOT touched —
 -- Josh decides hide vs delete separately.
 
+-- Single transaction: the ALTER's ACCESS EXCLUSIVE lock is held until COMMIT,
+-- so no concurrent write can land between the drop and the re-add, and a
+-- failure anywhere rolls the whole swap back (table never left unconstrained).
+BEGIN;
+
+LOCK TABLE scotus_cases IN ACCESS EXCLUSIVE MODE;
+
 -- Step 1: drop the old constraint so the data update can't race it
 ALTER TABLE scotus_cases
 DROP CONSTRAINT IF EXISTS scotus_cases_disposition_check;
@@ -26,6 +33,8 @@ ADD CONSTRAINT scotus_cases_disposition_check
     'reversed_and_remanded', 'vacated_and_remanded', 'affirmed_and_remanded',
     'dismissed', 'granted', 'denied', 'gvr', 'other'
   ));
+
+COMMIT;
 
 -- Verify (expect 0):
 -- SELECT count(*) FROM scotus_cases WHERE disposition = 'GVR';

--- a/public/admin.html
+++ b/public/admin.html
@@ -2388,7 +2388,7 @@
             { value: 'dismissed', label: 'Dismissed' },
             { value: 'granted', label: 'Granted' },
             { value: 'denied', label: 'Denied' },
-            { value: 'GVR', label: 'GVR (Grant, Vacate, Remand)' },
+            { value: 'gvr', label: 'GVR (Grant, Vacate, Remand)' },
             { value: 'other', label: 'Other' },
         ];
 

--- a/scripts/scotus/syllabus-extractor.js
+++ b/scripts/scotus/syllabus-extractor.js
@@ -101,7 +101,7 @@ export function extractDispositionFromSyllabus(opinionText) {
     if (judgmentIdx > 0) {
       const preceding = syllabusText.slice(Math.max(0, judgmentIdx - 200), judgmentIdx);
       if (/certiorari/i.test(preceding)) {
-        return { disposition: 'GVR', confidence: 'syllabus_deterministic', details: { line: chosen.lineText.trim(), gvr: true } };
+        return { disposition: 'gvr', confidence: 'syllabus_deterministic', details: { line: chosen.lineText.trim(), gvr: true } };
       }
     }
   }

--- a/scripts/tests/scout-crosscheck-fixtures.mjs
+++ b/scripts/tests/scout-crosscheck-fixtures.mjs
@@ -174,7 +174,7 @@ test('4. GVR detection', () => {
     ].join('\n'),
   });
   const result = extractDispositionFromSyllabus(text);
-  assert.equal(result.disposition, 'GVR');
+  assert.equal(result.disposition, 'gvr');
   assert.equal(result.confidence, 'syllabus_deterministic');
 });
 

--- a/src/__tests__/adapter-detail.test.ts
+++ b/src/__tests__/adapter-detail.test.ts
@@ -3,7 +3,46 @@ import {
   eoDetailToItem,
   scotusDetailToItem,
   pardonDetailToItem,
+  formatDisposition,
 } from '@/lib/adapter';
+
+describe('formatDisposition (ADO-551)', () => {
+  it('maps canonical enum values to display labels', () => {
+    expect(formatDisposition('affirmed')).toBe('Affirmed');
+    expect(formatDisposition('reversed_and_remanded')).toBe('Reversed & Remanded');
+    expect(formatDisposition('vacated_and_remanded')).toBe('Vacated & Remanded');
+    expect(formatDisposition('affirmed_and_remanded')).toBe('Affirmed & Remanded');
+    expect(formatDisposition('gvr')).toBe('Granted, Vacated & Remanded (GVR)');
+  });
+
+  it('accepts legacy GVR casing until migration 109 lands', () => {
+    expect(formatDisposition('GVR')).toBe('Granted, Vacated & Remanded (GVR)');
+  });
+
+  it('labels granted/denied by stage for cert and shadow docket cases', () => {
+    expect(formatDisposition('granted', 'cert_stage')).toBe('Cert Granted');
+    expect(formatDisposition('denied', 'cert_stage')).toBe('Cert Denied');
+    expect(formatDisposition('granted', 'shadow_docket')).toBe('Application Granted');
+    expect(formatDisposition('denied', 'shadow_docket')).toBe('Application Denied');
+    expect(formatDisposition('granted', 'merits')).toBe('Granted');
+    expect(formatDisposition('denied')).toBe('Denied');
+  });
+
+  it('case_type does not affect merits dispositions', () => {
+    expect(formatDisposition('reversed_and_remanded', 'merits')).toBe('Reversed & Remanded');
+    expect(formatDisposition('gvr', 'procedural')).toBe('Granted, Vacated & Remanded (GVR)');
+  });
+
+  it('humanizes unknown values instead of leaking raw snake_case', () => {
+    expect(formatDisposition('some_new_value')).toBe('Some new value');
+  });
+
+  it('returns empty string for null/empty', () => {
+    expect(formatDisposition(null)).toBe('');
+    expect(formatDisposition(undefined)).toBe('');
+    expect(formatDisposition('')).toBe('');
+  });
+});
 
 describe('eoDetailToItem', () => {
   const fullEo = {
@@ -74,7 +113,7 @@ describe('scotusDetailToItem', () => {
     case_type: 'merits',
     ruling_impact_level: 4,
     ruling_label: 'Major',
-    disposition: 'Reversed',
+    disposition: 'reversed_and_remanded',
     summary_spicy: 'A spicy SCOTUS take.',
     who_wins: 'The government',
     who_loses: 'Individual rights',
@@ -98,6 +137,7 @@ describe('scotusDetailToItem', () => {
     expect(labels).toContain('Term');
     expect(item.meta!.find(m => m.label === 'Dissenting')?.value).toBe('Sotomayor, Kagan, Jackson');
     expect(item.meta!.find(m => m.label === 'Citation')?.value).toBe('600 U.S. 100');
+    expect(item.meta!.find(m => m.label === 'Disposition')?.value).toBe('Reversed & Remanded');
   });
 
   it('skips null meta values', () => {

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -217,6 +217,41 @@ const SCOTUS_CASE_TYPES: Record<string, string> = {
   unclear: 'Unclear',
 };
 
+// Canonical disposition enum lives in the DB CHECK constraint (migration 109).
+// This is the display-label mapping for those values (ADO-551).
+const DISPOSITION_LABELS: Record<string, string> = {
+  affirmed: 'Affirmed',
+  reversed: 'Reversed',
+  vacated: 'Vacated',
+  remanded: 'Remanded',
+  reversed_and_remanded: 'Reversed & Remanded',
+  vacated_and_remanded: 'Vacated & Remanded',
+  affirmed_and_remanded: 'Affirmed & Remanded',
+  dismissed: 'Dismissed',
+  granted: 'Granted',
+  denied: 'Denied',
+  gvr: 'Granted, Vacated & Remanded (GVR)',
+  other: 'Other',
+};
+
+// granted/denied are cert-stage or emergency-application outcomes, not merits
+// dispositions — label them by stage so "Granted" never reads as a merits win.
+const DISPOSITION_LABELS_BY_CASE_TYPE: Record<string, Record<string, string>> = {
+  cert_stage: { granted: 'Cert Granted', denied: 'Cert Denied' },
+  shadow_docket: { granted: 'Application Granted', denied: 'Application Denied' },
+};
+
+export function formatDisposition(disposition: unknown, caseType?: unknown): string {
+  if (disposition == null || disposition === '') return '';
+  // Legacy rows may still carry 'GVR' until migration 109 is applied.
+  const key = String(disposition) === 'GVR' ? 'gvr' : String(disposition);
+  const contextual = DISPOSITION_LABELS_BY_CASE_TYPE[String(caseType)]?.[key];
+  if (contextual) return contextual;
+  if (DISPOSITION_LABELS[key]) return DISPOSITION_LABELS[key];
+  const humanized = key.replace(/_/g, ' ');
+  return humanized.charAt(0).toUpperCase() + humanized.slice(1);
+}
+
 export function scotusToItem(raw: Record<string, unknown>): DisplayItem {
   const sources: { label: string; url: string }[] = [];
   if (raw.source_url) sources.push({ label: 'Opinion', url: raw.source_url as string });
@@ -347,7 +382,8 @@ export function scotusDetailToItem(raw: Record<string, unknown>): DisplayItem {
   pushMeta(meta, 'Citation', raw.citation);
   pushMetaDate(meta, 'Decided', raw.decided_at);
   pushMetaDate(meta, 'Argued', raw.argued_at);
-  if (raw.disposition) meta.push({ label: 'Disposition', value: String(raw.disposition).charAt(0).toUpperCase() + String(raw.disposition).slice(1) });
+  const dispositionLabel = formatDisposition(raw.disposition, raw.case_type);
+  if (dispositionLabel) meta.push({ label: 'Disposition', value: dispositionLabel });
   pushMeta(meta, 'Vote', raw.vote_split);
   pushMeta(meta, 'Majority Opinion', raw.majority_author);
   const dissentAuthors = raw.dissent_authors;

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -29,8 +29,7 @@ const ALLOWED_FIELDS = [
 const VALID_DISPOSITIONS = [
   'affirmed', 'reversed', 'vacated', 'remanded',
   'reversed_and_remanded', 'vacated_and_remanded', 'affirmed_and_remanded',
-  // 'GVR' is legacy pre-migration-109 casing — drop it once 109 is applied on PROD
-  'dismissed', 'granted', 'denied', 'gvr', 'GVR', 'other',
+  'dismissed', 'granted', 'denied', 'gvr', 'other',
 ]
 const VALID_CASE_TYPES = ['merits', 'procedural', 'shadow_docket', 'cert_stage', 'unclear']
 const VALID_PREVAILING_PARTIES = ['petitioner', 'respondent', 'partial', 'unclear']
@@ -51,6 +50,11 @@ function jsonResponse(body: unknown, status: number) {
 function validateUpdates(sanitized: Record<string, unknown>): string | null {
   // Enum: disposition
   if ('disposition' in sanitized) {
+    // Legacy clients may still send pre-migration-109 casing; normalize so the
+    // persisted value always satisfies the DB CHECK constraint (ADO-551).
+    if (sanitized.disposition === 'GVR') {
+      sanitized.disposition = 'gvr'
+    }
     const v = sanitized.disposition
     if (v !== null && !VALID_DISPOSITIONS.includes(v as string)) {
       return `Invalid disposition. Must be one of: ${VALID_DISPOSITIONS.join(', ')}`

--- a/supabase/functions/admin-update-scotus/index.ts
+++ b/supabase/functions/admin-update-scotus/index.ts
@@ -29,7 +29,8 @@ const ALLOWED_FIELDS = [
 const VALID_DISPOSITIONS = [
   'affirmed', 'reversed', 'vacated', 'remanded',
   'reversed_and_remanded', 'vacated_and_remanded', 'affirmed_and_remanded',
-  'dismissed', 'granted', 'denied', 'GVR', 'other',
+  // 'GVR' is legacy pre-migration-109 casing — drop it once 109 is applied on PROD
+  'dismissed', 'granted', 'denied', 'gvr', 'GVR', 'other',
 ]
 const VALID_CASE_TYPES = ['merits', 'procedural', 'shadow_docket', 'cert_stage', 'unclear']
 const VALID_PREVAILING_PARTIES = ['petitioner', 'respondent', 'partial', 'unclear']


### PR DESCRIPTION
## ADO-551 — SCOTUS disposition normalization

Built from the audit on the ADO card (2026-08-19 comment). Full narrative: `docs/handoffs/2026-08-19-ado-551-scotus-disposition-normalization.md`

### Changes
- **`src/lib/adapter.ts`**: new `DISPOSITION_LABELS` map + `formatDisposition(disposition, caseType)` — fixes the raw `Reversed_and_remanded` rendering on detail pages; stage-aware labels for granted/denied (`Cert Granted/Denied` for cert_stage, `Application Granted/Denied` for shadow_docket); tolerates legacy `GVR` until migration 109 lands; humanizes unknown values.
- **`migrations/109_scotus_disposition_gvr_normalize.sql`** (NOT applied — Josh applies in SQL Editor): `UPDATE GVR->gvr` (PROD ids 1906, 2051; TEST has none) + CHECK constraint swap. Idempotent. **Apply order: migration BEFORE deploying gvr-writing code to PROD.**
- **`public/admin.html`**: disposition dropdown value `GVR` -> `gvr`.
- **`supabase/functions/admin-update-scotus`**: accepts both `gvr` and legacy `GVR` during transition (needs redeploy to TEST after merge).
- **`scripts/scotus/syllabus-extractor.js`** + fixture test: emits `gvr` (Scout is dormant; only its own test imports it).
- **SCOTUS agent prompt allow-list** (`prompt-v1.md`) + reference doc: `GVR` -> `gvr`. Reaches the live PROD agent only via cherry-pick to main, AFTER migration 109 is applied on PROD.

### Deliberately not done
- 10 PROD null-disposition rows (ids 1, 296-304) untouched — Josh decides hide vs delete.
- 5 PROD `other` rows are legitimate (audit crosstab).
- `public/app.js` titleCase has the same bug but only serves `dashboard-legacy.html` — skipped.

### Validation
121 vitest (6 new `formatDisposition` tests) + 20 scout fixtures + `npm run qa:smoke` all green. Two-pass inline review done.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)