### PR TITLE
fix(ado-545): month-day-year dates on the spine and everywhere else

### DIFF
--- a/src/__tests__/adapter-detail.test.ts
+++ b/src/__tests__/adapter-detail.test.ts
@@ -80,7 +80,7 @@ describe('eoDetailToItem', () => {
     const item = eoDetailToItem(fullEo);
     expect(item.meta).toBeDefined();
     expect(item.meta!.find(m => m.label === 'Executive Order')?.value).toBe('EO 14200');
-    expect(item.meta!.find(m => m.label === 'Signed')?.value).toBe('15 Mar 2025');
+    expect(item.meta!.find(m => m.label === 'Signed')?.value).toBe('Mar 15, 2025');
   });
 
   it('body and dek are empty (content in sections)', () => {
@@ -211,7 +211,7 @@ describe('pardonDetailToItem', () => {
 
   it('includes pardon date and crime in meta', () => {
     const item = pardonDetailToItem(fullPardon);
-    expect(item.meta!.find(m => m.label === 'Pardon Date')?.value).toBe('20 Jan 2025');
+    expect(item.meta!.find(m => m.label === 'Pardon Date')?.value).toBe('Jan 20, 2025');
     expect(item.meta!.find(m => m.label === 'Crime')?.value).toBe('white_collar');
     expect(item.meta!.find(m => m.label === 'Original Sentence')?.value).toBe('5 years federal prison');
   });

--- a/src/__tests__/date-utils.test.ts
+++ b/src/__tests__/date-utils.test.ts
@@ -3,15 +3,15 @@ import { fmtDate, relDate } from '@/lib/date-utils';
 
 describe('fmtDate', () => {
   it('formats date-only ISO string', () => {
-    expect(fmtDate('2026-04-14')).toBe('14 Apr 2026');
+    expect(fmtDate('2026-04-14')).toBe('Apr 14, 2026');
   });
 
   it('formats full ISO datetime', () => {
-    expect(fmtDate('2026-04-14T12:00:00Z')).toBe('14 Apr 2026');
+    expect(fmtDate('2026-04-14T12:00:00Z')).toBe('Apr 14, 2026');
   });
 
   it('formats another date correctly', () => {
-    expect(fmtDate('2026-01-01')).toBe('1 Jan 2026');
+    expect(fmtDate('2026-01-01')).toBe('Jan 1, 2026');
   });
 });
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,7 +101,7 @@ export function Footer() {
       </div>
       <div style={{ marginTop: 40, paddingTop: 20, borderTop: `1px solid ${theme.line}`, fontFamily: type.mono, fontSize: 10, color: theme.dim, display: 'flex', justifyContent: 'space-between', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
         <span>&copy; 2026 TrumpyTracker &middot; reader-supported</span>
-        <span>last updated: {new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
+        <span>last updated: {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</span>
       </div>
       <style>{`@media (max-width: 800px) { .tt-footer-grid { grid-template-columns: 1fr 1fr !important; } }`}</style>
     </footer>

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -12,7 +12,7 @@ export function Scorecard({ stats }: ScorecardProps) {
   const today = new Date();
   const weekStart = new Date(today);
   weekStart.setDate(today.getDate() - 6);
-  const fmt = (d: Date) => d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+  const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const cL5 = alarmPalette(5, 'restrained', mode, 'midnight');
   const cL4 = alarmPalette(4, 'restrained', mode, 'midnight');
 

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -342,7 +342,7 @@ function fmtMetaDate(val: unknown): string | null {
   const s = String(val);
   const d = new Date(s.includes('T') ? s : s + 'T00:00:00');
   if (isNaN(d.getTime())) return s;
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 function pushMeta(arr: { label: string; value: string }[], label: string, raw: unknown) {

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,6 +1,6 @@
 export function fmtDate(iso: string): string {
   const d = new Date(iso.includes('T') ? iso : iso + 'T00:00:00');
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 export function relDate(iso: string): string {


### PR DESCRIPTION
Follow-up to Josh's live-testing feedback on The Tracker: dates showed day-month-year ("19 Aug 2026"); he wants month-day-year ("Aug 19, 2026").

Changed all four formatters so the site is consistent: `fmtDate` in src/lib/date-utils.ts (spine entries, Home, Detail), `fmtMetaDate` in src/lib/adapter.ts (detail meta rows like Signed/Pardon Date), the Footer "last updated" stamp, and the Scorecard week range ("Aug 13 - Aug 19"). Spine month markers already said "August 2026" and are untouched. Test expectations updated to the new strings.

Validation: `npm run lint` clean, `npm run test:ui` 138/138. No data or logic changes - locale + option order only. Inline Codex review skipped per the trivial-change rule (format-only, 6 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)