### PR TITLE
feat(ado-554): The Tracker main line - curation rules, tracker_pin, 7 fronts

### DIFF
--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -344,14 +344,14 @@ Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
 | note | TEXT | Optional admin breadcrumb (why pinned) |
 | created_at / updated_at | TIMESTAMPTZ | updated_at via `set_updated_at()` trigger |
 
-**RLS:** anon SELECT-all policy (pins are public curation data — a force_shown row renders publicly). Writes service_role only. ADO-547 ships the admin editor.
+**RLS:** anon SELECT policy with a **column-level grant on `source`, `entity_id`, `pin` only** — pin existence is public curation data (a force_shown row renders publicly), but `note` is an admin breadcrumb and is NOT anon-readable. Writes service_role only. ADO-547 ships the admin editor.
 
 ### `v_tracker_stories` (view)
 **Purpose:** The Tracker spine's stories read path with the server-computed `main_line` rule (ADO-554, PRD §12 anchor principle)
 
 `id, primary_headline, first_seen_at, alarm_level, severity, front_id, front_name, front_slug, front_opening, tracker_pin, alarm_eff, main_line`
 
-**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND above the front's prior peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
+**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
 
 `security_invoker = true` — for anon, unpublished fronts' members count as loose ends (RLS hides the membership), by design. EO/SCOTUS/pardon rows have no front membership; the frontend applies their loose-end rule + pins client-side from `tracker_pin`.
 

--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -1,6 +1,6 @@
 # TrumpyTracker Database Schema
 
-**Last Updated:** 2026-08-19 (fronts tables, migration 111)
+**Last Updated:** 2026-08-23 (tracker_pin + v_tracker_stories, migration 112)
 **Status:** RSS v2 system active on both TEST and PROD
 
 ---
@@ -331,6 +331,29 @@ Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
 `event_id, story_count, source_count (article_story rows across members), update_count (approved only), last_activity_at (max member story last_updated_at), peak_alarm (COALESCE(alarm_level, severity map, 2) — rubric/admin QA only, never displays), days_since_update (whole days since last approved update's happened_at)`
 
 `security_invoker = true` — anon reads inherit table RLS. GRANT SELECT to anon on all three tables + view (migration 046 auto-revoke countered).
+
+### `tracker_pin`
+**Purpose:** Per-entry Tracker main-line override — optional hand-curation on top of the rule (ADO-554)
+**Migration:** `112_tracker_main_line.sql` (applied on TEST 2026-08-23)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| source | TEXT | PK part — `stories` / `eos` / `scotus` / `pardons` (CHECK) |
+| entity_id | TEXT | PK part — TEXT on purpose: EO ids are VARCHAR on PROD, INTEGER on TEST (migration 108 drift) |
+| pin | TEXT | `force_show` \| `force_hide` (CHECK) |
+| note | TEXT | Optional admin breadcrumb (why pinned) |
+| created_at / updated_at | TIMESTAMPTZ | updated_at via `set_updated_at()` trigger |
+
+**RLS:** anon SELECT-all policy (pins are public curation data — a force_shown row renders publicly). Writes service_role only. ADO-547 ships the admin editor.
+
+### `v_tracker_stories` (view)
+**Purpose:** The Tracker spine's stories read path with the server-computed `main_line` rule (ADO-554, PRD §12 anchor principle)
+
+`id, primary_headline, first_seen_at, alarm_level, severity, front_id, front_name, front_slug, front_opening, tracker_pin, alarm_eff, main_line`
+
+**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND above the front's prior peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
+
+`security_invoker = true` — for anon, unpublished fronts' members count as loose ends (RLS hides the membership), by design. EO/SCOTUS/pardon rows have no front membership; the frontend applies their loose-end rule + pins client-side from `tracker_pin`.
 
 ---
 

--- a/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
+++ b/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
@@ -1,0 +1,56 @@
+# Handoff — ADO-554: The Tracker main line (curation layer)
+
+**Date:** August 23, 2026
+**Ticket:** ADO-554 (new this session, sibling of 547 under epic 543) — Active → Testing
+**PR:** #127 `feature/ado-554-tracker-main-line` → `test`
+**Also this session:** ADO-544/545/546 closed as deployed-flag-off (Josh's standing instruction); ADO-547 AC6 re-scoped to the pin *editor* only, with a comment explaining the split.
+
+## Why this exists
+
+Josh's verdict on the PROD flag-off preview (August 23): the spine at alarm 4+ reads as **everything**, not the major-items main line. `rap_sheet` stays OFF on PROD until this ships — the flag flips once, debuting the curated Tracker. He asked for GENERALIZED anchor logic: rules decide the main line; he *can* hand-curate via `tracker_pin` but never *has* to.
+
+## The rule (v1) and where it came from
+
+Ground truth = Josh's 57 per-entry anchor flags in the rev-6 mockup (`.superpowers/brainstorm/events-homepage-v2/rap-sheet-w12-expand.html`, the `[date, alarm, headline, front, anchor]` rows). Analysis findings, so nobody re-derives them:
+
+- **Front openings:** all 7 fronts' first entries flagged 1 → mechanical rule, 7/7.
+- **Loose ends** (incl. every SCOTUS/EO/pardon row): flagged 1 iff alarm ≥ 4 → 18/19 (sole miss: "pardons a donor mid-trial", a4 flagged 0 — a routine recurrence; exactly what force_hide is for).
+- **Escalations:** NO mechanical rule reproduces them perfectly — "Gang of Eight skipped" (a5, flagged 0) vs "Fires the AG" (a5, flagged 1) are structurally identical; the difference is editorial. Best mechanical default: **alarm 5 OR new front peak at 4+** → 6/7 escalations, 5 over-inclusions all at alarm 5 (errs toward showing the worst — the safe direction; the alternatives would MISS "the Epstein files are released").
+- Net: **50/57 (88%) with zero curation.** Wave 2's drafter (`event_updates.significance='major'`) is the designed path to close the judgment gap; pins fix single rows meanwhile.
+
+```
+main_line(entry) =
+  force_show → in · force_hide → out
+  no published front → alarm_eff >= 4
+  front member → opening (earliest member) OR alarm_eff = 5
+                 OR (alarm_eff >= 4 AND > front prior peak)
+```
+
+## What shipped
+
+1. **Migration 112** (`migrations/112_tracker_main_line.sql`) — APPLIED on TEST (twice: idempotency proven):
+   - `tracker_pin` (PK source+entity_id; entity_id TEXT for the EO id drift). **Column-level anon grant on source/entity_id/pin only — `note` is admin-private** (AI-review blocker fix).
+   - `v_tracker_stories` (security_invoker): bakes in active+enriched, exposes front fields + `alarm_eff` + server-computed `main_line`. **Codex P1 fix: the opening/prior-peak window joins stories with the same active+enriched predicates** — merge tombstones in `story_event` can't hold the opening slot or suppress escalations.
+2. **`src/lib/timeline.ts`** — `TrackerView` ('main' | 0 | 3 | 5); stories read the view; `fetchTrackerPins` / `forceShowIdsBySource`; main mode drops force_hidden non-stories rows every page and injects force_shown rows (below the alarm-4 stream, first page only, no duplicates); `openFronts` tally.
+3. **`src/components/TrackerSpine.tsx`** — default segment **Main line**; front name renders as a row tag (nav lands with ADO-548); Open fronts tile; main-mode client alarm floor is 0 (server decided).
+4. **Seed data on TEST** (via supabase-test MCP, service_role): 7 published fronts (events ids 7–13: epstein-files, iran, trump-crypto, qatar-jet, selling-the-white-house, the-courts, kushners-deals — Kushner's has no members, no matching TEST stories), 27 story assignments, 2 demo pins (force_hide stories/14830 explainer; force_show eos/5 alarm-3 401(k) EO).
+5. **Docs:** database-schema.md Fronts section extended (tracker_pin + v_tracker_stories + the rule).
+
+## Verification done
+
+- vitest 146/146 (5 new pin/injection/main-mode tests), `tsc --noEmit` clean, vite build clean, `qa:smoke` exit 0.
+- Anon PostgREST: view + pins readable; `select=note` correctly 42501; main line = 414 story rows; open fronts = 7.
+- Live on localhost:3000 (TEST DB, chrome): Main line default with 7-fronts tally; Qatar's alarm-3 opening ON the line with front tag; Iran's 6 routine assigned a3/a4 rows OFF while its a5s stay tagged IRAN; unassigned Iran loose ends at 4+ still show (correct — not filed yet, that's 547's admin); force_shown EO appears at its Aug 2025 position; force_hidden explainer absent. Zero console errors.
+
+## Gotchas for next sessions
+
+- **PROD deploy order:** apply migration 112 BEFORE cherry-picking the code (stories fetch targets the view; missing view = no stories on the Tracker). Then seed PROD fronts + assignments, then flip `rap_sheet`.
+- Unassigned stories at alarm ≥ 4 stay on the main line as loose ends BY DESIGN — assignment coverage (ADO-547 admin / Wave 2 agent) is what makes fronts absorb their routine developments.
+- An unpublished front's members count as loose ends for anon (RLS hides membership) — a draft front can't change the public main line.
+- Applied DDL via claude-in-chrome → SQL Editor (Josh's session), fetching the SQL from raw.githubusercontent inside the page — the migration-111 pattern, worked again.
+
+## Open items
+
+- Josh eyeballs the TEST site (AC7) → then Ready for Prod.
+- ADO-547 (admin UI incl. pin editor) is the next build; 548 front pages give the front tags their navigation.
+- ADO-553 cohort verify is a separate queue item (6 pardons in needs_review — Josh works those in admin).

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -1,0 +1,184 @@
+-- Migration: 112_tracker_main_line.sql
+-- Purpose: The Tracker's curation layer (ADO-554, Epic ADO-543) — the "main line"
+--   inclusion rule from PRD §12's locked anchor principle, plus the tracker_pin
+--   override promised by the homepage design (rev 6, 2026-08-18).
+--
+--   A) tracker_pin       — per-entry force_show/force_hide across all four sources.
+--                          Hand-curation is OPTIONAL: the rule below decides the
+--                          main line; a pin only ever corrects a single row.
+--   B) v_tracker_stories — the spine's stories read path, with main_line computed
+--                          server-side:
+--                            pin override            → force_show in, force_hide out
+--                            no published front      → effective alarm >= 4 (loose end)
+--                            front member            → front opening (earliest member)
+--                                                      OR alarm 5
+--                                                      OR alarm >= 4 setting a new
+--                                                      front peak (escalation)
+--                          Routine developments on a front drop OFF the main line
+--                          and live on the front's own page (ADO-548).
+--
+-- EO/SCOTUS/pardon rows have no front membership today, so their main-line rule
+-- (loose end: alarm >= 4, plus pins) is applied by the frontend from the same
+-- tracker_pin table — no views needed for them.
+--
+-- Apply manually via the Supabase SQL Editor (NOT apply-migrations.js).
+-- DEPENDENCIES: migration 111 (events/story_event), set_updated_at() (migration 001).
+--
+-- SECURITY: migration 046 auto-revokes anon on new tables — explicit GRANTs below.
+-- Pins are public curation data by definition (a force_show row renders publicly),
+-- so anon gets a plain SELECT policy. Writes stay service_role-only (no anon or
+-- authenticated write policies). The view is security_invoker so anon reads
+-- through it inherit the RLS publish gates from migration 111 — an UNPUBLISHED
+-- front's members still count as loose ends for anon, which is the intended
+-- behavior (a draft front must not change the public main line).
+
+-- ============================================================================
+-- PART A: tracker_pin — per-entry main-line override, all four sources
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tracker_pin (
+  source     TEXT NOT NULL
+             CONSTRAINT tracker_pin_source_check
+             CHECK (source IN ('stories', 'eos', 'scotus', 'pardons')),
+  -- TEXT on purpose: EO ids are VARCHAR on PROD ('eo_<ts>_<suffix>') and INTEGER
+  -- on TEST (known drift, migration 108); stories/SCOTUS/pardons are numeric.
+  -- One table for all four sources beats four ALTER TABLEs and gives the admin
+  -- one place to list every pin (ADO-547 editor).
+  entity_id  TEXT NOT NULL,
+  pin        TEXT NOT NULL
+             CONSTRAINT tracker_pin_pin_check
+             CHECK (pin IN ('force_show', 'force_hide')),
+  note       TEXT,                                     -- optional admin breadcrumb (why pinned)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (source, entity_id)
+);
+
+COMMENT ON TABLE public.tracker_pin IS
+  'ADO-554: per-entry Tracker main-line override (force_show | force_hide) across stories/eos/scotus/pardons. Optional hand-curation on top of the rule in v_tracker_stories — never required for the main line to work. Written by admin (service_role); ADO-547 ships the editor.';
+
+DROP TRIGGER IF EXISTS trg_tracker_pin_set_updated_at ON public.tracker_pin;
+CREATE TRIGGER trg_tracker_pin_set_updated_at
+  BEFORE UPDATE ON public.tracker_pin
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.tracker_pin ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "tracker_pin_anon_select" ON public.tracker_pin;
+CREATE POLICY "tracker_pin_anon_select" ON public.tracker_pin
+  FOR SELECT TO anon
+  USING (true);
+
+GRANT SELECT ON public.tracker_pin TO anon;
+GRANT ALL    ON public.tracker_pin TO service_role;
+
+-- ============================================================================
+-- PART B: v_tracker_stories — spine read path with server-computed main_line
+-- ============================================================================
+
+-- security_invoker: anon reads hit the underlying tables' own RLS/grants.
+-- Anon holds SELECT on stories (046 re-grant), events/story_event (111,
+-- publish-gated), tracker_pin (above), so the joins resolve.
+CREATE OR REPLACE VIEW public.v_tracker_stories
+WITH (security_invoker = true) AS
+WITH front_members AS (
+  -- One row per member story of a PUBLISHED front, with the two front-relative
+  -- facts the rule needs: membership order (opening = first) and the peak
+  -- effective alarm among EARLIER members. Ordering is (first_seen_at, id) —
+  -- the same axis the spine pages on. The publish predicate is explicit for
+  -- service_role parity; for anon the RLS on events/story_event already
+  -- enforces it, so both roles compute identical main_line values.
+  SELECT
+    se.story_id,
+    se.event_id,
+    e.name AS front_name,
+    e.slug AS front_slug,
+    ROW_NUMBER() OVER w AS member_seq,
+    MAX(
+      COALESCE(
+        s.alarm_level,
+        CASE s.severity
+          WHEN 'critical' THEN 5
+          WHEN 'severe'   THEN 4
+          WHEN 'moderate' THEN 3
+          WHEN 'minor'    THEN 2
+        END,
+        2
+      )
+    ) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS front_prior_peak
+  FROM public.story_event se
+  JOIN public.events  e ON e.id = se.event_id AND e.publish_state = 'published'
+  JOIN public.stories s ON s.id = se.story_id
+  WINDOW w AS (PARTITION BY se.event_id ORDER BY s.first_seen_at, s.id)
+)
+SELECT
+  s.id,
+  s.primary_headline,
+  s.first_seen_at,
+  s.alarm_level,
+  s.severity,
+  fm.event_id     AS front_id,
+  fm.front_name,
+  fm.front_slug,
+  (fm.member_seq = 1)                                  AS front_opening,
+  p.pin                                                AS tracker_pin,
+  a.alarm_eff,
+  CASE
+    WHEN p.pin = 'force_show' THEN TRUE
+    WHEN p.pin = 'force_hide' THEN FALSE
+    -- Loose end (no published front): significant = alarm 4+.
+    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 4
+    -- Front member: opening, or escalation (alarm 5, or a new front peak at 4+).
+    ELSE fm.member_seq = 1
+      OR a.alarm_eff = 5
+      OR (a.alarm_eff >= 4 AND a.alarm_eff > COALESCE(fm.front_prior_peak, 0))
+  END AS main_line
+FROM public.stories s
+CROSS JOIN LATERAL (
+  -- Effective alarm: alarm_level, else the migration-064 severity mapping,
+  -- else 2 — the SAME fallback as the frontend adapters and v_event_stats.
+  SELECT COALESCE(
+    s.alarm_level,
+    CASE s.severity
+      WHEN 'critical' THEN 5
+      WHEN 'severe'   THEN 4
+      WHEN 'moderate' THEN 3
+      WHEN 'minor'    THEN 2
+    END,
+    2
+  )::smallint AS alarm_eff
+) a
+LEFT JOIN front_members fm ON fm.story_id = s.id
+LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::text
+-- The spine's base predicates, baked in (published, term scoping stays client-side):
+WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
+
+COMMENT ON VIEW public.v_tracker_stories IS
+  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle: pins override, loose ends need effective alarm >= 4, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
+
+GRANT SELECT ON public.v_tracker_stories TO anon;
+GRANT SELECT ON public.v_tracker_stories TO service_role;
+
+-- Refresh PostgREST's schema cache so the table/view are immediately queryable.
+NOTIFY pgrst, 'reload schema';
+
+-- ============================================================================
+-- VERIFICATION (run after applying)
+-- ============================================================================
+-- 1. Empty pin table, view resolves:
+--    SELECT count(*) FROM tracker_pin;
+--    SELECT count(*) FROM v_tracker_stories;                  -- = active enriched stories
+--    SELECT count(*) FROM v_tracker_stories WHERE main_line;  -- <= previous count
+-- 2. Rule sanity on a seeded front (after ADO-554 seeding):
+--    SELECT id, primary_headline, alarm_eff, front_name, front_opening, main_line
+--    FROM v_tracker_stories WHERE front_id IS NOT NULL
+--    ORDER BY front_id, first_seen_at;
+--    -- expect: member_seq 1 rows main_line = true; alarm_eff <= prior peak and < 5 rows false
+-- 3. Pin override: INSERT INTO tracker_pin VALUES ('stories', '<id>', 'force_hide');
+--    → that row's main_line flips false; DELETE the pin, it flips back.
+-- 4. Anon read (PostgREST anon key) returns rows — not 401/42501:
+--    curl -s "https://wnrjrywpcadwutfykflu.supabase.co/rest/v1/v_tracker_stories?select=id,main_line&limit=1" \
+--      -H "apikey: <ANON_KEY>" -H "Authorization: Bearer <ANON_KEY>"
+--    (repeat for tracker_pin — expect [])
+-- 5. Re-run this whole file — must be a no-op (idempotent).

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -25,9 +25,11 @@
 -- DEPENDENCIES: migration 111 (events/story_event), set_updated_at() (migration 001).
 --
 -- SECURITY: migration 046 auto-revokes anon on new tables — explicit GRANTs below.
--- Pins are public curation data by definition (a force_show row renders publicly),
--- so anon gets a plain SELECT policy. Writes stay service_role-only (no anon or
--- authenticated write policies). The view is security_invoker so anon reads
+-- Pin EXISTENCE is public curation data by definition (a force_show row renders
+-- publicly), so anon gets a SELECT policy — but only on source/entity_id/pin
+-- (column-level grant): the note column is an admin breadcrumb and stays
+-- private. Writes stay service_role-only (no anon or authenticated write
+-- policies). The view is security_invoker so anon reads
 -- through it inherit the RLS publish gates from migration 111 — an UNPUBLISHED
 -- front's members still count as loose ends for anon, which is the intended
 -- behavior (a draft front must not change the public main line).
@@ -70,8 +72,13 @@ CREATE POLICY "tracker_pin_anon_select" ON public.tracker_pin
   FOR SELECT TO anon
   USING (true);
 
-GRANT SELECT ON public.tracker_pin TO anon;
-GRANT ALL    ON public.tracker_pin TO service_role;
+-- Column-level anon grant: the frontend needs source/entity_id/pin only.
+-- `note` is an ADMIN breadcrumb (why pinned) and must not be publicly
+-- readable (AI review blocker on PR #127). REVOKE first so a re-run (or a DB
+-- that applied the earlier table-wide grant) converges to columns-only.
+REVOKE SELECT ON public.tracker_pin FROM anon;
+GRANT SELECT (source, entity_id, pin) ON public.tracker_pin TO anon;
+GRANT ALL ON public.tracker_pin TO service_role;
 
 -- ============================================================================
 -- PART B: v_tracker_stories — spine read path with server-computed main_line

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -96,6 +96,12 @@ WITH front_members AS (
   -- the same axis the spine pages on. The publish predicate is explicit for
   -- service_role parity; for anon the RLS on events/story_event already
   -- enforces it, so both roles compute identical main_line values.
+  --
+  -- The window runs over the SAME active/enriched story set the view exposes
+  -- (Codex P1 on PR #127): merge_stories leaves story_event pointing at
+  -- archived tombstones, and a hidden member must not hold member_seq 1 (the
+  -- visible first member would never flag as the opening) or feed its alarm
+  -- into front_prior_peak (suppressing real escalations).
   SELECT
     se.story_id,
     se.event_id,
@@ -117,6 +123,8 @@ WITH front_members AS (
   FROM public.story_event se
   JOIN public.events  e ON e.id = se.event_id AND e.publish_state = 'published'
   JOIN public.stories s ON s.id = se.story_id
+                       AND s.status = 'active'
+                       AND s.summary_neutral IS NOT NULL
   WINDOW w AS (PARTITION BY se.event_id ORDER BY s.first_seen_at, s.id)
 )
 SELECT

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -77,7 +77,10 @@ CREATE POLICY "tracker_pin_anon_select" ON public.tracker_pin
 -- readable (AI review blocker on PR #127). REVOKE first so a re-run (or a DB
 -- that applied the earlier table-wide grant) converges to columns-only.
 REVOKE SELECT ON public.tracker_pin FROM anon;
-GRANT SELECT (source, entity_id, pin) ON public.tracker_pin TO anon;
+-- updated_at included: the frontend orders newest-first (deterministic
+-- truncation if pins ever outgrow the fetch cap), and ORDER BY needs SELECT
+-- privilege on the column.
+GRANT SELECT (source, entity_id, pin, updated_at) ON public.tracker_pin TO anon;
 GRANT ALL ON public.tracker_pin TO service_role;
 
 -- ============================================================================

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -8,6 +8,9 @@ import {
   buildSourcePath,
   initialTrackerState,
   fetchTrackerPage,
+  fetchTrackerPins,
+  forceShowIdsBySource,
+  pinKey,
   coverageFrontier,
   visibleEntries,
   SOURCE_ROUTES,
@@ -15,6 +18,7 @@ import {
   TIMELINE_SOURCES,
   type TimelineEntry,
   type TimelineSource,
+  type TrackerPins,
   type TrackerState,
 } from '../lib/timeline';
 
@@ -138,8 +142,16 @@ describe('buildSourcePath', () => {
     expect(p).not.toContain('and=');
     expect(p).toContain('order=first_seen_at.desc,id.desc');
     expect(p).toContain('limit=60');
-    expect(p).toContain('status=eq.active');
-    expect(p).toContain('summary_neutral=not.is.null');
+    // status/enrichment predicates are baked into v_tracker_stories (ADO-554)
+    expect(p).toContain('v_tracker_stories?');
+    expect(p).not.toContain('status=');
+  });
+
+  it("main view: stories filter on the server-computed main_line, others keep alarm 4+", () => {
+    expect(dec(buildSourcePath('stories', 'main', null))).toContain('and=(main_line.is.true)');
+    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.4)');
+    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.4');
+    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.4');
   });
 
   it('floors every source at inauguration day - the record is term 2 only', () => {
@@ -270,7 +282,7 @@ describe('fetchTrackerPage', () => {
     vi.stubGlobal('window', { location: { hostname: 'localhost', search: '' } });
     vi.stubGlobal('fetch', vi.fn(async (input: string) => {
       calls.push(input);
-      if (input.includes('/stories?')) {
+      if (input.includes('/v_tracker_stories?')) {
         return { ok: true, json: async () => mkStoryRows(60) };
       }
       if (input.includes('/executive_orders?')) {
@@ -313,7 +325,7 @@ describe('fetchTrackerPage', () => {
     calls = [];
     await fetchTrackerPage(4, first);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('/stories?');
+    expect(calls[0]).toContain('/v_tracker_stories?');
     expect(decodeURIComponent(calls[0])).toContain('id.lt."941"');
   });
 
@@ -324,5 +336,107 @@ describe('fetchTrackerPage', () => {
     expect(entries).toHaveLength(0);
     expect(calls).toHaveLength(0);
     expect(next).toEqual(state);
+  });
+});
+
+describe('tracker pins (ADO-554)', () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+    vi.stubGlobal('window', { location: { hostname: 'localhost', search: '' } });
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+      calls.push(input);
+      if (input.includes('/tracker_pin?')) {
+        return {
+          ok: true,
+          json: async () => [
+            { source: 'eos', entity_id: 'eo_low', pin: 'force_show' },
+            { source: 'eos', entity_id: 'eo_bad', pin: 'force_hide' },
+            { source: 'pardons', entity_id: '77', pin: 'force_show' },
+            { source: 'stories', entity_id: '5', pin: 'force_show' },
+          ],
+        };
+      }
+      if (input.includes('/v_tracker_stories?')) {
+        return { ok: true, json: async () => [] };
+      }
+      if (input.includes('/executive_orders?') && input.includes('id=in.')) {
+        return {
+          ok: true,
+          json: async () => [
+            { id: 'eo_low', title: 'Quiet but nasty order', date: '2026-03-01', alarm_level: 2 },
+          ],
+        };
+      }
+      if (input.includes('/executive_orders?')) {
+        return {
+          ok: true,
+          json: async () => [
+            { id: 'eo_bad', title: 'Hidden order', date: '2026-06-01', alarm_level: 5 },
+            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 4 },
+          ],
+        };
+      }
+      if (input.includes('/pardons?') && input.includes('id=in.')) {
+        // the pinned pardon is ALSO in the 4+ stream: must not be injected twice
+        return {
+          ok: true,
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+        };
+      }
+      if (input.includes('/pardons?')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+        };
+      }
+      return { ok: true, json: async () => [] }; // scotus
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('fetchTrackerPins maps rows and degrades to empty on failure', async () => {
+    const pins = await fetchTrackerPins();
+    expect(pins.get(pinKey('eos', 'eo_low'))).toBe('force_show');
+    expect(pins.get(pinKey('eos', 'eo_bad'))).toBe('force_hide');
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => [] })));
+    expect((await fetchTrackerPins()).size).toBe(0);
+  });
+
+  it('forceShowIdsBySource groups non-stories force_show pins only', () => {
+    const pins: TrackerPins = new Map([
+      [pinKey('eos', 'eo_low'), 'force_show'],
+      [pinKey('eos', 'eo_bad'), 'force_hide'],
+      [pinKey('pardons', 77), 'force_show'],
+      [pinKey('stories', 5), 'force_show'], // server-side, excluded here
+    ]);
+    expect(forceShowIdsBySource(pins)).toEqual({ eos: ['eo_low'], pardons: ['77'] });
+  });
+
+  it('main view drops force_hidden non-stories entries and injects force_shown ones once', async () => {
+    const pins = await fetchTrackerPins();
+    const { entries } = await fetchTrackerPage('main', null, undefined, pins);
+
+    const ids = entries.map(e => `${e.source}:${e.id}`);
+    expect(ids).not.toContain('eos:eo_bad');            // force_hide dropped
+    expect(ids).toContain('eos:eo_kept');               // untouched stream row
+    expect(ids).toContain('eos:eo_low');                // alarm 2, injected by pin
+    // pinned pardon at alarm 4 arrives via the stream — exactly once
+    expect(ids.filter(id => id === 'pardons:77')).toHaveLength(1);
+  });
+
+  it('does not re-inject force_shown rows on later pages', async () => {
+    const pins = await fetchTrackerPins();
+    const { state } = await fetchTrackerPage('main', null, undefined, pins);
+    calls = [];
+    await fetchTrackerPage('main', state, undefined, pins);
+    expect(calls.some(c => c.includes('id=in.'))).toBe(false);
   });
 });

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -7,6 +7,7 @@ import { alarmPalette } from '@/tokens';
 import { fmtDate } from '@/lib/date-utils';
 import {
   fetchTrackerPage,
+  fetchTrackerPins,
   fetchTrackerTally,
   coverageFrontier,
   visibleEntries,
@@ -15,25 +16,28 @@ import {
   SOURCE_ROUTES,
   TERM_START,
   TIMELINE_SOURCES,
-  type AlarmMin,
   type TimelineEntry,
   type TimelineSource,
+  type TrackerPins,
   type TrackerState,
   type TrackerTally,
+  type TrackerView,
 } from '@/lib/timeline';
 
 // The Tracker (ADO-545): the homepage rap sheet as a vertical center-spine
 // timeline, replacing the W1.1 horizontal strip. The bar is the timeline;
 // entries alternate left/right, newest first, with month markers on the bar.
-// Type and dot size follow alarm level. Main line = alarm filter (default 4+);
-// "All" recovers the complete record. Below 760px it collapses to a single
-// column with the spine on the left. Approved design: mockup rev 6.
+// Type and dot size follow alarm level. Default view = the curated main line
+// (ADO-554: PRD §12 anchor rule + tracker_pin overrides, computed server-side
+// for stories, pins client-side for the rest); "All" recovers the complete
+// record. Below 760px it collapses to a single column with the spine on the
+// left. Approved design: mockup rev 6.
 
-const ALARM_STOPS: { label: string; min: AlarmMin }[] = [
-  { label: 'All', min: 0 },
-  { label: 'Alarm 3+', min: 3 },
-  { label: 'Alarm 4+', min: 4 },
-  { label: 'Only 5', min: 5 },
+const VIEW_STOPS: { label: string; view: TrackerView }[] = [
+  { label: 'Main line', view: 'main' },
+  { label: 'All', view: 0 },
+  { label: 'Alarm 3+', view: 3 },
+  { label: 'Only 5', view: 5 },
 ];
 
 const INAUGURATION = new Date(`${TERM_START}T00:00:00`);
@@ -74,35 +78,41 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   const [loaded, setLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [minAlarm, setMinAlarm] = useState<AlarmMin>(4);
+  const [view, setView] = useState<TrackerView>('main');
   const [off, setOff] = useState<Set<TimelineSource>>(new Set());
   const [query, setQuery] = useState('');
   const [tally, setTally] = useState<TrackerTally | null>(null);
 
   const acRef = useRef<AbortController | null>(null);
   const controlsRef = useRef<HTMLDivElement>(null);
+  // Pins are fetched once per mount (tiny table) and reused across view
+  // changes and paging; a failed fetch degrades to "no pins" for the session.
+  const pinsRef = useRef<TrackerPins | null>(null);
 
-  // First page — refetched whenever the alarm floor changes, because the
-  // server-side alarm predicate is baked into every source's cursor stream.
-  // The current list stays on screen until the new one arrives: clearing it
-  // collapses the page height and scroll-anchoring yanks the viewport around.
+  // First page — refetched whenever the view changes, because the server-side
+  // predicate (main_line or alarm floor) is baked into every source's cursor
+  // stream. The current list stays on screen until the new one arrives:
+  // clearing it collapses the page height and scroll-anchoring yanks the
+  // viewport around.
   useEffect(() => {
     if (!enabled) return;
     const ac = new AbortController();
     acRef.current = ac;
     setLoadingMore(false);
     setRefreshing(true);
-    fetchTrackerPage(minAlarm, null, ac.signal)
-      .then(({ entries: page, state }) => {
-        if (ac.signal.aborted) return;
-        setEntries(page);
-        setPageState(state);
-        setLoaded(true);
-        setRefreshing(false);
-      })
-      .catch(() => { /* the Tracker is additive — never break the homepage */ });
+    (async () => {
+      const pins = view === 'main'
+        ? (pinsRef.current ??= await fetchTrackerPins(ac.signal))
+        : undefined;
+      const { entries: page, state } = await fetchTrackerPage(view, null, ac.signal, pins);
+      if (ac.signal.aborted) return;
+      setEntries(page);
+      setPageState(state);
+      setLoaded(true);
+      setRefreshing(false);
+    })().catch(() => { /* the Tracker is additive — never break the homepage */ });
     return () => ac.abort();
-  }, [enabled, minAlarm]);
+  }, [enabled, view]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -114,6 +124,10 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   }, [enabled]);
 
   const frontier = pageState ? coverageFrontier(pageState) : null;
+  // In the main-line view the server (plus pins) already decided inclusion —
+  // the client alarm floor must be 0 or it would drop low-alarm front
+  // openings and force_shown entries the rule deliberately included.
+  const minAlarm = view === 'main' ? 0 : view;
   const visible = useMemo(
     () => visibleEntries(entries, { frontier, min: minAlarm, off, query }),
     [entries, frontier, minAlarm, off, query],
@@ -132,7 +146,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     if (!pageState || loadingMore || refreshing || allExhausted) return;
     const ac = acRef.current;
     setLoadingMore(true);
-    fetchTrackerPage(minAlarm, pageState, ac?.signal)
+    fetchTrackerPage(view, pageState, ac?.signal, view === 'main' ? pinsRef.current ?? undefined : undefined)
       .then(({ entries: more, state }) => {
         if (ac?.signal.aborted) return;
         setEntries(prev => mergeEntries([prev, more]));
@@ -143,11 +157,11 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
       .finally(() => setLoadingMore(false));
   };
 
-  // Changing the alarm floor swaps in a list of a different length; if the
-  // reader is scrolled deep, snap back to the controls so the change is
-  // legible instead of the browser clamping scroll somewhere arbitrary.
-  const changeAlarm = (min: AlarmMin) => {
-    setMinAlarm(min);
+  // Changing the view swaps in a list of a different length; if the reader is
+  // scrolled deep, snap back to the controls so the change is legible instead
+  // of the browser clamping scroll somewhere arbitrary.
+  const changeView = (v: TrackerView) => {
+    setView(v);
     const el = controlsRef.current;
     if (el && el.getBoundingClientRect().top < 0) {
       el.scrollIntoView({ block: 'start', behavior: 'instant' as ScrollBehavior });
@@ -179,6 +193,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   const tallyTiles: { n: string; label: string; bad?: boolean }[] = [
     { n: String(dayCount), label: 'Days into term 2' },
   ];
+  if (tally?.openFronts != null && tally.openFronts > 0) {
+    tallyTiles.push({ n: String(tally.openFronts), label: 'Open fronts' });
+  }
   if (tally?.developments != null) {
     tallyTiles.push({ n: tally.developments.toLocaleString('en-US'), label: 'Developments logged' });
   }
@@ -188,15 +205,15 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
 
   // ── Controls ──
   const seg = (
-    <span role="group" aria-label="Alarm level filter" style={{ display: 'inline-flex', border: `1px solid ${theme.line}` }}>
-      {ALARM_STOPS.map(({ label, min }) => {
-        const on = minAlarm === min;
+    <span role="group" aria-label="Timeline view filter" style={{ display: 'inline-flex', border: `1px solid ${theme.line}` }}>
+      {VIEW_STOPS.map(({ label, view: v }) => {
+        const on = view === v;
         return (
           <button
-            key={min}
+            key={String(v)}
             type="button"
             aria-pressed={on}
-            onClick={() => changeAlarm(min)}
+            onClick={() => changeView(v)}
             className="tt-ts-seg"
             style={{
               ...mono, fontSize: 10, padding: '8px 14px', background: on ? theme.bg2 : 'none',
@@ -326,12 +343,22 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
           display: 'flex', gap: 8, marginTop: 7, flexWrap: 'wrap', alignItems: 'center',
           justifyContent: narrow || right ? 'flex-start' : 'flex-end',
         }}>
-          <span style={{
-            ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
-            border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
-          }}>
-            {e.source === 'stories' ? 'Loose end' : SOURCE_LABELS[e.source]}
-          </span>
+          {e.front ? (
+            // Front tag — navigation to the front's own page arrives with ADO-548
+            <span style={{
+              ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.ink, fontWeight: 600,
+              border: `1px solid ${theme.dim}`, padding: '2px 8px', whiteSpace: 'nowrap',
+            }}>
+              {e.front.name}
+            </span>
+          ) : (
+            <span style={{
+              ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
+              border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
+            }}>
+              {e.source === 'stories' ? 'Loose end' : SOURCE_LABELS[e.source]}
+            </span>
+          )}
         </div>
       </div>,
     );
@@ -342,7 +369,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     : refreshing
       ? 'Updating…'
       : `${visible.length} development${visible.length === 1 ? '' : 's'}`
-        + (minAlarm > 0 ? ` at alarm ${minAlarm}+` : ' · the complete record');
+        + (view === 'main'
+          ? ' · the main line'
+          : view > 0 ? ` at alarm ${view}+` : ' · the complete record');
 
   return (
     <section aria-label="The Tracker timeline" style={{ padding: '8px 0 24px', borderBottom: `1px solid ${theme.line}` }}>
@@ -421,7 +450,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
             <div style={{ ...mono, position: 'relative', zIndex: 2, fontSize: 10.5, color: theme.dim, textAlign: narrow ? 'left' : 'center', padding: narrow ? '18px 0 18px 28px' : '18px 0', background: theme.bg }}>
               {query
                 ? 'Nothing on the record matches that search at this filter.'
-                : 'Nothing at this alarm level yet · try "All" for the complete record.'}
+                : view === 'main'
+                  ? 'Nothing on the main line yet · try "All" for the complete record.'
+                  : 'Nothing at this alarm level yet · try "All" for the complete record.'}
             </div>
           )}
         </div>

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -14,6 +14,13 @@ export const TERM_START = '2025-01-20';
 /** The alarm segmented filter's positions: All / 3+ / 4+ / Only 5 */
 export type AlarmMin = 0 | 3 | 4 | 5;
 
+/**
+ * The Tracker's view selector (ADO-554): 'main' is the curated main line
+ * (PRD §12 anchor principle — the default), the numbers are raw alarm floors
+ * that recover the complete record.
+ */
+export type TrackerView = AlarmMin | 'main';
+
 export interface TimelineEntry {
   id: string | number;
   source: TimelineSource;
@@ -21,6 +28,8 @@ export interface TimelineEntry {
   date: string;
   headline: string;
   alarm: number;
+  /** Published front this entry belongs to (stories only, via v_tracker_stories) */
+  front?: { name: string; slug: string };
 }
 
 export const SOURCE_LABELS: Record<TimelineSource, string> = {
@@ -60,6 +69,9 @@ export function storyRowToEntry(raw: Raw): TimelineEntry {
     date: (raw.first_seen_at as string) || '',
     headline: (raw.primary_headline as string) || '',
     alarm,
+    front: raw.front_name
+      ? { name: raw.front_name as string, slug: (raw.front_slug as string) || '' }
+      : undefined,
   };
 }
 
@@ -126,9 +138,11 @@ interface SourceSpec {
 // Key order is the chip display order (mockup rev 6).
 const SPECS: Record<TimelineSource, SourceSpec> = {
   stories: {
-    table: 'stories',
-    select: 'id,primary_headline,first_seen_at,alarm_level,severity',
-    base: `status=eq.active&summary_neutral=not.is.null&first_seen_at=gte.${TERM_START}`,
+    // v_tracker_stories (migration 112) bakes in status=active + enriched and
+    // adds front membership + the server-computed main_line column (ADO-554).
+    table: 'v_tracker_stories',
+    select: 'id,primary_headline,first_seen_at,alarm_level,severity,front_name,front_slug',
+    base: `first_seen_at=gte.${TERM_START}`,
     dateCol: 'first_seen_at',
     limit: 60,
     adapter: storyRowToEntry,
@@ -205,15 +219,21 @@ const quoted = (v: string | number) => `"${String(v).replace(/"/g, '')}"`;
  * Keyset pagination: order date desc, id desc; the next page is
  * (date < D) OR (date = D AND id < I). Values are quoted so timestamps
  * with `:`/`+` survive, and the whole logic tree is URL-encoded.
+ *
+ * In the 'main' view (ADO-554) stories filter on the server-computed
+ * main_line column; the other sources keep the alarm-4+ predicate (they are
+ * all loose ends until fronts can contain them) with pins applied client-side.
  */
 export function buildSourcePath(
   source: TimelineSource,
-  min: AlarmMin,
+  view: TrackerView,
   cursor: SourceCursor | null,
 ): string {
   const s = SPECS[source];
   const conditions: string[] = [];
-  const alarmFrag = s.alarm(min);
+  const alarmFrag = view === 'main'
+    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(4))
+    : s.alarm(view);
   if (alarmFrag) conditions.push(alarmFrag);
   if (cursor) {
     conditions.push(
@@ -234,14 +254,67 @@ export function initialTrackerState(): TrackerState {
   return state;
 }
 
+// ── Tracker pins (ADO-554) ──
+
+/** Map keyed `${source}:${entity_id}` → pin. Tiny table, fetched whole. */
+export type TrackerPins = Map<string, 'force_show' | 'force_hide'>;
+
+export const pinKey = (source: TimelineSource, id: string | number) => `${source}:${id}`;
+
+/**
+ * Fetch every pin. Failure (including the table not existing yet — code can
+ * deploy ahead of migration 112 while the flag is off) degrades to no pins.
+ */
+export async function fetchTrackerPins(signal?: AbortSignal): Promise<TrackerPins> {
+  const pins: TrackerPins = new Map();
+  try {
+    const { url, anonKey } = await import('./supabase');
+    const res = await fetch(
+      `${url}/rest/v1/tracker_pin?select=source,entity_id,pin&limit=1000`,
+      { headers: { 'apikey': anonKey, 'Authorization': `Bearer ${anonKey}` }, signal },
+    );
+    if (!res.ok) return pins;
+    const rows: Raw[] = await res.json();
+    for (const r of rows) {
+      pins.set(pinKey(r.source as TimelineSource, r.entity_id as string), r.pin as 'force_show' | 'force_hide');
+    }
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') throw err;
+  }
+  return pins;
+}
+
+/**
+ * The force_show pins for non-stories sources, grouped per source. Stories
+ * pins are resolved server-side in v_tracker_stories, so they are excluded.
+ */
+export function forceShowIdsBySource(pins: TrackerPins): Partial<Record<TimelineSource, string[]>> {
+  const out: Partial<Record<TimelineSource, string[]>> = {};
+  for (const [key, pin] of pins) {
+    if (pin !== 'force_show') continue;
+    const sep = key.indexOf(':');
+    const source = key.slice(0, sep) as TimelineSource;
+    if (source === 'stories' || !TIMELINE_SOURCES.includes(source)) continue;
+    (out[source] ??= []).push(key.slice(sep + 1));
+  }
+  return out;
+}
+
 /**
  * Fetch the next page for every non-exhausted source and advance its cursor.
  * Returns only the NEW entries (ascending); callers merge with what they hold.
+ *
+ * In the 'main' view, pins adjust the non-stories sources client-side:
+ * force_hide entries are dropped from every page, and on the FIRST page
+ * (state === null) force_show rows below the alarm-4 stream are fetched by id
+ * and merged in at their chronological position. Stories pins are already
+ * applied by v_tracker_stories on the server.
  */
 export async function fetchTrackerPage(
-  min: AlarmMin,
+  view: TrackerView,
   state: TrackerState | null,
   signal?: AbortSignal,
+  pins?: TrackerPins,
 ): Promise<{ entries: TimelineEntry[]; state: TrackerState }> {
   // Lazy import: lib/supabase reads window.location at module load, which would
   // break node-env unit tests that import this module's pure functions.
@@ -253,6 +326,7 @@ export async function fetchTrackerPage(
 
   const prev = state ?? initialTrackerState();
   const next: TrackerState = { ...prev };
+  const isMain = view === 'main';
 
   const groups = await Promise.all(
     TIMELINE_SOURCES.map(async source => {
@@ -260,7 +334,7 @@ export async function fetchTrackerPage(
       if (st.exhausted) return [];
       const spec = SPECS[source];
       try {
-        const res = await fetch(`${url}/rest/v1/${buildSourcePath(source, min, st.cursor)}`, { headers, signal });
+        const res = await fetch(`${url}/rest/v1/${buildSourcePath(source, view, st.cursor)}`, { headers, signal });
         if (!res.ok) {
           next[source] = { ...st, exhausted: true, errored: true };
           return [];
@@ -274,7 +348,11 @@ export async function fetchTrackerPage(
           exhausted: rows.length < spec.limit,
           errored: false,
         };
-        return rows.map(spec.adapter);
+        let entries = rows.map(spec.adapter);
+        if (isMain && source !== 'stories' && pins?.size) {
+          entries = entries.filter(e => pins.get(pinKey(source, e.id)) !== 'force_hide');
+        }
+        return entries;
       } catch (err) {
         if ((err as Error).name === 'AbortError') throw err;
         // One source failing must not blank the whole Tracker
@@ -283,6 +361,33 @@ export async function fetchTrackerPage(
       }
     }),
   );
+
+  // First page of the main line: surface force_show pins on non-stories
+  // sources. Only rows below the alarm-4 stream are merged — anything at 4+
+  // arrives (or already arrived) through normal paging, so injecting it again
+  // would duplicate the entry.
+  if (isMain && state === null && pins?.size) {
+    const bySource = forceShowIdsBySource(pins);
+    const injected = await Promise.all(
+      (Object.keys(bySource) as TimelineSource[]).map(async source => {
+        const spec = SPECS[source];
+        const ids = bySource[source]!.map(id => quoted(id)).join(',');
+        try {
+          const res = await fetch(
+            `${url}/rest/v1/${spec.table}?select=${spec.select}&${spec.base}&id=in.(${ids})`,
+            { headers, signal },
+          );
+          if (!res.ok) return [];
+          const rows: Raw[] = await res.json();
+          return rows.map(spec.adapter).filter(e => e.alarm < 4);
+        } catch (err) {
+          if ((err as Error).name === 'AbortError') throw err;
+          return []; // pins are additive — a failed fetch must not break the page
+        }
+      }),
+    );
+    groups.push(...injected);
+  }
 
   return { entries: mergeEntries(groups), state: next };
 }
@@ -331,6 +436,8 @@ export interface TrackerTally {
   developments: number | null;
   /** Alarm-5 developments in the last 30 days */
   alarm5Last30: number | null;
+  /** Published, unresolved fronts (ADO-554); null before migration 112 or on error */
+  openFronts: number | null;
 }
 
 async function countRows(
@@ -365,6 +472,12 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
 
   const since = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
 
+  const openFrontsPromise = countRows(
+    url, headers,
+    'events?select=id&publish_state=eq.published&lifecycle=neq.resolved',
+    signal,
+  );
+
   const perSource = await Promise.all(
     TIMELINE_SOURCES.map(async source => {
       const s = SPECS[source];
@@ -388,5 +501,6 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
   return {
     developments: sum(perSource.map(p => p.total)),
     alarm5Last30: sum(perSource.map(p => p.worst)),
+    openFronts: await openFrontsPromise,
   };
 }

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -269,8 +269,10 @@ export async function fetchTrackerPins(signal?: AbortSignal): Promise<TrackerPin
   const pins: TrackerPins = new Map();
   try {
     const { url, anonKey } = await import('./supabase');
+    // Newest-first so if curation ever outgrows the cap, the truncation is
+    // deterministic and the most recent pins win (review note on PR #127).
     const res = await fetch(
-      `${url}/rest/v1/tracker_pin?select=source,entity_id,pin&limit=1000`,
+      `${url}/rest/v1/tracker_pin?select=source,entity_id,pin&order=updated_at.desc&limit=1000`,
       { headers: { 'apikey': anonKey, 'Authorization': `Bearer ${anonKey}` }, signal },
     );
     if (!res.ok) return pins;


### PR DESCRIPTION
## What this is

ADO-554 (epic 543): the Tracker's curation layer. The spine's default view becomes **the main line** - rules decide inclusion per PRD §12's locked anchor principle; `tracker_pin` is an optional per-entry override, never required. This is the PROD `rap_sheet` flag-flip blocker: the flag flips once, debuting the curated Tracker.

## The rule (derived from Josh's 57 anchor picks in the rev-6 mockup; reproduces 50/57 with zero curation)

1. `force_show` pin → in; `force_hide` pin → out (all four sources)
2. No published front (loose end - includes all EO/SCOTUS/pardon rows today): effective alarm >= 4
3. Front member: front **opening** (earliest member) OR alarm 5 OR alarm >= 4 setting a new front peak. Routine front developments drop off the main line (front pages = ADO-548).

## Changes

- **Migration 112** (`migrations/112_tracker_main_line.sql`): `tracker_pin` table + `v_tracker_stories` view computing `main_line` server-side (security_invoker, anon grants, idempotent). **Applied + verified on TEST.**
- **`src/lib/timeline.ts`**: `TrackerView` ('main' | alarm floors); stories read the view (front tags come along); non-stories pins client-side - force_hide dropped every page, force_show fetched by id on the first page and merged below the alarm-4 stream (no duplicates); `openFronts` tally count.
- **`src/components/TrackerSpine.tsx`**: default segment "Main line" (All / Alarm 3+ / Only 5 recover the record); front name renders as a row tag (navigation lands with ADO-548); Open fronts tally tile.
- Tests: timeline suite 34 passing (5 new for pins/injection/main-mode paths); full vitest 146/146; `npm run qa:smoke` green; `tsc --noEmit` clean; vite build clean.

## Already live on TEST (data)

7 published fronts seeded (The Epstein Files, Iran, Trump Crypto, The Qatar Jet, Selling the White House, The Courts, Kushner's Deals), 27 demo story assignments, 2 demo pins (force_hide on an Epstein explainer, force_show on a below-threshold EO). Verified via anon PostgREST: main line = 414 stories, openings/escalations stay, routine front developments drop, pins flip rows both ways.

## PROD deploy notes (later, with the flag flip)

Apply migration 112 BEFORE cherry-picking this code (the spine's stories fetch targets `v_tracker_stories`; with the view missing, stories vanish from the Tracker - flag is off until then anyway). Then seed PROD fronts + assignments, then flip `rap_sheet`.

$0 new AI spend. Egress: tight view selects, pins table is tiny, HEAD counts for tallies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)