### PR TITLE
feat(ado-554): main-line rule v1.1 - loose-end bar at alarm 5

### DIFF
--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -351,7 +351,7 @@ Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
 
 `id, primary_headline, first_seen_at, alarm_level, severity, front_id, front_name, front_slug, front_opening, tracker_pin, alarm_eff, main_line`
 
-**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
+**The rule (v1.1):** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff = 5` (raised from 4+ on August 23, 2026: fronts are the organizing layer and enrichment severity saturation rates ~67% of stories 4+, which drowned the main line); front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
 
 `security_invoker = true` — for anon, unpublished fronts' members count as loose ends (RLS hides the membership), by design. EO/SCOTUS/pardon rows have no front membership; the frontend applies their loose-end rule + pins client-side from `tracker_pin`.
 

--- a/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
+++ b/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
@@ -54,3 +54,15 @@ main_line(entry) =
 - Josh eyeballs the TEST site (AC7) → then Ready for Prod.
 - ADO-547 (admin UI incl. pin editor) is the next build; 548 front pages give the front tags their navigation.
 - ADO-553 cohort verify is a separate queue item (6 pardons in needs_review — Josh works those in admin).
+
+---
+
+## Addendum — live-review round (same evening)
+
+Josh reviewed TEST live; three outcomes:
+
+1. **Rule v1.1 — loose-end bar raised to alarm 5** (fronts keep opening / alarm-5 / new-peak-at-4+). WHY: measured severity saturation — PROD rates 67% of term-2 stories alarm 4+ (9,329/13,924; 1,376 at 5), TEST 61% — so the 4+ bar read as "everything". DB side applied on TEST (main line 414 → 209 = 39 front rows + 170 a5 loose ends); frontend half is **PR #128 — OPEN, Josh merges from his desktop** after the Codex thread. Codex P1 (pin-vs-frontier) answered with a full-pipeline test + kept-by-design rationale (pins surface at their date; pin-to-top = ADO-552); P2 comment fixed. d31f16c.
+2. **52 more stories bulk-filed** into the fronts via keyword sweep (79 total) so front tags read across the line.
+3. **New cards:** ADO-555 front enrichment, ADO-556 stories severity calibration (owns the "bar back to 4+?" question), ADO-557 fronts automation planning session (Josh: "covered automatically going forward"). Josh confirmed ADO-548 (front pages / expand-a-front) was never tonight's scope — it is the next reader-facing build.
+
+Branch hygiene: all merged deploy/feature branches swept locally and on origin. Kept: `ado-551-disposition-normalize` (unmerged fix) and `origin/claude/research-political-rss-feeds-uwR6a` (no PR — Josh to decide).

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -9,7 +9,8 @@
 --   B) v_tracker_stories — the spine's stories read path, with main_line computed
 --                          server-side:
 --                            pin override            → force_show in, force_hide out
---                            no published front      → effective alarm >= 4 (loose end)
+--                            no published front      → effective alarm 5 (loose end;
+--                                                      v1.1 bar, see CASE comment)
 --                            front member            → front opening (earliest member)
 --                                                      OR alarm 5
 --                                                      OR alarm >= 4 setting a new
@@ -18,7 +19,7 @@
 --                          and live on the front's own page (ADO-548).
 --
 -- EO/SCOTUS/pardon rows have no front membership today, so their main-line rule
--- (loose end: alarm >= 4, plus pins) is applied by the frontend from the same
+-- (loose end: alarm 5, plus pins) is applied by the frontend from the same
 -- tracker_pin table — no views needed for them.
 --
 -- Apply manually via the Supabase SQL Editor (NOT apply-migrations.js).
@@ -145,8 +146,14 @@ SELECT
   CASE
     WHEN p.pin = 'force_show' THEN TRUE
     WHEN p.pin = 'force_hide' THEN FALSE
-    -- Loose end (no published front): significant = alarm 4+.
-    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 4
+    -- Loose end (no published front): alarm 5 only (rule v1.1, Josh
+    -- August 23, 2026). Fronts are the organizing layer — an unfiled alarm-4
+    -- story usually means "not filed yet", not "main line". The 4+ bar drowned
+    -- the line because enrichment rates ~67% of stories 4+ (severity
+    -- saturation, same disease as the pre-agent EO pipeline); a BLS-class
+    -- alarm-4 loose end reaches the main line via filing or a force_show pin
+    -- until severity calibration lands.
+    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 5
     -- Front member: opening, or escalation (alarm 5, or a new front peak at 4+).
     ELSE fm.member_seq = 1
       OR a.alarm_eff = 5
@@ -173,7 +180,7 @@ LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::t
 WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
 
 COMMENT ON VIEW public.v_tracker_stories IS
-  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle: pins override, loose ends need effective alarm >= 4, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
+  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle (rule v1.1): pins override, loose ends need effective alarm 5, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
 
 GRANT SELECT ON public.v_tracker_stories TO anon;
 GRANT SELECT ON public.v_tracker_stories TO service_role;

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -432,6 +432,53 @@ describe('tracker pins (ADO-554)', () => {
     expect(ids.filter(id => id === 'pardons:77')).toHaveLength(1);
   });
 
+  it('buffers an injected old pin behind the coverage frontier, then renders it at its date (Codex P1 on PR #128)', async () => {
+    // A pinned row surfaces AT ITS DATE, by design: the frontier must not be
+    // bypassed (that would fake completeness of an unloaded range). This pins
+    // down the full pipeline: fetchTrackerPage → coverageFrontier → visibleEntries.
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+      if (input.includes('/tracker_pin?')) {
+        return { ok: true, json: async () => [{ source: 'eos', entity_id: 'eo_low', pin: 'force_show' }] };
+      }
+      if (input.includes('/executive_orders?') && input.includes('id=in.')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'eo_low', title: 'Quiet but nasty order', date: '2026-03-01', alarm_level: 4 }],
+        };
+      }
+      if (input.includes('/executive_orders?')) {
+        // A FULL page (limit 25) → eos stays non-exhausted with cursor 2026-06-01,
+        // so the frontier sits months after the injected pin's date.
+        return {
+          ok: true,
+          json: async () => Array.from({ length: 25 }, (_, i) => ({
+            id: `eo_s${i}`, title: `Order ${i}`, alarm_level: 5,
+            date: `2026-06-${String(25 - i).padStart(2, '0')}`,
+          })),
+        };
+      }
+      return { ok: true, json: async () => [] }; // stories view, scotus, pardons
+    }));
+
+    const pins = await fetchTrackerPins();
+    const { entries, state } = await fetchTrackerPage('main', null, undefined, pins);
+
+    const frontier = coverageFrontier(state);
+    expect(frontier).toBe('2026-06-01');
+
+    const opts = { min: 0 as const, off: new Set<TimelineSource>(), query: '' };
+    // While coverage stops at June, the March pin is buffered — not lost, not shown.
+    const early = visibleEntries(entries, { ...opts, frontier });
+    expect(early.some(e => e.id === 'eo_low')).toBe(false);
+    expect(entries.some(e => e.id === 'eo_low')).toBe(true);
+
+    // Once every source is exhausted (frontier null), the pin renders at its date.
+    const done = visibleEntries(entries, { ...opts, frontier: null });
+    const ids = done.map(e => e.id);
+    expect(ids).toContain('eo_low');
+    expect(ids.indexOf('eo_low')).toBe(ids.length - 1); // oldest → rendered last (newest first)
+  });
+
   it('does not re-inject force_shown rows on later pages', async () => {
     const pins = await fetchTrackerPins();
     const { state } = await fetchTrackerPage('main', null, undefined, pins);

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -147,11 +147,11 @@ describe('buildSourcePath', () => {
     expect(p).not.toContain('status=');
   });
 
-  it("main view: stories filter on the server-computed main_line, others keep alarm 4+", () => {
+  it("main view: stories filter on the server-computed main_line, others get the alarm-5 loose-end bar", () => {
     expect(dec(buildSourcePath('stories', 'main', null))).toContain('and=(main_line.is.true)');
-    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.4)');
-    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.4');
-    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.4');
+    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.5)');
+    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.5');
+    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.5');
   });
 
   it('floors every source at inauguration day - the record is term 2 only', () => {
@@ -375,21 +375,21 @@ describe('tracker pins (ADO-554)', () => {
           ok: true,
           json: async () => [
             { id: 'eo_bad', title: 'Hidden order', date: '2026-06-01', alarm_level: 5 },
-            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 4 },
+            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 5 },
           ],
         };
       }
       if (input.includes('/pardons?') && input.includes('id=in.')) {
-        // the pinned pardon is ALSO in the 4+ stream: must not be injected twice
+        // the pinned pardon is ALSO in the alarm-5 stream: must not be injected twice
         return {
           ok: true,
-          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 5 }],
         };
       }
       if (input.includes('/pardons?')) {
         return {
           ok: true,
-          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 5 }],
         };
       }
       return { ok: true, json: async () => [] }; // scotus
@@ -428,7 +428,7 @@ describe('tracker pins (ADO-554)', () => {
     expect(ids).not.toContain('eos:eo_bad');            // force_hide dropped
     expect(ids).toContain('eos:eo_kept');               // untouched stream row
     expect(ids).toContain('eos:eo_low');                // alarm 2, injected by pin
-    // pinned pardon at alarm 4 arrives via the stream — exactly once
+    // pinned pardon at alarm 5 arrives via the stream — exactly once
     expect(ids.filter(id => id === 'pardons:77')).toHaveLength(1);
   });
 

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -310,9 +310,15 @@ export function forceShowIdsBySource(pins: TrackerPins): Partial<Record<Timeline
  *
  * In the 'main' view, pins adjust the non-stories sources client-side:
  * force_hide entries are dropped from every page, and on the FIRST page
- * (state === null) force_show rows below the alarm-4 stream are fetched by id
+ * (state === null) force_show rows below the alarm-5 stream are fetched by id
  * and merged in at their chronological position. Stories pins are already
  * applied by v_tracker_stories on the server.
+ *
+ * Pinned rows surface AT THEIR DATE, deliberately: the Tracker is a
+ * chronological record, not a pinboard (pin-to-top is the ADO-552 hero
+ * carousel), so an injected old pin stays buffered by the coverage frontier
+ * until paging reaches its date — exempting it would fake completeness of a
+ * range that hasn't loaded. Covered by the frontier test in the pins suite.
  */
 export async function fetchTrackerPage(
   view: TrackerView,

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -221,8 +221,10 @@ const quoted = (v: string | number) => `"${String(v).replace(/"/g, '')}"`;
  * with `:`/`+` survive, and the whole logic tree is URL-encoded.
  *
  * In the 'main' view (ADO-554) stories filter on the server-computed
- * main_line column; the other sources keep the alarm-4+ predicate (they are
- * all loose ends until fronts can contain them) with pins applied client-side.
+ * main_line column; the other sources get the loose-end bar — alarm 5 only
+ * (rule v1.1: they are all loose ends until fronts can contain them, and the
+ * 4+ bar drowned the line in severity-saturated rows) — with pins applied
+ * client-side.
  */
 export function buildSourcePath(
   source: TimelineSource,
@@ -232,7 +234,7 @@ export function buildSourcePath(
   const s = SPECS[source];
   const conditions: string[] = [];
   const alarmFrag = view === 'main'
-    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(4))
+    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(5))
     : s.alarm(view);
   if (alarmFrag) conditions.push(alarmFrag);
   if (cursor) {
@@ -365,7 +367,7 @@ export async function fetchTrackerPage(
   );
 
   // First page of the main line: surface force_show pins on non-stories
-  // sources. Only rows below the alarm-4 stream are merged — anything at 4+
+  // sources. Only rows below the alarm-5 stream are merged — anything at 5
   // arrives (or already arrived) through normal paging, so injecting it again
   // would duplicate the entry.
   if (isMain && state === null && pins?.size) {
@@ -381,7 +383,7 @@ export async function fetchTrackerPage(
           );
           if (!res.ok) return [];
           const rows: Raw[] = await res.json();
-          return rows.map(spec.adapter).filter(e => e.alarm < 4);
+          return rows.map(spec.adapter).filter(e => e.alarm < 5);
         } catch (err) {
           if ((err as Error).name === 'AbortError') throw err;
           return []; // pins are additive — a failed fetch must not break the page


### PR DESCRIPTION
Josh's live TEST review (August 23, 2026): the alarm-4+ loose-end bar drowned the main line because enrichment severity saturation rates ~67% of stories alarm 4+ (measured: TEST 61%, PROD 67%). Fronts are the organizing layer - an unfiled alarm-4 story means "not filed yet", not "main line".

Rule v1.1: loose ends (stories without a published front, and all EO/SCOTUS/pardon rows) make the main line at alarm 5 only. Front members keep the richer logic (opening OR alarm 5 OR new peak at 4+). A BLS-class alarm-4 loose end reaches the line via filing or force_show until severity calibration lands (being carded separately).

- Migration 112 updated in place (not yet on PROD) and re-applied on TEST: main line 414 → 209 stories (39 front anchors + 170 alarm-5 loose ends)
- timeline.ts: non-stories main-mode predicate 4→5; force_show injection guard alarm<5
- Also this session on TEST data: 52 more stories bulk-filed into the fronts (Epstein 28, Iran 22, Crypto 2 - 79 filed total) so front tags are visible across the line

Tests: timeline suite 34/34, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)