### PR TITLE
docs(ado-546): schema doc gains the fronts tables + handoff wrap-up

### DIFF
--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -1,6 +1,6 @@
 # TrumpyTracker Database Schema
 
-**Last Updated:** 2026-04-15
+**Last Updated:** 2026-08-19 (fronts tables, migration 111)
 **Status:** RSS v2 system active on both TEST and PROD
 
 ---
@@ -260,6 +260,77 @@ VALUES (
 
 **RLS Policies:**
 - `pardon_story_anon_select` - Only show links to public pardons
+
+---
+
+## Fronts (Events) Tables
+
+Added by migration 111 (ADO-546, applied on TEST 2026-08-19). Schema keeps the neutral
+`events` naming; public copy says "fronts". Fronts are an aggregation layer above stories —
+articles are never linked to fronts. **No stored counters:** `v_event_stats` derives everything.
+Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
+
+### `events`
+**Purpose:** One row per front (editorial storyline container)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | BIGINT | Primary key (identity) |
+| slug | TEXT | UNIQUE, presentation only — never a join key |
+| name | TEXT | "The Epstein Files" |
+| dek | TEXT | One-paragraph standing summary |
+| alarm_level | SMALLINT | 0-5 editorial (displays everywhere); CHECK 0-5, default 3 |
+| tier | TEXT | CHECK: 'flagship', 'major', 'standard' |
+| lifecycle | TEXT | CHECK: 'open', 'dormant', 'resolved'; resolved requires resolved_at |
+| publish_state | TEXT | CHECK: 'draft', 'review', 'published'; published requires published_at |
+| published_at / started_at / resolved_at | TIMESTAMPTZ | Editorial timestamps |
+| created_by | TEXT | CHECK: 'agent', 'human' |
+| enrichment_meta | JSONB | AI provenance |
+| created_at / updated_at | TIMESTAMPTZ | updated_at via set_updated_at() trigger |
+
+**RLS:** `events_anon_select` — anon sees `publish_state='published'` only. Writes are service_role only.
+
+### `event_updates`
+**Purpose:** One row per editorial update on a front (AI-drafted or human-written, approval-gated)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | BIGINT | Primary key (identity) |
+| event_id | BIGINT | FK → events (CASCADE); UNIQUE (id, event_id) backs the same-front FK |
+| headline / body | TEXT | Editorial content |
+| happened_at | TIMESTAMPTZ | When the development occurred |
+| sort_key | BIGINT | Breaks happened_at ties |
+| significance | TEXT | CHECK: 'major', 'minor' |
+| approval_state | TEXT | CHECK: 'pending', 'approved', 'rejected'; decided states require decided_at + decided_by, pending forbids them |
+| decided_at / decided_by | TIMESTAMPTZ / TEXT | The human gate; decided_by CHECK 'agent'/'human' |
+| was_edited | BOOLEAN | Human edited the draft before approving (draft-quality metric) |
+| created_by | TEXT | CHECK: 'agent', 'human' |
+| enrichment_meta | JSONB | Provenance only, never queried |
+
+**RLS:** `event_updates_anon_select` — anon sees approved updates on published fronts only.
+
+### `story_event`
+**Purpose:** Story→front membership. **PK is `story_id` ALONE — one front per story** (mirrors article_story)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| story_id | BIGINT | **PK**, FK → stories (CASCADE) |
+| event_id | BIGINT | FK → events (CASCADE) |
+| event_update_id | BIGINT | FK → event_updates (SET NULL) + composite FK (event_update_id, event_id) → event_updates (id, event_id) — an update link must belong to the same front |
+| assigned_by | TEXT | CHECK: 'agent', 'human' |
+| confidence | NUMERIC | CHECK 0-1 or NULL |
+| assigned_at / reassigned_at | TIMESTAMPTZ | |
+| reassigned_from_event_id | BIGINT | FK → events (SET NULL); makes assignment precision measurable |
+
+**RLS:** `story_event_anon_select` — anon sees memberships of published fronts only.
+**Gotcha:** `merge_stories` does NOT repoint story_event (unlike article_story) — a member story merged away leaves the front counting a tombstone. Open Wave 2 decision.
+
+### `v_event_stats` (view)
+**Purpose:** All derived front stats — nothing derived is ever stored (PRD §6.5)
+
+`event_id, story_count, source_count (article_story rows across members), update_count (approved only), last_activity_at (max member story last_updated_at), peak_alarm (COALESCE(alarm_level, severity map, 2) — rubric/admin QA only, never displays), days_since_update (whole days since last approved update's happened_at)`
+
+`security_invoker = true` — anon reads inherit table RLS. GRANT SELECT to anon on all three tables + view (migration 046 auto-revoke countered).
 
 ---
 

--- a/docs/handoffs/2026-08-19-ado-546-fronts-data-layer.md
+++ b/docs/handoffs/2026-08-19-ado-546-fronts-data-layer.md
@@ -62,8 +62,37 @@ security advisor on TEST — expect no new findings.
 
 ## Next session
 
-- Add events/event_updates/story_event/v_event_stats to `docs/database/database-schema.md`
-  (111 is applied on TEST now, so the doc can describe live state).
-- Then ADO-547 (admin UI for fronts) unblocks; A1/A2 above may generate follow-ups.
-- Working-tree note: unrelated uncommitted edits to `index.html` + `src/styles/base.css`
-  existed before this session and were left untouched on `test`.
+- ~~Add the new relations to database-schema.md~~ — DONE later this session.
+- ADO-547 (admin fronts UI) is next; its card was rewritten as a full product card
+  (KPIs, scope, two added gaps: manual update-writing + tracker_pin/migration 112).
+- Working-tree note: unrelated uncommitted edits (`. claude/test-only-paths.md`,
+  `supabase/.temp/cli-latest`, untracked `.agents/`, `scripts/maintenance/`) pre-existed
+  and were left untouched on `test`.
+
+## Session continuation (same night, Josh interactive)
+
+The session kept going after the 546 build. In order:
+
+1. **Codex P1/P2 on PR #119** — both accepted; fixed as guarded ALTERs (PART H of 111):
+   same-front composite FK (additive, keeps single-column FK for ON DELETE SET NULL —
+   avoids PG15-only syntax) + state/timestamp CHECKs (published⇒published_at,
+   resolved⇒resolved_at, decided⇔decided_at+decided_by). Josh re-applied on TEST;
+   every constraint verified live with real rejected writes. P3 (stale handoff) fixed.
+2. **PR #119 squash-merged** → ADO-546 **Ready for Prod** (all 6 ACs verified).
+3. **PR #120** — site-wide month-day-year dates ("Aug 19, 2026"), Josh's live-review ask:
+   fmtDate, fmtMetaDate, Footer, Scorecard + test expectations. Merged. Codex skipped
+   per trivial-change rule.
+4. **ADO-550 pardons fix deployed to PROD** — PR #121 cherry-pick (aaf43a6 → main,
+   AI review pass), Track Pardons run triggered: **25 inserted, 0 errors**, backlog
+   recovered, tripwire live. **Closed.** Watch: 2 Perplexity validation errors
+   (receipts_timeline date null) — card it if the enrichment agent doesn't clear them.
+   New pardons render grey until the daily agent enriches (corruption_level null).
+5. **ADO cards 543-549 + 552 reformatted** — reader-standpoint titles, What/Where/
+   Technical descriptions, month-day-year dates. 547 upgraded to a full product card
+   (problem, KPIs from PRD §4.2, out-of-scope, and two scope gaps folded in: manual
+   update-writing for Wave 1 + tracker_pin overrides with a future migration 112).
+6. **544 + 545 → Ready for Prod** (Josh's live check passed). With 546, the whole
+   Tracker stack awaits one PROD deploy: cherry-picks to main + Josh applies 111 in
+   the PROD SQL Editor + rap_sheet flag flip after verify. Josh hasn't pulled the
+   trigger yet.
+7. **database-schema.md** gained the four fronts relations (this docs PR).


### PR DESCRIPTION
Docs only. Adds events / event_updates / story_event / v_event_stats to docs/database/database-schema.md (migration 111 is applied on TEST, so the doc now describes live state, including the Codex-round constraints and the merge_stories/story_event gotcha), and extends the session handoff with the post-build continuation (Codex fixes, merges, ADO-550 PROD deploy, card reformats, 544/545 Ready for Prod).

No code, no review needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)