### PR TITLE
Analytics Phase 5a + Tracker debut: ADO-558/559/560/563 + ADO-554 (rap_sheet ON)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ## What it is
 AI political-accountability tracker. Four content types: **Stories** (clustered news), **Executive Orders**, **SCOTUS** cases, and **Pardons** — each ingested, AI-enriched, reviewed, and published.
 
-## Pipeline flow (current state, 2026-08-05)
+## Pipeline flow (current state, 2026-08-24)
 
 ```mermaid
 flowchart LR
@@ -51,6 +51,15 @@ flowchart LR
 | `COURTLISTENER_API_TOKEN` | SCOTUS case fetch | New SCOTUS cases |
 | `ADMIN_DASHBOARD_PASSWORD` (Supabase secret) | admin edge functions (judge-log, judge-merge, etc.) | Admin dashboard actions |
 
+## Analytics vendors (client-side only, $0/month)
+
+| Vendor | Loads when | What it captures | Where configured |
+|--------|-----------|------------------|------------------|
+| GA4 | PROD hostname only (`public/analytics-gate.js`, ADO-558) | Pageviews | GA4 property (unchanged) |
+| PostHog (project 572949, US cloud, Free plan, **no payment method on file = hard $0 cap**) | PROD hostname only, same gate (ADO-559) | `$pageview`, autocapture, sampled + masked session replay, named KPI events `card_open` / `source_click` / `share_click` / `filter_apply` / `search` / `pagination` (ADO-560) | `src/lib/analytics.ts` (typed wrapper), `public/shared.js` (legacy pages); dashboards live in PostHog |
+
+Neither vendor runs on TEST or localhost, so analytics are only observable on trumpytracker.com. Feedback + newsletter events ship in Phase 5b (ADO-561/562).
+
 ## Kill switches (repo variables unless noted)
 
 | Switch | Governs | Default |
@@ -60,6 +69,7 @@ flowchart LR
 | `ENABLE_TIERB_MARGIN_BYPASS` | Tier B clustering margin bypass | `true` |
 | `JUDGE_DRY_RUN` (cloud agent env) | Judge live-merge vs dry-run (`'false'` = live) | `false` (live) |
 | Disable a RemoteTrigger cron | Any single Claude agent | — |
+| `rap_sheet` in `public/shared/flags-prod.json` | The Tracker homepage (main line, fronts) — ON since August 24, 2026 (ADO-554) | `true` |
 
 ## Components (what each owns)
 - **RSS pipeline** (`rss-tracker-supabase.js`): fetch → cluster, inline. Budget-capped ($5/day), runs every 2h on PROD via GitHub Actions.

--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -323,7 +323,7 @@ Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
 
 `id, primary_headline, first_seen_at, alarm_level, severity, front_id, front_name, front_slug, front_opening, tracker_pin, alarm_eff, main_line`
 
-**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
+**The rule (v1.1):** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff = 5` (raised from 4+ on August 23, 2026: fronts are the organizing layer and enrichment severity saturation rates ~67% of stories 4+, which drowned the main line); front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
 
 `security_invoker = true` — for anon, unpublished fronts' members count as loose ends (RLS hides the membership), by design. EO/SCOTUS/pardon rows have no front membership; the frontend applies their loose-end rule + pins client-side from `tracker_pin`.
 

--- a/docs/database/database-schema.md
+++ b/docs/database/database-schema.md
@@ -1,6 +1,6 @@
 # TrumpyTracker Database Schema
 
-**Last Updated:** 2026-08-19 (fronts tables, migration 111)
+**Last Updated:** 2026-08-23 (tracker_pin + v_tracker_stories, migration 112)
 **Status:** RSS v2 system active on both TEST and PROD
 
 ---
@@ -303,6 +303,29 @@ Full column contract: PRD §6 (`docs/features/events-tracker/prd.md`).
 `event_id, story_count, source_count (article_story rows across members), update_count (approved only), last_activity_at (max member story last_updated_at), peak_alarm (COALESCE(alarm_level, severity map, 2) — rubric/admin QA only, never displays), days_since_update (whole days since last approved update's happened_at)`
 
 `security_invoker = true` — anon reads inherit table RLS. GRANT SELECT to anon on all three tables + view (migration 046 auto-revoke countered).
+
+### `tracker_pin`
+**Purpose:** Per-entry Tracker main-line override — optional hand-curation on top of the rule (ADO-554)
+**Migration:** `112_tracker_main_line.sql` (applied on TEST 2026-08-23)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| source | TEXT | PK part — `stories` / `eos` / `scotus` / `pardons` (CHECK) |
+| entity_id | TEXT | PK part — TEXT on purpose: EO ids are VARCHAR on PROD, INTEGER on TEST (migration 108 drift) |
+| pin | TEXT | `force_show` \| `force_hide` (CHECK) |
+| note | TEXT | Optional admin breadcrumb (why pinned) |
+| created_at / updated_at | TIMESTAMPTZ | updated_at via `set_updated_at()` trigger |
+
+**RLS:** anon SELECT policy with a **column-level grant on `source`, `entity_id`, `pin` only** — pin existence is public curation data (a force_shown row renders publicly), but `note` is an admin breadcrumb and is NOT anon-readable. Writes service_role only. ADO-547 ships the admin editor.
+
+### `v_tracker_stories` (view)
+**Purpose:** The Tracker spine's stories read path with the server-computed `main_line` rule (ADO-554, PRD §12 anchor principle)
+
+`id, primary_headline, first_seen_at, alarm_level, severity, front_id, front_name, front_slug, front_opening, tracker_pin, alarm_eff, main_line`
+
+**The rule:** `force_show` pin → true; `force_hide` → false; no published front (loose end) → `alarm_eff >= 4`; front member → front opening (earliest member by `first_seen_at, id`) OR `alarm_eff = 5` OR (`alarm_eff >= 4` AND strictly greater than every earlier member's `alarm_eff` in that front — a tie is not a new peak). `alarm_eff` = COALESCE(alarm_level, severity map, 2) — same fallback as the adapters and `v_event_stats`. Bakes in `status = 'active' AND summary_neutral IS NOT NULL`; term scoping stays client-side.
+
+`security_invoker = true` — for anon, unpublished fronts' members count as loose ends (RLS hides the membership), by design. EO/SCOTUS/pardon rows have no front membership; the frontend applies their loose-end rule + pins client-side from `tracker_pin`.
 
 ---
 

--- a/docs/features/analytics/plan-product-analytics-v1.md
+++ b/docs/features/analytics/plan-product-analytics-v1.md
@@ -1,0 +1,125 @@
+# Implementation Plan: Product Analytics v1
+
+**PRD:** `docs/features/analytics/prd.md` (read it first — this plan implements that scope, nothing more)
+**ADO:** Epic 254 → Bug 558 (GA4 gate, ships first) + Stories 559 (P1), 560 (P2), 561 (P3), 562 (P4), 563 (P5) — each phase ≈ one session
+**Before starting: check PRD §0 "Open Decisions" — unanswered items there block the stories they name (Phase 0 blocks ADO-559).**
+**Branch:** develop on `test` (direct commit/push in interactive sessions; autonomous/overnight sessions deliver via PR to `test` per the 2026-08-19 convention). PROD ships via cherry-picked deployment branch + PR to `main`.
+
+---
+
+## Phase 0: PostHog account setup (Josh, ~15 min, no code)
+
+**Status August 23, 2026: DONE except the key handoff** — US cloud project 572949 created; no payment method attached (= billing-cap equivalent; if a card is ever added, set a $0 limit that day); replay sampling 10%; input masking left at PostHog's mask-everything default (do NOT turn off — newsletter email + feedback box would show in recordings); repo-watch/GitHub integration declined. **Remaining: paste the `phc_` key into ADO-559.** Original steps kept below for re-setup reference:
+
+1. Create PostHog Cloud US account + one project ("TrumpyTracker PROD").
+2. **Set the project billing limit to $0** (Settings → Billing) — hard requirement before any script ships.
+3. Enable session replay: sample rate 10%, "mask all text inputs" ON.
+4. Copy the project API key (`phc_...`). **Reviewer exception, stated here so nobody blocks it later:** this is a *publishable* client key, same trust class as the Supabase anon key already committed in this frontend — it identifies the project, it grants no read access. It lives in a clearly named constant (`POSTHOG_PUBLISHABLE_KEY`) in the snippet/config, committed on purpose. Secret-class PostHog keys (personal API keys) must never appear in the repo.
+
+## Phase 1: PostHog bootstrap + environment gating (1 session)
+
+**Files:** `index.html`, `public/*.html` (the live legacy pages that already carry the gtag snippet), new `src/lib/analytics.ts`
+
+1. **Load path decision: HTML snippet only, no npm dependency.** One load mechanism for both the React app and legacy pages — the official PostHog snippet (async, deferred) added next to the existing gtag snippet in `index.html` and each legacy page that has gtag today (`rg -l googletagmanager public/*.html` for the authoritative list). `src/lib/analytics.ts` types the global (`declare global { interface Window { posthog?: ... } }`) — do NOT add `posthog-js` to package.json; two load paths would drift.
+   - **Scope check before touching legacy pages:** confirm which `public/*.html` pages are still production surfaces actually served on trumpytracker.com (vs dead/parked files). Only instrument live ones; list them in the ADO card.
+2. **Gate on hostname:** initialize PostHog only when `location.hostname === 'trumpytracker.com'`. On TEST/localhost, expose a console-logging stub.
+   - **Fix the existing GA4 leak while here:** today the gtag snippet fires `gtag('config', ...)` unconditionally in `index.html` and every legacy page, so TEST/localhost **pageviews already pollute PROD GA4** — only `shared.js` custom events are gated. Gating the config call is not enough: the external `googletagmanager.com/gtag/js` script tag itself must not load off-PROD (the QA criterion is ZERO analytics network calls). Replace the static `<script async src>` with conditional injection — inside the hostname gate, `document.createElement('script')` for both gtag and PostHog. Same pattern in `index.html` and every live legacy page; also gate the `App.tsx` route-change `gtag('config', ...)` call. One gating convention, both vendors, script level.
+   - **This GA4 gate can (and should) ship first as its own small commit/PR** ahead of the PostHog work — it immediately stops dev/TEST traffic corrupting PROD traffic numbers and carries near-zero risk.
+3. Autocapture ON (default). SPA pageviews: pin the exact option against the current posthog-js docs at implementation time (recent SDKs: `capture_pageview: 'history_change'`; older ones need a manual `$pageview` capture on route change). Do not guess — verify against the SDK version the snippet serves, and record the chosen config in this doc.
+
+   **RESOLVED (August 23, 2026, ADO-559).** Verified by fetching the CDN bundle actually served at `https://us-assets.i.posthog.com/static/array.js`: it reports `LIB_VERSION="1.418.10"` and contains the `"history_change"` branch, so the option is supported. Config shipped in `public/analytics-gate.js`:
+
+   ```js
+   posthog.init(POSTHOG_PUBLISHABLE_KEY, {
+     api_host: 'https://us.i.posthog.com',
+     autocapture: true,
+     capture_pageview: 'history_change',   // SPA route changes, no manual $pageview
+     capture_pageleave: true,
+     person_profiles: 'identified_only',   // nobody is ever identified -> no person
+                                           // profiles for anonymous traffic (free tier)
+     session_recording: { maskAllInputs: true },
+   });
+   ```
+
+   Because PostHog captures route changes itself, `trackPageView()` in `src/lib/analytics.ts` is **GA4-only** on purpose — it is not a dual-fire.
+
+   **Loader deviation, and why.** The plan said "the official PostHog snippet". We load `array.js` via `document.createElement` + `init` on `onload` instead of pasting PostHog's minified queueing stub. The stub's only job is buffering calls made before the library lands, which a readable ~10-line queue in `analytics-gate.js` does instead. The deciding reason is a real hazard: `array.js` self-assigns `window.posthog` and its bootstrap is `if (!window.posthog || isArray(window.posthog._i))`, so assigning *any* non-stub object to `window.posthog` makes PostHog **skip initialization entirely and fail silently**. The gate therefore must not touch that global before load, and both surfaces mirror through a `window.TTAnalytics.capture` façade rather than `window.posthog` directly. Covered by a regression test.
+4. `src/lib/analytics.ts`: thin typed wrapper with **per-event property maps**, not a loose Record —
+   ```ts
+   interface EventProps {
+     card_open: { item_type: ItemType; alarm_level: number; feed_position: number | 'hero' | 'featured'; tab: string };
+     source_click: { item_type: ItemType; outlet_domain: string; source_position: number };
+     search: { tab: string; query_length: number };
+     // ...one entry per PRD §4 event
+   }
+   function track<E extends keyof EventProps>(event: E, props: EventProps[E]): void
+   ```
+   - Event names AND property keys/types are compile-time enforced (same philosophy as `skip-reasons.js`) — a future caller physically cannot pass free text or a raw query string to `search`, because the type only accepts `query_length: number`. This is the React-side equivalent of `shared.js`'s `ALLOWED_PARAMS` runtime allowlist, which the wrapper's direct `window.gtag` dual-fire would otherwise bypass. Belt-and-suspenders: the wrapper also drops undeclared prop keys at runtime (guards against `as any` casts).
+   - `ItemType` is an analytics-local type — `type AnalyticsItemType = 'story' | 'eo' | 'scotus' | 'pardon'` defined in `analytics.ts` with a small normalizer from `DisplayItem.type` (which is a plain `string` in `src/types.ts`); don't widen the shared types for this.
+   - **Wrapper scope: React app ONLY.** `analytics.ts` is bundled by Vite and is NOT available to `public/shared.js`/legacy pages. Legacy pages keep their existing `trackEvent` + `ALLOWED_PARAMS` path for GA4, and mirror their named events to PostHog with a small guarded addition inside `shared.js` itself (`if (window.posthog) posthog.capture(name, params)` after the allowlist filter, so the same allowlist protects both vendors). No shared shim — two surfaces, two deliberately separate implementations, one allowlist each.
+   - Dual-fires to `window.gtag` when present (event name + props passed through).
+   - Never throws; all calls wrapped so an analytics failure can't break the UI.
+5. GA4 allowlist: add any new param names to `ALLOWED_PARAMS` in `public/shared.js` and bump `schema_v` (see memory/gotcha: unlisted params are SILENTLY dropped).
+6. **GA4's role, stated so nobody over-builds it:** GA4 is traffic/acquisition reporting plus a raw-event backup. PostHog is the behavioral analysis layer. Do NOT pre-register GA4 custom dimensions for the new event properties — without registration the props still land in raw events (BigQuery-exportable), they just aren't sliceable in GA4 reports, and that's fine. Register a custom dimension manually only if/when a specific Looker Studio report needs that specific property, as a documented one-off.
+
+**QA:** `npm run qa:smoke`; verify locally that NO network calls go to PostHog/GA4 (console stub only); verify the snippet is inert without the PROD hostname.
+
+## Phase 2: Named events in the React app (1 session)
+
+**Files:** `src/components/Card.tsx`, `src/pages/Detail.tsx`, `src/pages/Home.tsx` (or wherever filter pills/search/pagination handlers live — confirm via `src/hooks/useFilters.ts` call sites), `src/App.tsx`
+
+Wire the PRD §4 events:
+
+| Event | Where |
+|---|---|
+| `card_open` | **In `Home.tsx`, not `Card.tsx`.** `Card` receives only `item`/`headlineMode`/`onOpen` and doesn't know its position or tab, and two open surfaces bypass `Card` entirely (the hero `<h1 onClick>` and the featured card). Fix: `Home` builds a per-item wrapper — `const openWithTracking = (item, position) => { track('card_open', { item_type, alarm_level, feed_position: position, tab }); onOpenItem(item.id); }` — and passes the closure at all three call sites: hero (`feed_position: 'hero'`), featured (`'featured'`), and grid cards (numeric index). `Home` already has the item, the index at map time, and the tab via its filter config; `Card`'s interface doesn't change. |
+| `source_click` | `Detail.tsx` — the sources list anchors AND the event-timeline source anchors (two distinct render sites; instrument both) |
+| `share_click` | `Detail.tsx` — the copy-link and social share handlers |
+| `correction_click` | `Detail.tsx` — the corrections mailto anchor |
+| `filter_apply`, `search`, `pagination` | `useFilters` consumers — fire at the commit point, not per keystroke |
+
+Rules:
+- Props only from PRD §4 — no free text, no query strings (length only).
+- Don't block navigation on event dispatch (fire-and-forget; PostHog handles beacon/unload).
+
+**QA:** vitest for the wrapper (event-name typing, gtag dual-fire, no-throw on missing SDK); `npm run qa:smoke`; manual click-through on local with console stub verifying every event + props.
+
+## Phase 3: Feedback popup (1 session)
+
+**Scope decision (Josh, August 23, 2026): deliberately minimal — "a simple popup where they can say there's an issue with the site." Message-only, React app only, no email, no category, no Turnstile, no legacy include. Deferred extras listed in PRD §5 — do NOT build them.**
+
+**Files:** new `src/components/FeedbackButton.tsx`, new `supabase/functions/feedback-submit/index.ts`, new migration, `public/shared/flags-prod.json` + `flags-test.json`
+
+1. **Migration `113_feedback.sql`** (112 exists — `112_tracker_main_line.sql`; re-verify max number at build time): `CREATE TABLE IF NOT EXISTS feedback` — `id` identity, `message` text NOT NULL (≤2000 enforced in function), `page_path` text, `created_at` timestamptz DEFAULT now(). **Every statement idempotent** (`IF NOT EXISTS` / guarded `DO` blocks) per AGENTS.md. RLS on, **no anon grants** (post-046 lockdown means it's invisible to anon by default — that's correct; only service_role reads/writes). No PII columns, so no retention machinery needed; prune ad hoc if it ever grows.
+2. **Edge function `feedback-submit`:** clone the `newsletter-signup` skeleton MINUS Turnstile — CORS headers, `rate_limits` reuse, honeypot check (reject when the hidden field is filled), input validation (non-empty, ≤2000 chars), insert with service role. No new secrets. Deploy to TEST ref `wnrjrywpcadwutfykflu` first.
+3. **React component:** floating button → popup (one text box with placeholder "What's wrong / what's missing? Don't include personal info." + hidden honeypot + submit) → POST to function. Behind feature flag **`feedback`** — flag files store unprefixed keys (see `rap_sheet` in `flags-prod.json`); `ff_` is only the URL-override prefix (`?ff_feedback=true`), stripped by `useFeatureFlag.ts`. OFF in `flags-prod.json` at ship, ON in `flags-test.json`.
+4. Fire `feedback_open` / `feedback_submit` (props: `page_path` only) via the wrapper.
+
+**QA:** function unit-tested against TEST (happy path, rate-limit, honeypot filled, empty message, 2001-char message); `npm run qa:smoke`; verify a TEST submission lands in the table.
+
+## Phase 4: Newsletter funnel + dashboards + privacy note (1 session)
+
+**Files:** `src/components/Footer.tsx` + `src/lib/newsletter.ts` (the React app's live newsletter path — the one the PRD's problem statement is actually about), `public/shared.js` (legacy pages' helpers), About page component, PostHog UI
+
+1. **React funnel first:** instrument `Footer.tsx`/`newsletter.ts` with `newsletter_view` (form rendered), `newsletter_submit`, `newsletter_success`, `newsletter_error` through the `analytics.ts` wrapper. Then mirror the same four steps in the legacy `shared.js` helpers (which already have submit/success/error — add `newsletter_view`, staying on `shared.js`'s own `trackEvent`/allowlist path with the PostHog mirror from Phase 1; legacy pages never import the Vite-bundled wrapper).
+2. Build the three dashboards in PostHog (PRD §6) and paste their URLs into the ADO card.
+   - Also configure the **feedback notification**: a PostHog alert on the `feedback_submit` event that emails Josh daily when count > 0 (digest-style, not per-event). Verify the alert email arrives (trigger a TEST-flag submission on PROD post-deploy, or use PostHog's test-send).
+3. About page: analytics disclosure paragraph (PRD §7).
+
+## Phase 5: PROD rollout + verification (part of a deploy session)
+
+1. Cherry-pick to a deployment branch → PR to `main` per `docs/guides/prod-deployment-checklist.md`. Deploy `feedback-submit` to PROD ref `osjbulmltfpcoldydexg`; apply migration 113 on PROD. No new secrets (feedback v1 has no Turnstile).
+2. Post-deploy verify on trumpytracker.com (analytics only work here): autocapture events arriving, each named event via real clicks, replay recording sampled + masked, GA4 still receiving.
+3. Flip the `feedback` key to `true` in `flags-prod.json` after a live test submission (the JSON key is `feedback`, NOT `ff_feedback` — see Phase 3 step 3).
+4. Confirm PostHog still can't bill (no payment method, or $0 limit if a card was added) one more time in settings.
+5. Update `docs/ARCHITECTURE.md` current-state tables (new vendor, new edge function, new flag, new secret consumers) — same-session rule.
+
+---
+
+## Explicitly out of scope (PRD §2)
+
+Web-vitals/perf, error tracking, uptime, admin feedback viewer. First fast-follow = PostHog web-vitals flag + `src/lib/api.ts` timing wrapper.
+
+## Cost
+
+$0/month: PostHog free tier with $0 hard cap, GA4 free, one more edge function (free tier), feedback table negligible. No OpenAI/Claude usage anywhere in this feature.

--- a/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
+++ b/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
@@ -1,0 +1,56 @@
+# Handoff — ADO-554: The Tracker main line (curation layer)
+
+**Date:** August 23, 2026
+**Ticket:** ADO-554 (new this session, sibling of 547 under epic 543) — Active → Testing
+**PR:** #127 `feature/ado-554-tracker-main-line` → `test`
+**Also this session:** ADO-544/545/546 closed as deployed-flag-off (Josh's standing instruction); ADO-547 AC6 re-scoped to the pin *editor* only, with a comment explaining the split.
+
+## Why this exists
+
+Josh's verdict on the PROD flag-off preview (August 23): the spine at alarm 4+ reads as **everything**, not the major-items main line. `rap_sheet` stays OFF on PROD until this ships — the flag flips once, debuting the curated Tracker. He asked for GENERALIZED anchor logic: rules decide the main line; he *can* hand-curate via `tracker_pin` but never *has* to.
+
+## The rule (v1) and where it came from
+
+Ground truth = Josh's 57 per-entry anchor flags in the rev-6 mockup (`.superpowers/brainstorm/events-homepage-v2/rap-sheet-w12-expand.html`, the `[date, alarm, headline, front, anchor]` rows). Analysis findings, so nobody re-derives them:
+
+- **Front openings:** all 7 fronts' first entries flagged 1 → mechanical rule, 7/7.
+- **Loose ends** (incl. every SCOTUS/EO/pardon row): flagged 1 iff alarm ≥ 4 → 18/19 (sole miss: "pardons a donor mid-trial", a4 flagged 0 — a routine recurrence; exactly what force_hide is for).
+- **Escalations:** NO mechanical rule reproduces them perfectly — "Gang of Eight skipped" (a5, flagged 0) vs "Fires the AG" (a5, flagged 1) are structurally identical; the difference is editorial. Best mechanical default: **alarm 5 OR new front peak at 4+** → 6/7 escalations, 5 over-inclusions all at alarm 5 (errs toward showing the worst — the safe direction; the alternatives would MISS "the Epstein files are released").
+- Net: **50/57 (88%) with zero curation.** Wave 2's drafter (`event_updates.significance='major'`) is the designed path to close the judgment gap; pins fix single rows meanwhile.
+
+```
+main_line(entry) =
+  force_show → in · force_hide → out
+  no published front → alarm_eff >= 4
+  front member → opening (earliest member) OR alarm_eff = 5
+                 OR (alarm_eff >= 4 AND > front prior peak)
+```
+
+## What shipped
+
+1. **Migration 112** (`migrations/112_tracker_main_line.sql`) — APPLIED on TEST (twice: idempotency proven):
+   - `tracker_pin` (PK source+entity_id; entity_id TEXT for the EO id drift). **Column-level anon grant on source/entity_id/pin only — `note` is admin-private** (AI-review blocker fix).
+   - `v_tracker_stories` (security_invoker): bakes in active+enriched, exposes front fields + `alarm_eff` + server-computed `main_line`. **Codex P1 fix: the opening/prior-peak window joins stories with the same active+enriched predicates** — merge tombstones in `story_event` can't hold the opening slot or suppress escalations.
+2. **`src/lib/timeline.ts`** — `TrackerView` ('main' | 0 | 3 | 5); stories read the view; `fetchTrackerPins` / `forceShowIdsBySource`; main mode drops force_hidden non-stories rows every page and injects force_shown rows (below the alarm-4 stream, first page only, no duplicates); `openFronts` tally.
+3. **`src/components/TrackerSpine.tsx`** — default segment **Main line**; front name renders as a row tag (nav lands with ADO-548); Open fronts tile; main-mode client alarm floor is 0 (server decided).
+4. **Seed data on TEST** (via supabase-test MCP, service_role): 7 published fronts (events ids 7–13: epstein-files, iran, trump-crypto, qatar-jet, selling-the-white-house, the-courts, kushners-deals — Kushner's has no members, no matching TEST stories), 27 story assignments, 2 demo pins (force_hide stories/14830 explainer; force_show eos/5 alarm-3 401(k) EO).
+5. **Docs:** database-schema.md Fronts section extended (tracker_pin + v_tracker_stories + the rule).
+
+## Verification done
+
+- vitest 146/146 (5 new pin/injection/main-mode tests), `tsc --noEmit` clean, vite build clean, `qa:smoke` exit 0.
+- Anon PostgREST: view + pins readable; `select=note` correctly 42501; main line = 414 story rows; open fronts = 7.
+- Live on localhost:3000 (TEST DB, chrome): Main line default with 7-fronts tally; Qatar's alarm-3 opening ON the line with front tag; Iran's 6 routine assigned a3/a4 rows OFF while its a5s stay tagged IRAN; unassigned Iran loose ends at 4+ still show (correct — not filed yet, that's 547's admin); force_shown EO appears at its Aug 2025 position; force_hidden explainer absent. Zero console errors.
+
+## Gotchas for next sessions
+
+- **PROD deploy order:** apply migration 112 BEFORE cherry-picking the code (stories fetch targets the view; missing view = no stories on the Tracker). Then seed PROD fronts + assignments, then flip `rap_sheet`.
+- Unassigned stories at alarm ≥ 4 stay on the main line as loose ends BY DESIGN — assignment coverage (ADO-547 admin / Wave 2 agent) is what makes fronts absorb their routine developments.
+- An unpublished front's members count as loose ends for anon (RLS hides membership) — a draft front can't change the public main line.
+- Applied DDL via claude-in-chrome → SQL Editor (Josh's session), fetching the SQL from raw.githubusercontent inside the page — the migration-111 pattern, worked again.
+
+## Open items
+
+- Josh eyeballs the TEST site (AC7) → then Ready for Prod.
+- ADO-547 (admin UI incl. pin editor) is the next build; 548 front pages give the front tags their navigation.
+- ADO-553 cohort verify is a separate queue item (6 pardons in needs_review — Josh works those in admin).

--- a/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
+++ b/docs/handoffs/2026-08-23-ado-554-tracker-main-line.md
@@ -54,3 +54,15 @@ main_line(entry) =
 - Josh eyeballs the TEST site (AC7) → then Ready for Prod.
 - ADO-547 (admin UI incl. pin editor) is the next build; 548 front pages give the front tags their navigation.
 - ADO-553 cohort verify is a separate queue item (6 pardons in needs_review — Josh works those in admin).
+
+---
+
+## Addendum — live-review round (same evening)
+
+Josh reviewed TEST live; three outcomes:
+
+1. **Rule v1.1 — loose-end bar raised to alarm 5** (fronts keep opening / alarm-5 / new-peak-at-4+). WHY: measured severity saturation — PROD rates 67% of term-2 stories alarm 4+ (9,329/13,924; 1,376 at 5), TEST 61% — so the 4+ bar read as "everything". DB side applied on TEST (main line 414 → 209 = 39 front rows + 170 a5 loose ends); frontend half is **PR #128 — OPEN, Josh merges from his desktop** after the Codex thread. Codex P1 (pin-vs-frontier) answered with a full-pipeline test + kept-by-design rationale (pins surface at their date; pin-to-top = ADO-552); P2 comment fixed. d31f16c.
+2. **52 more stories bulk-filed** into the fronts via keyword sweep (79 total) so front tags read across the line.
+3. **New cards:** ADO-555 front enrichment, ADO-556 stories severity calibration (owns the "bar back to 4+?" question), ADO-557 fronts automation planning session (Josh: "covered automatically going forward"). Josh confirmed ADO-548 (front pages / expand-a-front) was never tonight's scope — it is the next reader-facing build.
+
+Branch hygiene: all merged deploy/feature branches swept locally and on origin. Kept: `ado-551-disposition-normalize` (unmerged fix) and `origin/claude/research-political-rss-feeds-uwR6a` (no PR — Josh to decide).

--- a/docs/handoffs/2026-08-23-ado-558-559-analytics-phase1.md
+++ b/docs/handoffs/2026-08-23-ado-558-559-analytics-phase1.md
@@ -1,0 +1,117 @@
+# Handoff: ADO-558 + ADO-559 — Product Analytics v1, Bug fix + Phase 1
+
+**Date:** August 23, 2026
+**ADO:** Epic 254 → Bug 558 (Active), User Story 559 (Active)
+**PRs:** [#129](https://github.com/AJWolfe18/TTracker/pull/129) (558) and [#130](https://github.com/AJWolfe18/TTracker/pull/130) (559), both open to `test`, both `@codex review` requested
+**Branches:** `feature/ado-558-ga4-hostname-gate`, `feature/ado-559-posthog-bootstrap` (stacked on 558)
+**Worktree:** `.claude/worktrees/analytics-v1` — used because another session owned the main tree
+
+---
+
+## What Josh needs to do
+
+1. **Merge PR #129 first**, then PR #130. (#130 is cut from #129, so its diff includes those files until #129 lands. If #130 goes first nothing breaks — #129 then shows as already-merged and can be closed.)
+2. Nothing else. Both cards stay **Active** until their PRs merge.
+
+---
+
+## What shipped
+
+### ADO-558 — GA4 was polluting PROD analytics
+
+Every dev and TEST visit was counted in PROD GA4 (`G-5MDT4HFMNB`). The gtag script tag and `gtag('config', …)` fired unconditionally in `index.html`, on `src/App.tsx` route changes, and on every legacy page. Only `shared.js` *custom events* were gated — pageviews were not.
+
+**Fix:** one gating pattern in one file.
+
+| File | Change |
+|---|---|
+| `public/analytics-gate.js` | **New.** The only place any analytics vendor loads. On PROD it injects the GA4 script via `document.createElement`; off PROD it installs a console-logging `gtag` stub and creates no script element and no `dataLayer`. Exposes `window.TT_ANALYTICS_ENABLED`. |
+| `index.html` + 3 legacy pages | Load that one file instead of each holding an inline copy. |
+| `src/lib/analytics.ts` | **New.** React-side half of the same rule. |
+| `src/App.tsx` | Per-route `gtag('config')` now goes through `trackPageView`. |
+
+### ADO-559 — PostHog bootstrap + typed wrapper (Phase 1)
+
+PostHog joins GA4 behind the same gate. Snippet-only load, **no npm dependency**, so there is one load path and the two can't drift.
+
+| File | Change |
+|---|---|
+| `public/analytics-gate.js` | Injects posthog-js alongside GA4 on PROD; off PROD both vendors are console stubs. |
+| `src/lib/analytics.ts` | `track<E>(event, props)` with per-event property maps, runtime allowlist, GA4 dual-fire, never throws. |
+| `public/shared.js` | `ALLOWED_PARAMS` gains the PRD §4 params; `schema_v` 1 → 2; PostHog mirror after the allowlist filter; environment gate unified onto the allowlist rule. |
+| `docs/features/analytics/plan-product-analytics-v1.md` | Phase 1 step 3 config recorded, as the plan required. |
+
+---
+
+## Three findings worth carrying forward
+
+### 1. Never assign `window.posthog` before posthog-js loads
+
+The plan said "use the official PostHog snippet". We don't. Reading the bundle actually served revealed why that matters:
+
+```js
+var i = v.posthog;
+if (!i || X(i._i)) { /* create instance, assign v.posthog */ }
+```
+
+`array.js` **self-assigns `window.posthog`**, and only initializes if that global is absent or is a stub carrying an `_i` array. Assigning any other object to `window.posthog` makes PostHog **skip initialization entirely and fail silently** — no error, no events, nothing to notice.
+
+So the gate loads `array.js` and calls `init` in `onload`, with a small capped queue for captures made before it lands, and both surfaces mirror through a `window.TTAnalytics.capture` façade instead of touching `window.posthog`. Pinned by a regression test.
+
+### 2. The SPA pageview option is pinned to a verified SDK version
+
+The bundle at `https://us-assets.i.posthog.com/static/array.js` reports `LIB_VERSION="1.418.10"` and contains the `"history_change"` branch, so `capture_pageview: 'history_change'` is supported. **Consequence:** `trackPageView()` is **GA4-only** on purpose — PostHog captures route changes itself, so dual-firing would double-count.
+
+### 3. `shared.js`'s environment gate was a denylist, and it leaked
+
+It checked `'test--'`, `localhost`, `127.0.0.1` — which misses Netlify **deploy previews** (`deploy-preview-42--…`) and any other branch deploy. Now unified onto the allowlist rule via `TT_ANALYTICS_ENABLED`, with a fallback that fails closed.
+
+---
+
+## How to verify
+
+```bash
+npx vitest run     # 169/169 (22 analytics)
+npm run lint       # tsc --noEmit, clean
+npm run qa:smoke   # exit 0
+npm run build && grep -rl "googletagmanager\|posthog" dist/ | grep -v '\.map$'
+#   -> dist/analytics-gate.js only
+```
+
+The strongest evidence is `src/__tests__/analytics.test.ts`: it imports the **real shipped loader** with `?raw` and executes it against a fake DOM on 7 off-PROD hostnames — `localhost`, `127.0.0.1`, `test--…netlify.app`, `deploy-preview-42--…`, the bare netlify subdomain, plus `trumpytracker.com.evil.example` and `nottrumpytracker.com` — asserting **0 script elements created, 0 appended, no `dataLayer`**. That is the ADO-558 AC proven directly rather than inferred.
+
+The compile-time schema guard was verified by deliberately breaking it:
+
+```
+error TS2322: Type 'SchemaCheck' is not assignable to type 'Record<keyof EventProps, true>'.
+  Types of property 'search' are incompatible.
+    Type '["ANALYTICS SCHEMA DRIFT", "query_length"]' is not assignable to type 'true'.
+```
+
+It names the event *and* the drifting key. Reverted after the check.
+
+---
+
+## Review response (PR #129 automated review, no blockers)
+
+**Taken:** double-include guard (a second injection would double-count pageviews — the very metric being fixed); case-insensitive hostname + `www` alias (still exact-match, never a suffix test).
+
+**Rejected — one would have caused a real bug:** the suggestion to use a relative `src` instead of `/analytics-gate.js` **would break the React app.** It is an SPA served at routes like `/detail/123`, where a relative path resolves to `/detail/analytics-gate.js` and 404s. Also rejected: `<link rel="preload">` (the tag is already first in `<head>`) and `id="analytics-gate"` (no runtime or test value).
+
+---
+
+## Gotchas hit along the way
+
+- **A subset of `node_modules` is tracked in this repo.** `npm ci` in a fresh worktree rewrites their line endings and they show as modified. Stage files explicitly — **never `git add -A`** here.
+- **`@types/node` is not a dependency.** A test that imported `node:fs`/`node:vm` failed `tsc`. Vite's `?raw` import plus `new Function` does the same job with no node builtins.
+- The legacy pages are **orphaned but still served**: `dashboard-legacy.html`, `executive-orders.html`, `pardons.html` ship in `dist/` and are reachable by direct URL, but nothing in the current site links to them. Gated anyway — same pollution, two-line change.
+
+---
+
+## Next
+
+- **ADO-560** (Phase 2): wire the PRD §4 named events in the React app. `card_open` belongs in `Home.tsx`, not `Card.tsx` — see the plan's table for why (three open surfaces, two of which bypass `Card`).
+- Phases 3–5 unchanged: feedback popup, newsletter funnel + dashboards, PROD rollout.
+- **Verification debt by design:** real events arriving in PostHog, replay sampling/masking, and GA4 continuity can only be confirmed after the PROD deploy (PRD §3). That is Phase 5 / ADO-563.
+
+**Cost: $0.** PostHog free tier, no payment method attached, `person_profiles: 'identified_only'` so anonymous traffic creates no person profiles.

--- a/index.html
+++ b/index.html
@@ -24,14 +24,8 @@
     rel="stylesheet"
   />
 
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5MDT4HFMNB"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-5MDT4HFMNB');
-  </script>
+  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD. -->
+  <script src="/analytics-gate.js"></script>
 
   <!-- FOUC prevention: set mode before any CSS/React loads -->
   <script>

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -1,0 +1,202 @@
+-- Migration: 112_tracker_main_line.sql
+-- Purpose: The Tracker's curation layer (ADO-554, Epic ADO-543) — the "main line"
+--   inclusion rule from PRD §12's locked anchor principle, plus the tracker_pin
+--   override promised by the homepage design (rev 6, 2026-08-18).
+--
+--   A) tracker_pin       — per-entry force_show/force_hide across all four sources.
+--                          Hand-curation is OPTIONAL: the rule below decides the
+--                          main line; a pin only ever corrects a single row.
+--   B) v_tracker_stories — the spine's stories read path, with main_line computed
+--                          server-side:
+--                            pin override            → force_show in, force_hide out
+--                            no published front      → effective alarm >= 4 (loose end)
+--                            front member            → front opening (earliest member)
+--                                                      OR alarm 5
+--                                                      OR alarm >= 4 setting a new
+--                                                      front peak (escalation)
+--                          Routine developments on a front drop OFF the main line
+--                          and live on the front's own page (ADO-548).
+--
+-- EO/SCOTUS/pardon rows have no front membership today, so their main-line rule
+-- (loose end: alarm >= 4, plus pins) is applied by the frontend from the same
+-- tracker_pin table — no views needed for them.
+--
+-- Apply manually via the Supabase SQL Editor (NOT apply-migrations.js).
+-- DEPENDENCIES: migration 111 (events/story_event), set_updated_at() (migration 001).
+--
+-- SECURITY: migration 046 auto-revokes anon on new tables — explicit GRANTs below.
+-- Pin EXISTENCE is public curation data by definition (a force_show row renders
+-- publicly), so anon gets a SELECT policy — but only on source/entity_id/pin
+-- (column-level grant): the note column is an admin breadcrumb and stays
+-- private. Writes stay service_role-only (no anon or authenticated write
+-- policies). The view is security_invoker so anon reads
+-- through it inherit the RLS publish gates from migration 111 — an UNPUBLISHED
+-- front's members still count as loose ends for anon, which is the intended
+-- behavior (a draft front must not change the public main line).
+
+-- ============================================================================
+-- PART A: tracker_pin — per-entry main-line override, all four sources
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tracker_pin (
+  source     TEXT NOT NULL
+             CONSTRAINT tracker_pin_source_check
+             CHECK (source IN ('stories', 'eos', 'scotus', 'pardons')),
+  -- TEXT on purpose: EO ids are VARCHAR on PROD ('eo_<ts>_<suffix>') and INTEGER
+  -- on TEST (known drift, migration 108); stories/SCOTUS/pardons are numeric.
+  -- One table for all four sources beats four ALTER TABLEs and gives the admin
+  -- one place to list every pin (ADO-547 editor).
+  entity_id  TEXT NOT NULL,
+  pin        TEXT NOT NULL
+             CONSTRAINT tracker_pin_pin_check
+             CHECK (pin IN ('force_show', 'force_hide')),
+  note       TEXT,                                     -- optional admin breadcrumb (why pinned)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (source, entity_id)
+);
+
+COMMENT ON TABLE public.tracker_pin IS
+  'ADO-554: per-entry Tracker main-line override (force_show | force_hide) across stories/eos/scotus/pardons. Optional hand-curation on top of the rule in v_tracker_stories — never required for the main line to work. Written by admin (service_role); ADO-547 ships the editor.';
+
+DROP TRIGGER IF EXISTS trg_tracker_pin_set_updated_at ON public.tracker_pin;
+CREATE TRIGGER trg_tracker_pin_set_updated_at
+  BEFORE UPDATE ON public.tracker_pin
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.tracker_pin ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "tracker_pin_anon_select" ON public.tracker_pin;
+CREATE POLICY "tracker_pin_anon_select" ON public.tracker_pin
+  FOR SELECT TO anon
+  USING (true);
+
+-- Column-level anon grant: the frontend needs source/entity_id/pin only.
+-- `note` is an ADMIN breadcrumb (why pinned) and must not be publicly
+-- readable (AI review blocker on PR #127). REVOKE first so a re-run (or a DB
+-- that applied the earlier table-wide grant) converges to columns-only.
+REVOKE SELECT ON public.tracker_pin FROM anon;
+-- updated_at included: the frontend orders newest-first (deterministic
+-- truncation if pins ever outgrow the fetch cap), and ORDER BY needs SELECT
+-- privilege on the column.
+GRANT SELECT (source, entity_id, pin, updated_at) ON public.tracker_pin TO anon;
+GRANT ALL ON public.tracker_pin TO service_role;
+
+-- ============================================================================
+-- PART B: v_tracker_stories — spine read path with server-computed main_line
+-- ============================================================================
+
+-- security_invoker: anon reads hit the underlying tables' own RLS/grants.
+-- Anon holds SELECT on stories (046 re-grant), events/story_event (111,
+-- publish-gated), tracker_pin (above), so the joins resolve.
+CREATE OR REPLACE VIEW public.v_tracker_stories
+WITH (security_invoker = true) AS
+WITH front_members AS (
+  -- One row per member story of a PUBLISHED front, with the two front-relative
+  -- facts the rule needs: membership order (opening = first) and the peak
+  -- effective alarm among EARLIER members. Ordering is (first_seen_at, id) —
+  -- the same axis the spine pages on. The publish predicate is explicit for
+  -- service_role parity; for anon the RLS on events/story_event already
+  -- enforces it, so both roles compute identical main_line values.
+  --
+  -- The window runs over the SAME active/enriched story set the view exposes
+  -- (Codex P1 on PR #127): merge_stories leaves story_event pointing at
+  -- archived tombstones, and a hidden member must not hold member_seq 1 (the
+  -- visible first member would never flag as the opening) or feed its alarm
+  -- into front_prior_peak (suppressing real escalations).
+  SELECT
+    se.story_id,
+    se.event_id,
+    e.name AS front_name,
+    e.slug AS front_slug,
+    ROW_NUMBER() OVER w AS member_seq,
+    MAX(
+      COALESCE(
+        s.alarm_level,
+        CASE s.severity
+          WHEN 'critical' THEN 5
+          WHEN 'severe'   THEN 4
+          WHEN 'moderate' THEN 3
+          WHEN 'minor'    THEN 2
+        END,
+        2
+      )
+    ) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS front_prior_peak
+  FROM public.story_event se
+  JOIN public.events  e ON e.id = se.event_id AND e.publish_state = 'published'
+  JOIN public.stories s ON s.id = se.story_id
+                       AND s.status = 'active'
+                       AND s.summary_neutral IS NOT NULL
+  WINDOW w AS (PARTITION BY se.event_id ORDER BY s.first_seen_at, s.id)
+)
+SELECT
+  s.id,
+  s.primary_headline,
+  s.first_seen_at,
+  s.alarm_level,
+  s.severity,
+  fm.event_id     AS front_id,
+  fm.front_name,
+  fm.front_slug,
+  (fm.member_seq = 1)                                  AS front_opening,
+  p.pin                                                AS tracker_pin,
+  a.alarm_eff,
+  CASE
+    WHEN p.pin = 'force_show' THEN TRUE
+    WHEN p.pin = 'force_hide' THEN FALSE
+    -- Loose end (no published front): significant = alarm 4+.
+    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 4
+    -- Front member: opening, or escalation (alarm 5, or a new front peak at 4+).
+    ELSE fm.member_seq = 1
+      OR a.alarm_eff = 5
+      OR (a.alarm_eff >= 4 AND a.alarm_eff > COALESCE(fm.front_prior_peak, 0))
+  END AS main_line
+FROM public.stories s
+CROSS JOIN LATERAL (
+  -- Effective alarm: alarm_level, else the migration-064 severity mapping,
+  -- else 2 — the SAME fallback as the frontend adapters and v_event_stats.
+  SELECT COALESCE(
+    s.alarm_level,
+    CASE s.severity
+      WHEN 'critical' THEN 5
+      WHEN 'severe'   THEN 4
+      WHEN 'moderate' THEN 3
+      WHEN 'minor'    THEN 2
+    END,
+    2
+  )::smallint AS alarm_eff
+) a
+LEFT JOIN front_members fm ON fm.story_id = s.id
+LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::text
+-- The spine's base predicates, baked in (published, term scoping stays client-side):
+WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
+
+COMMENT ON VIEW public.v_tracker_stories IS
+  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle: pins override, loose ends need effective alarm >= 4, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
+
+GRANT SELECT ON public.v_tracker_stories TO anon;
+GRANT SELECT ON public.v_tracker_stories TO service_role;
+
+-- Refresh PostgREST's schema cache so the table/view are immediately queryable.
+NOTIFY pgrst, 'reload schema';
+
+-- ============================================================================
+-- VERIFICATION (run after applying)
+-- ============================================================================
+-- 1. Empty pin table, view resolves:
+--    SELECT count(*) FROM tracker_pin;
+--    SELECT count(*) FROM v_tracker_stories;                  -- = active enriched stories
+--    SELECT count(*) FROM v_tracker_stories WHERE main_line;  -- <= previous count
+-- 2. Rule sanity on a seeded front (after ADO-554 seeding):
+--    SELECT id, primary_headline, alarm_eff, front_name, front_opening, main_line
+--    FROM v_tracker_stories WHERE front_id IS NOT NULL
+--    ORDER BY front_id, first_seen_at;
+--    -- expect: member_seq 1 rows main_line = true; alarm_eff <= prior peak and < 5 rows false
+-- 3. Pin override: INSERT INTO tracker_pin VALUES ('stories', '<id>', 'force_hide');
+--    → that row's main_line flips false; DELETE the pin, it flips back.
+-- 4. Anon read (PostgREST anon key) returns rows — not 401/42501:
+--    curl -s "https://wnrjrywpcadwutfykflu.supabase.co/rest/v1/v_tracker_stories?select=id,main_line&limit=1" \
+--      -H "apikey: <ANON_KEY>" -H "Authorization: Bearer <ANON_KEY>"
+--    (repeat for tracker_pin — expect [])
+-- 5. Re-run this whole file — must be a no-op (idempotent).

--- a/migrations/112_tracker_main_line.sql
+++ b/migrations/112_tracker_main_line.sql
@@ -9,7 +9,8 @@
 --   B) v_tracker_stories — the spine's stories read path, with main_line computed
 --                          server-side:
 --                            pin override            → force_show in, force_hide out
---                            no published front      → effective alarm >= 4 (loose end)
+--                            no published front      → effective alarm 5 (loose end;
+--                                                      v1.1 bar, see CASE comment)
 --                            front member            → front opening (earliest member)
 --                                                      OR alarm 5
 --                                                      OR alarm >= 4 setting a new
@@ -18,7 +19,7 @@
 --                          and live on the front's own page (ADO-548).
 --
 -- EO/SCOTUS/pardon rows have no front membership today, so their main-line rule
--- (loose end: alarm >= 4, plus pins) is applied by the frontend from the same
+-- (loose end: alarm 5, plus pins) is applied by the frontend from the same
 -- tracker_pin table — no views needed for them.
 --
 -- Apply manually via the Supabase SQL Editor (NOT apply-migrations.js).
@@ -145,8 +146,14 @@ SELECT
   CASE
     WHEN p.pin = 'force_show' THEN TRUE
     WHEN p.pin = 'force_hide' THEN FALSE
-    -- Loose end (no published front): significant = alarm 4+.
-    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 4
+    -- Loose end (no published front): alarm 5 only (rule v1.1, Josh
+    -- August 23, 2026). Fronts are the organizing layer — an unfiled alarm-4
+    -- story usually means "not filed yet", not "main line". The 4+ bar drowned
+    -- the line because enrichment rates ~67% of stories 4+ (severity
+    -- saturation, same disease as the pre-agent EO pipeline); a BLS-class
+    -- alarm-4 loose end reaches the main line via filing or a force_show pin
+    -- until severity calibration lands.
+    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 5
     -- Front member: opening, or escalation (alarm 5, or a new front peak at 4+).
     ELSE fm.member_seq = 1
       OR a.alarm_eff = 5
@@ -173,7 +180,7 @@ LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::t
 WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
 
 COMMENT ON VIEW public.v_tracker_stories IS
-  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle: pins override, loose ends need effective alarm >= 4, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
+  'ADO-554: the Tracker spine''s stories read path. main_line implements PRD §12''s anchor principle (rule v1.1): pins override, loose ends need effective alarm 5, front members make the main line only as the front''s opening, at alarm 5, or on a new front peak at 4+. Tight columns on purpose — never widen to content/embedding (egress rule).';
 
 GRANT SELECT ON public.v_tracker_stories TO anon;
 GRANT SELECT ON public.v_tracker_stories TO service_role;

--- a/public/analytics-gate.js
+++ b/public/analytics-gate.js
@@ -50,17 +50,13 @@
   window.TT_ANALYTICS_ENABLED = enabled;
 
   // ---------------------------------------------------------------------
-  // Off PROD: console only. No script tags, no dataLayer, no requests.
+  // Off PROD: silent no-op stubs. No script tags, no dataLayer, no requests,
+  // no console output (repo rule: no console.log in shipped code). To see
+  // what WOULD fire on TEST, watch TTAnalytics.capture / gtag in DevTools.
   // ---------------------------------------------------------------------
   if (!enabled) {
-    window.gtag = function () {
-      console.log('[analytics:off-prod] gtag', Array.prototype.slice.call(arguments));
-    };
-    window.TTAnalytics = {
-      capture: function (name, props) {
-        console.log('[analytics:off-prod] posthog.capture', name, props);
-      },
-    };
+    window.gtag = function () {};
+    window.TTAnalytics = { capture: function () {} };
     return;
   }
 

--- a/public/analytics-gate.js
+++ b/public/analytics-gate.js
@@ -1,0 +1,60 @@
+/**
+ * Analytics environment gate (ADO-558).
+ *
+ * One gating pattern for every HTML surface: analytics vendors are only ever
+ * loaded on the production hostname. Off PROD (localhost, the Netlify TEST
+ * site, branch/deploy previews) nothing is injected and ZERO network requests
+ * are made to any analytics vendor -- callers get a console-logging stub so
+ * existing instrumentation keeps working without touching the wire.
+ *
+ * Loaded as a plain classic script from <head> by index.html (React app) and
+ * by every live legacy page in public/. It is deliberately NOT a module and
+ * NOT bundled by Vite, so it cannot import from src/ -- the React app mirrors
+ * these two constants in src/lib/analytics.ts. Keep them in sync.
+ *
+ * PostHog is added to this same gate in ADO-559 (Phase 1) -- one convention,
+ * both vendors, script level.
+ */
+(function () {
+  'use strict';
+
+  // If this file is ever included twice on one page, only the first run counts.
+  // A second GA4 injection would double-count pageviews -- the exact metric
+  // this gate exists to protect.
+  if (window.TT_ANALYTICS_GATE_LOADED) return;
+  window.TT_ANALYTICS_GATE_LOADED = true;
+
+  // Exact-match allowlist, never a suffix test (a suffix test would let
+  // trumpytracker.com.example.org through). www currently 301s to the apex, so
+  // only the apex is reachable today; the alias is here so that flipping
+  // Netlify's primary domain can't silently switch analytics off.
+  var ANALYTICS_HOSTNAMES = ['trumpytracker.com', 'www.trumpytracker.com'];
+  var GA4_MEASUREMENT_ID = 'G-5MDT4HFMNB';
+
+  var host = (window.location.hostname || '').toLowerCase();
+  var enabled = ANALYTICS_HOSTNAMES.indexOf(host) !== -1;
+
+  // Exposed so page scripts can branch without re-implementing the hostname
+  // rule (public/shared.js keeps its own defensive check as well).
+  window.TT_ANALYTICS_ENABLED = enabled;
+
+  if (!enabled) {
+    // Console stub only. No dataLayer, no script tag, no requests.
+    window.gtag = function () {
+      console.log('[analytics:off-prod] gtag', Array.prototype.slice.call(arguments));
+    };
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag() {
+    window.dataLayer.push(arguments);
+  };
+  window.gtag('js', new Date());
+  window.gtag('config', GA4_MEASUREMENT_ID);
+
+  var gaScript = document.createElement('script');
+  gaScript.async = true;
+  gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA4_MEASUREMENT_ID;
+  document.head.appendChild(gaScript);
+})();

--- a/public/analytics-gate.js
+++ b/public/analytics-gate.js
@@ -1,19 +1,22 @@
 /**
- * Analytics environment gate (ADO-558).
+ * Analytics environment gate (ADO-558) + PostHog bootstrap (ADO-559).
  *
- * One gating pattern for every HTML surface: analytics vendors are only ever
- * loaded on the production hostname. Off PROD (localhost, the Netlify TEST
- * site, branch/deploy previews) nothing is injected and ZERO network requests
- * are made to any analytics vendor -- callers get a console-logging stub so
- * existing instrumentation keeps working without touching the wire.
+ * One gating pattern for every HTML surface and every vendor: analytics are
+ * only ever loaded on the production hostname. Off PROD (localhost, the Netlify
+ * TEST site, branch/deploy previews) nothing is injected and ZERO network
+ * requests are made to any analytics vendor -- callers get console logging
+ * instead, so instrumentation is still observable while developing.
  *
- * Loaded as a plain classic script from <head> by index.html (React app) and
- * by every live legacy page in public/. It is deliberately NOT a module and
- * NOT bundled by Vite, so it cannot import from src/ -- the React app mirrors
- * these two constants in src/lib/analytics.ts. Keep them in sync.
+ * Loaded as a plain classic script from <head> by index.html (React app) and by
+ * every legacy page in public/ that carries analytics. It is deliberately NOT a
+ * module and NOT bundled by Vite, so it cannot import from src/ -- the React
+ * app mirrors the constants in src/lib/analytics.ts. Keep them in sync.
  *
- * PostHog is added to this same gate in ADO-559 (Phase 1) -- one convention,
- * both vendors, script level.
+ * Exposes:
+ *   window.TT_ANALYTICS_ENABLED  boolean
+ *   window.gtag(...)             GA4 (real on PROD, console stub off PROD)
+ *   window.TTAnalytics.capture(name, props)
+ *                                PostHog mirror, safe to call at any time
  */
 (function () {
   'use strict';
@@ -31,6 +34,14 @@
   var ANALYTICS_HOSTNAMES = ['trumpytracker.com', 'www.trumpytracker.com'];
   var GA4_MEASUREMENT_ID = 'G-5MDT4HFMNB';
 
+  // Publishable client-side project key -- identifies the PostHog project and
+  // grants no read access, same trust class as the Supabase anon key already in
+  // this frontend. Committed on purpose (plan Phase 0 "reviewer exception").
+  // Secret-class PostHog keys (personal API keys) must never appear in the repo.
+  var POSTHOG_PUBLISHABLE_KEY = 'phc_DfxYmHLbTycAnoLHV6ed3s2JeUpABfnxzwrerBJU8Dy3';
+  var POSTHOG_API_HOST = 'https://us.i.posthog.com';
+  var POSTHOG_ASSET_HOST = 'https://us-assets.i.posthog.com';
+
   var host = (window.location.hostname || '').toLowerCase();
   var enabled = ANALYTICS_HOSTNAMES.indexOf(host) !== -1;
 
@@ -38,14 +49,24 @@
   // rule (public/shared.js keeps its own defensive check as well).
   window.TT_ANALYTICS_ENABLED = enabled;
 
+  // ---------------------------------------------------------------------
+  // Off PROD: console only. No script tags, no dataLayer, no requests.
+  // ---------------------------------------------------------------------
   if (!enabled) {
-    // Console stub only. No dataLayer, no script tag, no requests.
     window.gtag = function () {
       console.log('[analytics:off-prod] gtag', Array.prototype.slice.call(arguments));
+    };
+    window.TTAnalytics = {
+      capture: function (name, props) {
+        console.log('[analytics:off-prod] posthog.capture', name, props);
+      },
     };
     return;
   }
 
+  // ---------------------------------------------------------------------
+  // GA4
+  // ---------------------------------------------------------------------
   window.dataLayer = window.dataLayer || [];
   window.gtag = function gtag() {
     window.dataLayer.push(arguments);
@@ -57,4 +78,69 @@
   gaScript.async = true;
   gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA4_MEASUREMENT_ID;
   document.head.appendChild(gaScript);
+
+  // ---------------------------------------------------------------------
+  // PostHog
+  //
+  // We load posthog-js (array.js) directly and init it on load, rather than
+  // pasting PostHog's minified queueing stub. Two reasons:
+  //   1. The stub's only job is buffering calls made before the library
+  //      arrives, which the small queue below does readably.
+  //   2. array.js self-assigns window.posthog, and its bootstrap is
+  //      `if (!window.posthog || isArray(window.posthog._i))`. Assigning our
+  //      own object to window.posthog would make PostHog skip initialization
+  //      ENTIRELY and fail silently, so we must not touch that global before
+  //      the library loads. (Verified against posthog-js 1.418.10.)
+  // ---------------------------------------------------------------------
+  var pendingEvents = [];
+  var posthogReady = false;
+
+  window.TTAnalytics = {
+    capture: function (name, props) {
+      if (!posthogReady) {
+        // Cap the buffer so a load failure can't grow it without bound.
+        if (pendingEvents.length < 50) pendingEvents.push([name, props]);
+        return;
+      }
+      try {
+        window.posthog.capture(name, props);
+      } catch (err) {
+        /* analytics must never break the page */
+      }
+    },
+  };
+
+  var phScript = document.createElement('script');
+  phScript.async = true;
+  phScript.src = POSTHOG_ASSET_HOST + '/static/array.js';
+  phScript.onload = function () {
+    if (!window.posthog || typeof window.posthog.init !== 'function') return;
+    try {
+      window.posthog.init(POSTHOG_PUBLISHABLE_KEY, {
+        api_host: POSTHOG_API_HOST,
+        // Autocapture covers generic clicks/taps for free (PRD section 2).
+        autocapture: true,
+        // SPA route changes. Pinned against posthog-js 1.418.10, which serves
+        // this option; older SDKs needed a manual $pageview on route change.
+        capture_pageview: 'history_change',
+        capture_pageleave: true,
+        // No accounts on this site, so nobody is ever identified. This keeps
+        // PostHog from creating person profiles for anonymous traffic, which
+        // is what keeps us inside the free tier (PRD section 3).
+        person_profiles: 'identified_only',
+        // Belt and suspenders with the project-level setting: replay sampling
+        // and masking are configured in the PostHog project, and we assert
+        // masking here too so a settings change can't silently unmask inputs.
+        session_recording: { maskAllInputs: true },
+      });
+      posthogReady = true;
+      for (var i = 0; i < pendingEvents.length; i++) {
+        window.posthog.capture(pendingEvents[i][0], pendingEvents[i][1]);
+      }
+      pendingEvents.length = 0;
+    } catch (err) {
+      /* analytics must never break the page */
+    }
+  };
+  document.head.appendChild(phScript);
 })();

--- a/public/dashboard-legacy.html
+++ b/public/dashboard-legacy.html
@@ -77,14 +77,8 @@
   <!-- Cloudflare Turnstile (newsletter bot protection) -->
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5MDT4HFMNB"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-5MDT4HFMNB');
-  </script>
+  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD. -->
+  <script src="/analytics-gate.js"></script>
 </head>
 <body>
   <div id="root">

--- a/public/executive-orders.html
+++ b/public/executive-orders.html
@@ -77,14 +77,8 @@
   <!-- Cloudflare Turnstile (newsletter bot protection) -->
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5MDT4HFMNB"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-5MDT4HFMNB');
-  </script>
+  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD. -->
+  <script src="/analytics-gate.js"></script>
 </head>
 <body>
   <div id="root">

--- a/public/pardons.html
+++ b/public/pardons.html
@@ -77,14 +77,8 @@
   <!-- Cloudflare Turnstile (newsletter bot protection) -->
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5MDT4HFMNB"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-5MDT4HFMNB');
-  </script>
+  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD. -->
+  <script src="/analytics-gate.js"></script>
 </head>
 <body>
   <div id="root">

--- a/public/shared.js
+++ b/public/shared.js
@@ -352,12 +352,49 @@
     'error_type', 'component',
     // merch tracking
     'method',
+    // Product Analytics v1 named events (PRD section 4, ADO-559). Legacy pages
+    // wire these in later phases; the allowlist ships first so an unlisted
+    // param can never be silently dropped mid-phase.
+    'item_type', 'alarm_level', 'feed_position', 'tab',
+    'outlet_domain', 'source_position',
+    'channel', 'filter_key', 'filter_value', 'query_length',
+    'surface', 'error_category', 'page_path',
     // schema version
     'schema_v'
   ]);
 
+  // Bumped to 2 when the Product Analytics v1 params above were added.
+  // Mirrors SCHEMA_VERSION in src/lib/analytics.ts.
+  const SCHEMA_VERSION = 2;
+
+  /**
+   * Is this the production environment? Authoritative answer comes from
+   * public/analytics-gate.js, which is the single place the hostname rule
+   * lives. The literal is only a fallback for the case where that script
+   * failed to load, and it fails CLOSED (no gate, no analytics off PROD).
+   */
+  function isAnalyticsEnvEnabled() {
+    if (typeof window.TT_ANALYTICS_ENABLED === 'boolean') {
+      return window.TT_ANALYTICS_ENABLED;
+    }
+    const host = (window.location.hostname || '').toLowerCase();
+    return host === 'trumpytracker.com' || host === 'www.trumpytracker.com';
+  }
+
   // Allowed transport types for beacon
   const ALLOWED_TRANSPORTS = new Set(['beacon', 'xhr', 'image']);
+
+  /**
+   * Params kept for GA4 legacy continuity but NEVER mirrored to PostHog.
+   *
+   * Product Analytics v1 (PRD section 4) is explicit: search sends length only,
+   * and no event property may be derived from free-text user input. `term_hash`
+   * is a 32-bit hash of the search term -- low entropy and trivially reversible
+   * for a site with a bounded vocabulary, so it is not a safe anonymiser. GA4
+   * keeps receiving it so existing Looker Studio reports don't break; PostHog,
+   * the new analysis layer, starts clean.
+   */
+  const POSTHOG_EXCLUDED_PARAMS = new Set(['term_hash']);
 
   /**
    * Track analytics event (Google Analytics) with PII protection
@@ -366,17 +403,16 @@
    * @param {Object} opts - Options (e.g., { transport_type: 'beacon' })
    */
   function trackEvent(eventName, eventParams = {}, opts = {}) {
-    if (typeof gtag !== 'function') return;
-
-    // Skip analytics on test environments
-    const hostname = window.location.hostname;
-    if (hostname.includes('test--') || hostname === 'localhost' || hostname === '127.0.0.1') {
-      console.log('[Analytics:TEST]', eventName, eventParams);
+    // Environment gate. Single allowlist rule, shared with analytics-gate.js
+    // (ADO-559). The previous check was a denylist for 'test--'/localhost,
+    // which missed Netlify deploy previews and any other branch deploy.
+    if (!isAnalyticsEnvEnabled()) {
+      console.log('[Analytics:off-prod]', eventName, eventParams);
       return;
     }
 
     // Build safe params with allowlist
-    const safeParams = { schema_v: 1 };
+    const safeParams = { schema_v: SCHEMA_VERSION };
 
     for (const [key, val] of Object.entries(eventParams)) {
       if (ALLOWED_PARAMS.has(key) && val !== undefined && val !== null) {
@@ -391,7 +427,34 @@
       safeParams.transport_type = opts.transport_type;
     }
 
-    gtag('event', eventName, safeParams);
+    // The two vendors are dispatched INDEPENDENTLY. Neither a missing gtag nor
+    // a throwing one may suppress the other vendor or break the page, so there
+    // is no shared early return and no unguarded call (mirrors the React
+    // wrapper in src/lib/analytics.ts).
+    if (typeof gtag === 'function') {
+      try {
+        gtag('event', eventName, safeParams);
+      } catch (err) {
+        /* analytics must never break the page */
+      }
+    }
+
+    // Mirror to PostHog through the gate's façade (ADO-559). Deliberately
+    // AFTER the allowlist filter, so the same allowlist protects both vendors,
+    // minus the params PostHog must never receive (see POSTHOG_EXCLUDED_PARAMS).
+    // window.TTAnalytics is defined by public/analytics-gate.js and buffers
+    // until posthog-js finishes loading, so this is safe to call at any time.
+    if (window.TTAnalytics) {
+      const posthogParams = {};
+      for (const [key, val] of Object.entries(safeParams)) {
+        if (!POSTHOG_EXCLUDED_PARAMS.has(key)) posthogParams[key] = val;
+      }
+      try {
+        window.TTAnalytics.capture(eventName, posthogParams);
+      } catch (err) {
+        /* analytics must never break the page */
+      }
+    }
   }
 
   /**
@@ -585,10 +648,8 @@
       const data = await response.json();
 
       if (response.ok && data.success) {
-        // Set GA4 user property (skip on test environments)
-        const hostname = window.location.hostname;
-        const isTest = hostname.includes('test--') || hostname === 'localhost' || hostname === '127.0.0.1';
-        if (typeof gtag === 'function' && !isTest) {
+        // Set GA4 user property (PROD only - same gate as trackEvent)
+        if (typeof gtag === 'function' && isAnalyticsEnvEnabled()) {
           gtag('set', 'user_properties', { newsletter_subscriber: true });
         }
 

--- a/public/shared.js
+++ b/public/shared.js
@@ -406,10 +406,7 @@
     // Environment gate. Single allowlist rule, shared with analytics-gate.js
     // (ADO-559). The previous check was a denylist for 'test--'/localhost,
     // which missed Netlify deploy previews and any other branch deploy.
-    if (!isAnalyticsEnvEnabled()) {
-      console.log('[Analytics:off-prod]', eventName, eventParams);
-      return;
-    }
+    if (!isAnalyticsEnvEnabled()) return; // silent off PROD (no console.log in shipped code)
 
     // Build safe params with allowlist
     const safeParams = { schema_v: SCHEMA_VERSION };

--- a/public/shared/flags-prod.json
+++ b/public/shared/flags-prod.json
@@ -1,10 +1,10 @@
 {
   "_comment": "Feature flags for PROD environment - only enable verified features",
-  "_updated": "2026-08-17",
+  "_updated": "2026-08-24",
 
   "scotus": true,
   "pardons": true,
   "executive_orders": true,
   "tone_v2": false,
-  "rap_sheet": false
+  "rap_sheet": true
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,7 +120,7 @@ function TypePage({
         setTotalPages(result.totalPages);
 
         if (filters.page > result.totalPages && result.totalPages > 0) {
-          filters.setPage(result.totalPages);
+          filters.setPage(result.totalPages, { silent: true });
         }
       })
       .catch(err => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { LoadingSkeleton } from '@/edge-states/LoadingSkeleton';
 import { fetchList, fetchStoryDetail, fetchEoDetail, fetchScotusDetail, fetchPardonDetail } from '@/lib/api';
 import { getFilterConfig } from '@/lib/filters';
 import { useFilters } from '@/hooks/useFilters';
+import { trackPageView } from '@/lib/analytics';
 import { deriveStats } from '@/types';
 import type { DisplayItem } from '@/types';
 import type { FetchOptions } from '@/lib/api';
@@ -17,18 +18,12 @@ const About = lazy(() => import('@/pages/About').then(m => ({ default: m.About }
 
 type DetailFetcher = (id: string | number, signal?: AbortSignal) => Promise<DisplayItem | null>;
 
-declare global {
-  interface Window { gtag?: (...args: unknown[]) => void; }
-}
-
 export function App() {
   const themeValue = useThemeProvider();
   const [location, navigate] = useLocation();
 
   useEffect(() => {
-    if (window.gtag) {
-      window.gtag('config', 'G-5MDT4HFMNB', { page_path: location });
-    }
+    trackPageView(location);
   }, [location]);
 
   const makeOpenHandler = (prefix: string) => (id: string | number) => {

--- a/src/__tests__/analytics-track.test.ts
+++ b/src/__tests__/analytics-track.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ANALYTICS_HOSTNAME,
+  SCHEMA_VERSION,
+  track,
+  toAnalyticsItemType,
+  type EventName,
+} from '../lib/analytics';
+
+// Vitest runs node-env (no jsdom), so `window` is stubbed by hand.
+type FakeWindow = {
+  location: { hostname: string };
+  gtag?: (...args: unknown[]) => void;
+  TTAnalytics?: { capture: (name: string, props: Record<string, unknown>) => void };
+};
+
+function setWindow(hostname: string, extra: Partial<FakeWindow> = {}) {
+  (globalThis as unknown as { window?: FakeWindow }).window = {
+    location: { hostname },
+    ...extra,
+  };
+}
+
+const OFF_PROD_HOSTS = [
+  'localhost',
+  '127.0.0.1',
+  'test--taupe-capybara-0ff2ed.netlify.app',
+  'deploy-preview-42--taupe-capybara-0ff2ed.netlify.app',
+];
+
+describe('track() wrapper', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    delete (globalThis as unknown as { window?: FakeWindow }).window;
+  });
+
+  function prodWindow() {
+    const capture = vi.fn();
+    const gtag = vi.fn();
+    setWindow(ANALYTICS_HOSTNAME, { gtag, TTAnalytics: { capture } });
+    return { capture, gtag };
+  }
+
+  it('dual-fires to PostHog and GA4, stamping schema_v on GA4 only', () => {
+    const { capture, gtag } = prodWindow();
+
+    track('card_open', { item_type: 'story', alarm_level: 5, feed_position: 3, tab: 'news' });
+
+    expect(capture).toHaveBeenCalledWith('card_open', {
+      item_type: 'story',
+      alarm_level: 5,
+      feed_position: 3,
+      tab: 'news',
+    });
+    expect(gtag).toHaveBeenCalledWith('event', 'card_open', {
+      item_type: 'story',
+      alarm_level: 5,
+      feed_position: 3,
+      tab: 'news',
+      schema_v: SCHEMA_VERSION,
+    });
+  });
+
+  it('drops undeclared keys at runtime, so an `as any` cast cannot leak PII', () => {
+    const { capture, gtag } = prodWindow();
+
+    // Exactly what the type system forbids, forced through anyway.
+    track('search', {
+      tab: 'news',
+      query_length: 12,
+      query: 'my private search text',
+      email: 'someone@example.com',
+    } as unknown as { tab: string; query_length: number });
+
+    expect(capture).toHaveBeenCalledWith('search', { tab: 'news', query_length: 12 });
+
+    const gaProps = gtag.mock.calls[0][2] as Record<string, unknown>;
+    expect(gaProps).toEqual({ tab: 'news', query_length: 12, schema_v: SCHEMA_VERSION });
+    expect(JSON.stringify(gaProps)).not.toContain('private');
+    expect(JSON.stringify(gaProps)).not.toContain('example.com');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('omits null and undefined values rather than sending them', () => {
+    const { capture } = prodWindow();
+
+    track('share_click', {
+      channel: 'copy_link',
+      item_type: undefined as unknown as 'story',
+    });
+
+    expect(capture).toHaveBeenCalledWith('share_click', { channel: 'copy_link' });
+  });
+
+  it('sends nothing off PROD', () => {
+    const capture = vi.fn();
+    const gtag = vi.fn();
+    for (const host of OFF_PROD_HOSTS) {
+      setWindow(host, { gtag, TTAnalytics: { capture } });
+      track('pagination', { tab: 'eos', page: 2 });
+    }
+    expect(capture).not.toHaveBeenCalled();
+    expect(gtag).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('never throws when a vendor is missing or throws', () => {
+    setWindow(ANALYTICS_HOSTNAME);
+    expect(() => track('feedback_open', { page_path: '/news' })).not.toThrow();
+
+    setWindow(ANALYTICS_HOSTNAME, {
+      gtag: () => {
+        throw new Error('ad blocker');
+      },
+      TTAnalytics: {
+        capture: () => {
+          throw new Error('ad blocker');
+        },
+      },
+    });
+    expect(() => track('feedback_open', { page_path: '/news' })).not.toThrow();
+  });
+
+  it('still reaches GA4 when PostHog is blocked', () => {
+    const gtag = vi.fn();
+    setWindow(ANALYTICS_HOSTNAME, {
+      gtag,
+      TTAnalytics: {
+        capture: () => {
+          throw new Error('blocked');
+        },
+      },
+    });
+
+    track('correction_click', { item_type: 'eo' });
+
+    expect(gtag).toHaveBeenCalledWith('event', 'correction_click', {
+      item_type: 'eo',
+      schema_v: SCHEMA_VERSION,
+    });
+  });
+});
+
+describe('toAnalyticsItemType', () => {
+  it('normalises the tab/route spellings used across the app', () => {
+    expect(toAnalyticsItemType('story')).toBe('story');
+    expect(toAnalyticsItemType('stories')).toBe('story');
+    expect(toAnalyticsItemType('eo')).toBe('eo');
+    expect(toAnalyticsItemType('eos')).toBe('eo');
+    expect(toAnalyticsItemType('executive_order')).toBe('eo');
+    expect(toAnalyticsItemType('scotus')).toBe('scotus');
+    expect(toAnalyticsItemType('pardon')).toBe('pardon');
+    expect(toAnalyticsItemType('pardons')).toBe('pardon');
+  });
+
+  it('returns null for anything unrecognised instead of inventing a category', () => {
+    expect(toAnalyticsItemType('nonsense')).toBeNull();
+    expect(toAnalyticsItemType(undefined)).toBeNull();
+    expect(toAnalyticsItemType(null)).toBeNull();
+  });
+});
+
+describe('event taxonomy', () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: FakeWindow }).window;
+  });
+
+  it('carries every named event in PRD section 4', () => {
+    const expected: EventName[] = [
+      'card_open', 'source_click', 'share_click', 'correction_click',
+      'filter_apply', 'search', 'pagination',
+      'newsletter_view', 'newsletter_submit', 'newsletter_success', 'newsletter_error',
+      'feedback_open', 'feedback_submit',
+    ];
+
+    const capture = vi.fn();
+    setWindow(ANALYTICS_HOSTNAME, { gtag: vi.fn(), TTAnalytics: { capture } });
+
+    for (const name of expected) {
+      // Props are per-event typed; this loop only checks the names round-trip.
+      track(name as 'feedback_open', { page_path: '/x' });
+    }
+
+    expect(capture.mock.calls.map((c) => c[0]).sort()).toEqual([...expected].sort());
+  });
+});

--- a/src/__tests__/analytics-track.test.ts
+++ b/src/__tests__/analytics-track.test.ts
@@ -110,7 +110,7 @@ describe('track() wrapper', () => {
     }
     expect(capture).not.toHaveBeenCalled();
     expect(gtag).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalled();
+    expect(logSpy, 'off-PROD path is silent (no console.log in shipped code)').not.toHaveBeenCalled();
   });
 
   it('never throws when a vendor is missing or throws', () => {

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// Loaded as text so the real shipped loader is what gets executed below.
+import gateSource from '../../public/analytics-gate.js?raw';
+
+import {
+  ANALYTICS_HOSTNAME,
+  GA4_MEASUREMENT_ID,
+  isAnalyticsEnabled,
+  trackPageView,
+} from '../lib/analytics';
+
+// Vitest runs node-env (no jsdom), so `window` is stubbed by hand.
+type FakeWindow = {
+  location: { hostname: string };
+  gtag?: (...args: unknown[]) => void;
+  TT_ANALYTICS_ENABLED?: boolean;
+  dataLayer?: unknown[];
+};
+
+function setWindow(hostname: string, extra: Partial<FakeWindow> = {}): FakeWindow {
+  const w: FakeWindow = { location: { hostname }, ...extra };
+  (globalThis as unknown as { window?: FakeWindow }).window = w;
+  return w;
+}
+
+const OFF_PROD_HOSTS = [
+  'localhost',
+  '127.0.0.1',
+  'test--taupe-capybara-0ff2ed.netlify.app',
+  'deploy-preview-42--taupe-capybara-0ff2ed.netlify.app',
+  'taupe-capybara-0ff2ed.netlify.app',
+  'trumpytracker.com.evil.example',
+  'nottrumpytracker.com',
+];
+
+describe('src/lib/analytics gate', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    delete (globalThis as unknown as { window?: FakeWindow }).window;
+  });
+
+  it('is disabled when there is no window (SSR / node)', () => {
+    delete (globalThis as unknown as { window?: FakeWindow }).window;
+    expect(isAnalyticsEnabled()).toBe(false);
+  });
+
+  it('is enabled only on the production hostnames, case-insensitively', () => {
+    for (const host of [
+      ANALYTICS_HOSTNAME,
+      `www.${ANALYTICS_HOSTNAME}`,
+      'TrumpyTracker.com',
+    ]) {
+      setWindow(host);
+      expect(isAnalyticsEnabled(), `expected ${host} to be enabled`).toBe(true);
+    }
+
+    for (const host of OFF_PROD_HOSTS) {
+      setWindow(host);
+      expect(isAnalyticsEnabled(), `expected ${host} to be gated off`).toBe(false);
+    }
+  });
+
+  it('sends the GA4 page_path config on PROD', () => {
+    const gtag = vi.fn();
+    setWindow(ANALYTICS_HOSTNAME, { gtag });
+
+    trackPageView('/detail/123');
+
+    expect(gtag).toHaveBeenCalledWith('config', GA4_MEASUREMENT_ID, { page_path: '/detail/123' });
+  });
+
+  it('never calls gtag off PROD, even if a stub is present', () => {
+    const gtag = vi.fn();
+    for (const host of OFF_PROD_HOSTS) {
+      setWindow(host, { gtag });
+      trackPageView('/news');
+    }
+    expect(gtag).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('does not throw when gtag is missing or throws on PROD', () => {
+    setWindow(ANALYTICS_HOSTNAME);
+    expect(() => trackPageView('/')).not.toThrow();
+
+    setWindow(ANALYTICS_HOSTNAME, {
+      gtag: () => {
+        throw new Error('blocked by an ad blocker');
+      },
+    });
+    expect(() => trackPageView('/')).not.toThrow();
+  });
+});
+
+/**
+ * public/analytics-gate.js is the loader shared by index.html and the legacy
+ * pages. It is a classic browser script, so it is executed here in a vm with a
+ * fake DOM -- this is the direct proof of the ADO-558 acceptance criterion
+ * "ZERO network requests to googletagmanager.com off PROD (script tag included)".
+ */
+function runGate(hostname: string) {
+  const appended: Array<{ src?: string; async?: boolean }> = [];
+  const created: Array<{ src?: string; async?: boolean }> = [];
+  const logs: unknown[][] = [];
+
+  const win: Record<string, unknown> = { location: { hostname } };
+  const document = {
+    createElement: (tag: string) => {
+      if (tag !== 'script') throw new Error(`unexpected createElement(${tag})`);
+      const el: { src?: string; async?: boolean } = {};
+      created.push(el);
+      return el;
+    },
+    head: {
+      appendChild: (el: { src?: string; async?: boolean }) => {
+        appended.push(el);
+        return el;
+      },
+    },
+  };
+
+  // The loader is a classic IIFE that reads `window`/`document`/`console` off
+  // the global scope; passing them as parameters shadows the real globals so
+  // the test can never touch the network or the host environment.
+  const run = new Function('window', 'document', 'console', gateSource) as (
+    w: unknown,
+    d: unknown,
+    c: unknown,
+  ) => void;
+
+  const console = { log: (...args: unknown[]) => logs.push(args) };
+  run(win, document, console);
+
+  // Simulate the same file being included on the page a second time.
+  const runAgain = () => run(win, document, console);
+
+  return { win, appended, created, logs, runAgain };
+}
+
+describe('public/analytics-gate.js', () => {
+  it('injects the GA4 script exactly once on PROD', () => {
+    const { win, appended } = runGate(ANALYTICS_HOSTNAME);
+
+    expect(win.TT_ANALYTICS_ENABLED).toBe(true);
+    expect(appended).toHaveLength(1);
+    expect(appended[0].src).toBe(
+      `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`,
+    );
+    expect(appended[0].async).toBe(true);
+
+    // The GA4 bootstrap commands are queued for the remote script.
+    const dataLayer = win.dataLayer as unknown[];
+    expect(dataLayer).toHaveLength(2);
+    expect(Array.from(dataLayer[0] as ArrayLike<unknown>)[0]).toBe('js');
+    expect(Array.from(dataLayer[1] as ArrayLike<unknown>)).toEqual([
+      'config',
+      GA4_MEASUREMENT_ID,
+    ]);
+  });
+
+  it('creates NO script element and no dataLayer off PROD', () => {
+    for (const host of OFF_PROD_HOSTS) {
+      const { win, appended, created } = runGate(host);
+
+      expect(win.TT_ANALYTICS_ENABLED, host).toBe(false);
+      expect(created, `${host} must not create a script element`).toHaveLength(0);
+      expect(appended, `${host} must not append a script element`).toHaveLength(0);
+      expect(win.dataLayer, `${host} must not create a dataLayer`).toBeUndefined();
+    }
+  });
+
+  it('is inert on a second inclusion, so pageviews cannot be double-counted', () => {
+    const { win, appended, runAgain } = runGate(ANALYTICS_HOSTNAME);
+    expect(appended).toHaveLength(1);
+
+    runAgain();
+
+    expect(appended, 'a second include must not inject GA4 again').toHaveLength(1);
+    expect(win.dataLayer, 'a second include must not re-queue js/config').toHaveLength(2);
+  });
+
+  it('exposes a console-only gtag stub off PROD', () => {
+    const { win, logs, appended } = runGate('localhost');
+
+    expect(typeof win.gtag).toBe('function');
+    (win.gtag as (...args: unknown[]) => void)('event', 'outbound_click', { a: 1 });
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0][0]).toBe('[analytics:off-prod] gtag');
+    expect(appended).toHaveLength(0);
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -104,21 +104,23 @@ describe('src/lib/analytics gate', () => {
  * fake DOM -- this is the direct proof of the ADO-558 acceptance criterion
  * "ZERO network requests to googletagmanager.com off PROD (script tag included)".
  */
+type FakeScript = { src?: string; async?: boolean; onload?: () => void };
+
 function runGate(hostname: string) {
-  const appended: Array<{ src?: string; async?: boolean }> = [];
-  const created: Array<{ src?: string; async?: boolean }> = [];
+  const appended: FakeScript[] = [];
+  const created: FakeScript[] = [];
   const logs: unknown[][] = [];
 
   const win: Record<string, unknown> = { location: { hostname } };
   const document = {
     createElement: (tag: string) => {
       if (tag !== 'script') throw new Error(`unexpected createElement(${tag})`);
-      const el: { src?: string; async?: boolean } = {};
+      const el: FakeScript = {};
       created.push(el);
       return el;
     },
     head: {
-      appendChild: (el: { src?: string; async?: boolean }) => {
+      appendChild: (el: FakeScript) => {
         appended.push(el);
         return el;
       },
@@ -143,16 +145,16 @@ function runGate(hostname: string) {
   return { win, appended, created, logs, runAgain };
 }
 
+const GA_SRC = `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`;
+const POSTHOG_SRC = 'https://us-assets.i.posthog.com/static/array.js';
+
 describe('public/analytics-gate.js', () => {
-  it('injects the GA4 script exactly once on PROD', () => {
+  it('injects GA4 and PostHog exactly once each on PROD', () => {
     const { win, appended } = runGate(ANALYTICS_HOSTNAME);
 
     expect(win.TT_ANALYTICS_ENABLED).toBe(true);
-    expect(appended).toHaveLength(1);
-    expect(appended[0].src).toBe(
-      `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`,
-    );
-    expect(appended[0].async).toBe(true);
+    expect(appended.map((s) => s.src)).toEqual([GA_SRC, POSTHOG_SRC]);
+    expect(appended.every((s) => s.async === true)).toBe(true);
 
     // The GA4 bootstrap commands are queued for the remote script.
     const dataLayer = win.dataLayer as unknown[];
@@ -177,22 +179,111 @@ describe('public/analytics-gate.js', () => {
 
   it('is inert on a second inclusion, so pageviews cannot be double-counted', () => {
     const { win, appended, runAgain } = runGate(ANALYTICS_HOSTNAME);
-    expect(appended).toHaveLength(1);
+    expect(appended).toHaveLength(2);
 
     runAgain();
 
-    expect(appended, 'a second include must not inject GA4 again').toHaveLength(1);
+    expect(appended, 'a second include must not inject the vendors again').toHaveLength(2);
     expect(win.dataLayer, 'a second include must not re-queue js/config').toHaveLength(2);
   });
 
-  it('exposes a console-only gtag stub off PROD', () => {
+  it('exposes console-only gtag and TTAnalytics stubs off PROD', () => {
     const { win, logs, appended } = runGate('localhost');
 
     expect(typeof win.gtag).toBe('function');
     (win.gtag as (...args: unknown[]) => void)('event', 'outbound_click', { a: 1 });
 
-    expect(logs).toHaveLength(1);
-    expect(logs[0][0]).toBe('[analytics:off-prod] gtag');
+    const tt = win.TTAnalytics as { capture: (n: string, p: unknown) => void };
+    expect(typeof tt.capture).toBe('function');
+    tt.capture('card_open', { tab: 'news' });
+
+    expect(logs.map((l) => l[0])).toEqual([
+      '[analytics:off-prod] gtag',
+      '[analytics:off-prod] posthog.capture',
+    ]);
     expect(appended).toHaveLength(0);
+  });
+
+  /**
+   * posthog-js self-assigns window.posthog and its bootstrap is
+   * `if (!window.posthog || isArray(window.posthog._i))`. If the gate assigned
+   * its own object to that global, PostHog would skip init entirely and fail
+   * silently -- so the gate must leave it alone until the library loads.
+   */
+  it('never touches window.posthog before the SDK loads', () => {
+    const { win } = runGate(ANALYTICS_HOSTNAME);
+    expect(win.posthog).toBeUndefined();
+  });
+
+  it('buffers captures made before the SDK loads, then flushes them in order', () => {
+    const { win, appended } = runGate(ANALYTICS_HOSTNAME);
+    const tt = win.TTAnalytics as { capture: (n: string, p: unknown) => void };
+
+    // A user clicks before array.js has finished downloading.
+    tt.capture('card_open', { tab: 'news', feed_position: 0 });
+    tt.capture('source_click', { outlet_domain: 'apnews.com' });
+
+    const captured: Array<[string, unknown]> = [];
+    let initArgs: unknown[] = [];
+    win.posthog = {
+      init: (...args: unknown[]) => {
+        initArgs = args;
+      },
+      capture: (n: string, p: unknown) => captured.push([n, p]),
+    };
+
+    const phScript = appended.find((s) => s.src === POSTHOG_SRC);
+    phScript?.onload?.();
+
+    expect(initArgs[0]).toMatch(/^phc_/);
+    expect(initArgs[1]).toMatchObject({
+      api_host: 'https://us.i.posthog.com',
+      autocapture: true,
+      capture_pageview: 'history_change',
+      person_profiles: 'identified_only',
+      session_recording: { maskAllInputs: true },
+    });
+
+    expect(captured).toEqual([
+      ['card_open', { tab: 'news', feed_position: 0 }],
+      ['source_click', { outlet_domain: 'apnews.com' }],
+    ]);
+
+    // Post-load captures go straight through, not into the buffer.
+    tt.capture('share_click', { channel: 'copy' });
+    expect(captured).toHaveLength(3);
+  });
+
+  it('survives an SDK that fails to load or throws on init', () => {
+    const { win, appended } = runGate(ANALYTICS_HOSTNAME);
+    const tt = win.TTAnalytics as { capture: (n: string, p: unknown) => void };
+    const phScript = appended.find((s) => s.src === POSTHOG_SRC);
+
+    // array.js blocked by an ad blocker: window.posthog never appears.
+    expect(() => phScript?.onload?.()).not.toThrow();
+    expect(() => tt.capture('card_open', { tab: 'news' })).not.toThrow();
+
+    // ...or it loads but init throws.
+    win.posthog = {
+      init: () => {
+        throw new Error('boom');
+      },
+      capture: () => {},
+    };
+    expect(() => phScript?.onload?.()).not.toThrow();
+    expect(() => tt.capture('card_open', { tab: 'news' })).not.toThrow();
+  });
+
+  it('caps the pre-load buffer so a failed load cannot grow it unbounded', () => {
+    const { win, appended } = runGate(ANALYTICS_HOSTNAME);
+    const tt = win.TTAnalytics as { capture: (n: string, p: unknown) => void };
+
+    for (let i = 0; i < 200; i++) tt.capture('pagination', { page: i });
+
+    const captured: unknown[] = [];
+    win.posthog = { init: () => {}, capture: () => captured.push(1) };
+    appended.find((s) => s.src === POSTHOG_SRC)?.onload?.();
+
+    expect(captured).toHaveLength(50);
   });
 });

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -82,7 +82,7 @@ describe('src/lib/analytics gate', () => {
       trackPageView('/news');
     }
     expect(gtag).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalled();
+    expect(logSpy, 'off-PROD path is silent (no console.log in shipped code)').not.toHaveBeenCalled();
   });
 
   it('does not throw when gtag is missing or throws on PROD', () => {
@@ -187,7 +187,7 @@ describe('public/analytics-gate.js', () => {
     expect(win.dataLayer, 'a second include must not re-queue js/config').toHaveLength(2);
   });
 
-  it('exposes console-only gtag and TTAnalytics stubs off PROD', () => {
+  it('exposes silent no-op gtag and TTAnalytics stubs off PROD', () => {
     const { win, logs, appended } = runGate('localhost');
 
     expect(typeof win.gtag).toBe('function');
@@ -197,10 +197,7 @@ describe('public/analytics-gate.js', () => {
     expect(typeof tt.capture).toBe('function');
     tt.capture('card_open', { tab: 'news' });
 
-    expect(logs.map((l) => l[0])).toEqual([
-      '[analytics:off-prod] gtag',
-      '[analytics:off-prod] posthog.capture',
-    ]);
+    expect(logs, 'off-PROD stubs must not write to the console').toEqual([]);
     expect(appended).toHaveLength(0);
   });
 

--- a/src/__tests__/shared-track-event.test.ts
+++ b/src/__tests__/shared-track-event.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// Loaded as text so the real shipped legacy helper is what gets exercised.
+import sharedSource from '../../public/shared.js?raw';
+
+/**
+ * `public/shared.js` is the legacy vanilla-page helper. It is a classic
+ * browser IIFE (`(function (global) { ... })(window)`), not a module, so it is
+ * executed here against a hand-built fake browser environment.
+ *
+ * These tests pin two rules that are easy to break silently on a later edit:
+ *   1. PostHog never receives `term_hash` (PRD section 4: search sends length
+ *      only, nothing derived from free-text input).
+ *   2. GA4 and PostHog dispatch INDEPENDENTLY -- a missing or throwing gtag
+ *      must not suppress the PostHog mirror or break the page.
+ */
+type TrackEvent = (name: string, params?: Record<string, unknown>, opts?: Record<string, unknown>) => void;
+
+interface Loaded {
+  trackEvent: TrackEvent;
+  trackSearchAction: (term: string, resultCount: number) => void;
+  gaCalls: unknown[][];
+  phCalls: Array<[string, Record<string, unknown>]>;
+}
+
+function loadShared(options: {
+  /** `null` means "gtag is not defined at all". */
+  gtag?: ((...args: unknown[]) => void) | null;
+  withPostHog?: boolean;
+  hostname?: string;
+} = {}): Loaded {
+  const gaCalls: unknown[][] = [];
+  const phCalls: Array<[string, Record<string, unknown>]> = [];
+
+  const store = () => {
+    const m = new Map<string, string>();
+    return {
+      getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+      setItem: (k: string, v: string) => void m.set(k, v),
+      removeItem: (k: string) => void m.delete(k),
+    };
+  };
+
+  const gtag =
+    options.gtag === null
+      ? undefined
+      : options.gtag ?? ((...args: unknown[]) => void gaCalls.push(args));
+
+  const win: Record<string, unknown> = {
+    SUPABASE_CONFIG: { SUPABASE_URL: 'https://example.supabase.co', SUPABASE_ANON_KEY: 'anon' },
+    location: { hostname: options.hostname ?? 'trumpytracker.com', search: '', pathname: '/' },
+    history: { replaceState: () => {}, pushState: () => {}, state: null },
+    localStorage: store(),
+    sessionStorage: store(),
+    scrollY: 0,
+    scrollTo: () => {},
+    matchMedia: () => ({ matches: false }),
+    addEventListener: () => {},
+    gtag,
+    // TT_ANALYTICS_ENABLED is normally set by public/analytics-gate.js.
+    TT_ANALYTICS_ENABLED: (options.hostname ?? 'trumpytracker.com') === 'trumpytracker.com',
+  };
+
+  if (options.withPostHog !== false) {
+    win.TTAnalytics = {
+      capture: (name: string, props: Record<string, unknown>) => {
+        phCalls.push([name, props]);
+      },
+    };
+  }
+
+  const document = {
+    body: { innerHTML: '', style: {} },
+    documentElement: { setAttribute: () => {} },
+    addEventListener: () => {},
+    createElement: () => ({ style: {} }),
+  };
+
+  const run = new Function(
+    'window',
+    'document',
+    'localStorage',
+    'sessionStorage',
+    'gtag',
+    'console',
+    `${sharedSource}\nreturn window.TTShared;`,
+  ) as (...args: unknown[]) => { trackEvent: TrackEvent; trackSearchAction: (t: string, n: number) => void };
+
+  const shared = run(
+    win,
+    document,
+    win.localStorage,
+    win.sessionStorage,
+    gtag,
+    { log: () => {}, warn: () => {}, error: () => {} },
+  );
+
+  return { trackEvent: shared.trackEvent, trackSearchAction: shared.trackSearchAction, gaCalls, phCalls };
+}
+
+describe('public/shared.js trackEvent -> PostHog mirror', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warnSpy.mockRestore());
+
+  it('sends term_hash to GA4 but NEVER to PostHog', () => {
+    const { trackSearchAction, gaCalls, phCalls } = loadShared();
+
+    trackSearchAction('epstein documents', 7);
+
+    // GA4 keeps legacy continuity for existing Looker Studio reports.
+    const gaParams = gaCalls[0][2] as Record<string, unknown>;
+    expect(gaParams.term_hash).toBeTypeOf('string');
+    expect(gaParams.term_len).toBe('epstein documents'.length);
+
+    // PostHog starts clean: nothing derived from the query text.
+    const [phName, phParams] = phCalls[0];
+    expect(phName).toBe('search_action');
+    expect(phParams).not.toHaveProperty('term_hash');
+    expect(phParams.term_len).toBe('epstein documents'.length);
+    expect(JSON.stringify(phParams)).not.toContain(gaParams.term_hash as string);
+  });
+
+  it('still mirrors to PostHog when gtag is missing entirely', () => {
+    const { trackEvent, phCalls } = loadShared({ gtag: null });
+
+    trackEvent('outbound_click', { source_domain: 'apnews.com' });
+
+    expect(phCalls).toHaveLength(1);
+    expect(phCalls[0][0]).toBe('outbound_click');
+    expect(phCalls[0][1]).toMatchObject({ source_domain: 'apnews.com' });
+  });
+
+  it('still mirrors to PostHog when gtag throws, and does not rethrow', () => {
+    const { trackEvent, phCalls } = loadShared({
+      gtag: () => {
+        throw new Error('ad blocker ate gtag');
+      },
+    });
+
+    expect(() => trackEvent('detail_toggle', { action: 'open' })).not.toThrow();
+    expect(phCalls).toHaveLength(1);
+    expect(phCalls[0][0]).toBe('detail_toggle');
+  });
+
+  it('does not throw when PostHog is absent', () => {
+    const { trackEvent, gaCalls } = loadShared({ withPostHog: false });
+
+    expect(() => trackEvent('outbound_click', { source_domain: 'apnews.com' })).not.toThrow();
+    expect(gaCalls).toHaveLength(1);
+  });
+
+  it('sends to neither vendor off PROD', () => {
+    const { trackEvent, gaCalls, phCalls } = loadShared({ hostname: 'localhost' });
+
+    trackEvent('outbound_click', { source_domain: 'apnews.com' });
+
+    expect(gaCalls).toHaveLength(0);
+    expect(phCalls).toHaveLength(0);
+  });
+});

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -147,11 +147,11 @@ describe('buildSourcePath', () => {
     expect(p).not.toContain('status=');
   });
 
-  it("main view: stories filter on the server-computed main_line, others keep alarm 4+", () => {
+  it("main view: stories filter on the server-computed main_line, others get the alarm-5 loose-end bar", () => {
     expect(dec(buildSourcePath('stories', 'main', null))).toContain('and=(main_line.is.true)');
-    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.4)');
-    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.4');
-    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.4');
+    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.5)');
+    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.5');
+    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.5');
   });
 
   it('floors every source at inauguration day - the record is term 2 only', () => {
@@ -375,21 +375,21 @@ describe('tracker pins (ADO-554)', () => {
           ok: true,
           json: async () => [
             { id: 'eo_bad', title: 'Hidden order', date: '2026-06-01', alarm_level: 5 },
-            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 4 },
+            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 5 },
           ],
         };
       }
       if (input.includes('/pardons?') && input.includes('id=in.')) {
-        // the pinned pardon is ALSO in the 4+ stream: must not be injected twice
+        // the pinned pardon is ALSO in the alarm-5 stream: must not be injected twice
         return {
           ok: true,
-          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 5 }],
         };
       }
       if (input.includes('/pardons?')) {
         return {
           ok: true,
-          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 5 }],
         };
       }
       return { ok: true, json: async () => [] }; // scotus
@@ -428,8 +428,55 @@ describe('tracker pins (ADO-554)', () => {
     expect(ids).not.toContain('eos:eo_bad');            // force_hide dropped
     expect(ids).toContain('eos:eo_kept');               // untouched stream row
     expect(ids).toContain('eos:eo_low');                // alarm 2, injected by pin
-    // pinned pardon at alarm 4 arrives via the stream — exactly once
+    // pinned pardon at alarm 5 arrives via the stream — exactly once
     expect(ids.filter(id => id === 'pardons:77')).toHaveLength(1);
+  });
+
+  it('buffers an injected old pin behind the coverage frontier, then renders it at its date (Codex P1 on PR #128)', async () => {
+    // A pinned row surfaces AT ITS DATE, by design: the frontier must not be
+    // bypassed (that would fake completeness of an unloaded range). This pins
+    // down the full pipeline: fetchTrackerPage → coverageFrontier → visibleEntries.
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+      if (input.includes('/tracker_pin?')) {
+        return { ok: true, json: async () => [{ source: 'eos', entity_id: 'eo_low', pin: 'force_show' }] };
+      }
+      if (input.includes('/executive_orders?') && input.includes('id=in.')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 'eo_low', title: 'Quiet but nasty order', date: '2026-03-01', alarm_level: 4 }],
+        };
+      }
+      if (input.includes('/executive_orders?')) {
+        // A FULL page (limit 25) → eos stays non-exhausted with cursor 2026-06-01,
+        // so the frontier sits months after the injected pin's date.
+        return {
+          ok: true,
+          json: async () => Array.from({ length: 25 }, (_, i) => ({
+            id: `eo_s${i}`, title: `Order ${i}`, alarm_level: 5,
+            date: `2026-06-${String(25 - i).padStart(2, '0')}`,
+          })),
+        };
+      }
+      return { ok: true, json: async () => [] }; // stories view, scotus, pardons
+    }));
+
+    const pins = await fetchTrackerPins();
+    const { entries, state } = await fetchTrackerPage('main', null, undefined, pins);
+
+    const frontier = coverageFrontier(state);
+    expect(frontier).toBe('2026-06-01');
+
+    const opts = { min: 0 as const, off: new Set<TimelineSource>(), query: '' };
+    // While coverage stops at June, the March pin is buffered — not lost, not shown.
+    const early = visibleEntries(entries, { ...opts, frontier });
+    expect(early.some(e => e.id === 'eo_low')).toBe(false);
+    expect(entries.some(e => e.id === 'eo_low')).toBe(true);
+
+    // Once every source is exhausted (frontier null), the pin renders at its date.
+    const done = visibleEntries(entries, { ...opts, frontier: null });
+    const ids = done.map(e => e.id);
+    expect(ids).toContain('eo_low');
+    expect(ids.indexOf('eo_low')).toBe(ids.length - 1); // oldest → rendered last (newest first)
   });
 
   it('does not re-inject force_shown rows on later pages', async () => {

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -8,6 +8,9 @@ import {
   buildSourcePath,
   initialTrackerState,
   fetchTrackerPage,
+  fetchTrackerPins,
+  forceShowIdsBySource,
+  pinKey,
   coverageFrontier,
   visibleEntries,
   SOURCE_ROUTES,
@@ -15,6 +18,7 @@ import {
   TIMELINE_SOURCES,
   type TimelineEntry,
   type TimelineSource,
+  type TrackerPins,
   type TrackerState,
 } from '../lib/timeline';
 
@@ -138,8 +142,16 @@ describe('buildSourcePath', () => {
     expect(p).not.toContain('and=');
     expect(p).toContain('order=first_seen_at.desc,id.desc');
     expect(p).toContain('limit=60');
-    expect(p).toContain('status=eq.active');
-    expect(p).toContain('summary_neutral=not.is.null');
+    // status/enrichment predicates are baked into v_tracker_stories (ADO-554)
+    expect(p).toContain('v_tracker_stories?');
+    expect(p).not.toContain('status=');
+  });
+
+  it("main view: stories filter on the server-computed main_line, others keep alarm 4+", () => {
+    expect(dec(buildSourcePath('stories', 'main', null))).toContain('and=(main_line.is.true)');
+    expect(dec(buildSourcePath('eos', 'main', null))).toContain('and=(alarm_level.gte.4)');
+    expect(dec(buildSourcePath('scotus', 'main', null))).toContain('ruling_impact_level.gte.4');
+    expect(dec(buildSourcePath('pardons', 'main', null))).toContain('corruption_level.gte.4');
   });
 
   it('floors every source at inauguration day - the record is term 2 only', () => {
@@ -270,7 +282,7 @@ describe('fetchTrackerPage', () => {
     vi.stubGlobal('window', { location: { hostname: 'localhost', search: '' } });
     vi.stubGlobal('fetch', vi.fn(async (input: string) => {
       calls.push(input);
-      if (input.includes('/stories?')) {
+      if (input.includes('/v_tracker_stories?')) {
         return { ok: true, json: async () => mkStoryRows(60) };
       }
       if (input.includes('/executive_orders?')) {
@@ -313,7 +325,7 @@ describe('fetchTrackerPage', () => {
     calls = [];
     await fetchTrackerPage(4, first);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('/stories?');
+    expect(calls[0]).toContain('/v_tracker_stories?');
     expect(decodeURIComponent(calls[0])).toContain('id.lt."941"');
   });
 
@@ -324,5 +336,107 @@ describe('fetchTrackerPage', () => {
     expect(entries).toHaveLength(0);
     expect(calls).toHaveLength(0);
     expect(next).toEqual(state);
+  });
+});
+
+describe('tracker pins (ADO-554)', () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+    vi.stubGlobal('window', { location: { hostname: 'localhost', search: '' } });
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+      calls.push(input);
+      if (input.includes('/tracker_pin?')) {
+        return {
+          ok: true,
+          json: async () => [
+            { source: 'eos', entity_id: 'eo_low', pin: 'force_show' },
+            { source: 'eos', entity_id: 'eo_bad', pin: 'force_hide' },
+            { source: 'pardons', entity_id: '77', pin: 'force_show' },
+            { source: 'stories', entity_id: '5', pin: 'force_show' },
+          ],
+        };
+      }
+      if (input.includes('/v_tracker_stories?')) {
+        return { ok: true, json: async () => [] };
+      }
+      if (input.includes('/executive_orders?') && input.includes('id=in.')) {
+        return {
+          ok: true,
+          json: async () => [
+            { id: 'eo_low', title: 'Quiet but nasty order', date: '2026-03-01', alarm_level: 2 },
+          ],
+        };
+      }
+      if (input.includes('/executive_orders?')) {
+        return {
+          ok: true,
+          json: async () => [
+            { id: 'eo_bad', title: 'Hidden order', date: '2026-06-01', alarm_level: 5 },
+            { id: 'eo_kept', title: 'Visible order', date: '2026-05-01', alarm_level: 4 },
+          ],
+        };
+      }
+      if (input.includes('/pardons?') && input.includes('id=in.')) {
+        // the pinned pardon is ALSO in the 4+ stream: must not be injected twice
+        return {
+          ok: true,
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+        };
+      }
+      if (input.includes('/pardons?')) {
+        return {
+          ok: true,
+          json: async () => [{ id: 77, recipient_name: 'Big Donor', pardon_date: '2026-04-01', corruption_level: 4 }],
+        };
+      }
+      return { ok: true, json: async () => [] }; // scotus
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('fetchTrackerPins maps rows and degrades to empty on failure', async () => {
+    const pins = await fetchTrackerPins();
+    expect(pins.get(pinKey('eos', 'eo_low'))).toBe('force_show');
+    expect(pins.get(pinKey('eos', 'eo_bad'))).toBe('force_hide');
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => [] })));
+    expect((await fetchTrackerPins()).size).toBe(0);
+  });
+
+  it('forceShowIdsBySource groups non-stories force_show pins only', () => {
+    const pins: TrackerPins = new Map([
+      [pinKey('eos', 'eo_low'), 'force_show'],
+      [pinKey('eos', 'eo_bad'), 'force_hide'],
+      [pinKey('pardons', 77), 'force_show'],
+      [pinKey('stories', 5), 'force_show'], // server-side, excluded here
+    ]);
+    expect(forceShowIdsBySource(pins)).toEqual({ eos: ['eo_low'], pardons: ['77'] });
+  });
+
+  it('main view drops force_hidden non-stories entries and injects force_shown ones once', async () => {
+    const pins = await fetchTrackerPins();
+    const { entries } = await fetchTrackerPage('main', null, undefined, pins);
+
+    const ids = entries.map(e => `${e.source}:${e.id}`);
+    expect(ids).not.toContain('eos:eo_bad');            // force_hide dropped
+    expect(ids).toContain('eos:eo_kept');               // untouched stream row
+    expect(ids).toContain('eos:eo_low');                // alarm 2, injected by pin
+    // pinned pardon at alarm 4 arrives via the stream — exactly once
+    expect(ids.filter(id => id === 'pardons:77')).toHaveLength(1);
+  });
+
+  it('does not re-inject force_shown rows on later pages', async () => {
+    const pins = await fetchTrackerPins();
+    const { state } = await fetchTrackerPage('main', null, undefined, pins);
+    calls = [];
+    await fetchTrackerPage('main', state, undefined, pins);
+    expect(calls.some(c => c.includes('id=in.'))).toBe(false);
   });
 });

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -7,6 +7,7 @@ import { alarmPalette } from '@/tokens';
 import { fmtDate } from '@/lib/date-utils';
 import {
   fetchTrackerPage,
+  fetchTrackerPins,
   fetchTrackerTally,
   coverageFrontier,
   visibleEntries,
@@ -15,25 +16,28 @@ import {
   SOURCE_ROUTES,
   TERM_START,
   TIMELINE_SOURCES,
-  type AlarmMin,
   type TimelineEntry,
   type TimelineSource,
+  type TrackerPins,
   type TrackerState,
   type TrackerTally,
+  type TrackerView,
 } from '@/lib/timeline';
 
 // The Tracker (ADO-545): the homepage rap sheet as a vertical center-spine
 // timeline, replacing the W1.1 horizontal strip. The bar is the timeline;
 // entries alternate left/right, newest first, with month markers on the bar.
-// Type and dot size follow alarm level. Main line = alarm filter (default 4+);
-// "All" recovers the complete record. Below 760px it collapses to a single
-// column with the spine on the left. Approved design: mockup rev 6.
+// Type and dot size follow alarm level. Default view = the curated main line
+// (ADO-554: PRD §12 anchor rule + tracker_pin overrides, computed server-side
+// for stories, pins client-side for the rest); "All" recovers the complete
+// record. Below 760px it collapses to a single column with the spine on the
+// left. Approved design: mockup rev 6.
 
-const ALARM_STOPS: { label: string; min: AlarmMin }[] = [
-  { label: 'All', min: 0 },
-  { label: 'Alarm 3+', min: 3 },
-  { label: 'Alarm 4+', min: 4 },
-  { label: 'Only 5', min: 5 },
+const VIEW_STOPS: { label: string; view: TrackerView }[] = [
+  { label: 'Main line', view: 'main' },
+  { label: 'All', view: 0 },
+  { label: 'Alarm 3+', view: 3 },
+  { label: 'Only 5', view: 5 },
 ];
 
 const INAUGURATION = new Date(`${TERM_START}T00:00:00`);
@@ -74,35 +78,41 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   const [loaded, setLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [minAlarm, setMinAlarm] = useState<AlarmMin>(4);
+  const [view, setView] = useState<TrackerView>('main');
   const [off, setOff] = useState<Set<TimelineSource>>(new Set());
   const [query, setQuery] = useState('');
   const [tally, setTally] = useState<TrackerTally | null>(null);
 
   const acRef = useRef<AbortController | null>(null);
   const controlsRef = useRef<HTMLDivElement>(null);
+  // Pins are fetched once per mount (tiny table) and reused across view
+  // changes and paging; a failed fetch degrades to "no pins" for the session.
+  const pinsRef = useRef<TrackerPins | null>(null);
 
-  // First page — refetched whenever the alarm floor changes, because the
-  // server-side alarm predicate is baked into every source's cursor stream.
-  // The current list stays on screen until the new one arrives: clearing it
-  // collapses the page height and scroll-anchoring yanks the viewport around.
+  // First page — refetched whenever the view changes, because the server-side
+  // predicate (main_line or alarm floor) is baked into every source's cursor
+  // stream. The current list stays on screen until the new one arrives:
+  // clearing it collapses the page height and scroll-anchoring yanks the
+  // viewport around.
   useEffect(() => {
     if (!enabled) return;
     const ac = new AbortController();
     acRef.current = ac;
     setLoadingMore(false);
     setRefreshing(true);
-    fetchTrackerPage(minAlarm, null, ac.signal)
-      .then(({ entries: page, state }) => {
-        if (ac.signal.aborted) return;
-        setEntries(page);
-        setPageState(state);
-        setLoaded(true);
-        setRefreshing(false);
-      })
-      .catch(() => { /* the Tracker is additive — never break the homepage */ });
+    (async () => {
+      const pins = view === 'main'
+        ? (pinsRef.current ??= await fetchTrackerPins(ac.signal))
+        : undefined;
+      const { entries: page, state } = await fetchTrackerPage(view, null, ac.signal, pins);
+      if (ac.signal.aborted) return;
+      setEntries(page);
+      setPageState(state);
+      setLoaded(true);
+      setRefreshing(false);
+    })().catch(() => { /* the Tracker is additive — never break the homepage */ });
     return () => ac.abort();
-  }, [enabled, minAlarm]);
+  }, [enabled, view]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -114,6 +124,10 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   }, [enabled]);
 
   const frontier = pageState ? coverageFrontier(pageState) : null;
+  // In the main-line view the server (plus pins) already decided inclusion —
+  // the client alarm floor must be 0 or it would drop low-alarm front
+  // openings and force_shown entries the rule deliberately included.
+  const minAlarm = view === 'main' ? 0 : view;
   const visible = useMemo(
     () => visibleEntries(entries, { frontier, min: minAlarm, off, query }),
     [entries, frontier, minAlarm, off, query],
@@ -132,7 +146,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     if (!pageState || loadingMore || refreshing || allExhausted) return;
     const ac = acRef.current;
     setLoadingMore(true);
-    fetchTrackerPage(minAlarm, pageState, ac?.signal)
+    fetchTrackerPage(view, pageState, ac?.signal, view === 'main' ? pinsRef.current ?? undefined : undefined)
       .then(({ entries: more, state }) => {
         if (ac?.signal.aborted) return;
         setEntries(prev => mergeEntries([prev, more]));
@@ -143,11 +157,11 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
       .finally(() => setLoadingMore(false));
   };
 
-  // Changing the alarm floor swaps in a list of a different length; if the
-  // reader is scrolled deep, snap back to the controls so the change is
-  // legible instead of the browser clamping scroll somewhere arbitrary.
-  const changeAlarm = (min: AlarmMin) => {
-    setMinAlarm(min);
+  // Changing the view swaps in a list of a different length; if the reader is
+  // scrolled deep, snap back to the controls so the change is legible instead
+  // of the browser clamping scroll somewhere arbitrary.
+  const changeView = (v: TrackerView) => {
+    setView(v);
     const el = controlsRef.current;
     if (el && el.getBoundingClientRect().top < 0) {
       el.scrollIntoView({ block: 'start', behavior: 'instant' as ScrollBehavior });
@@ -179,6 +193,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   const tallyTiles: { n: string; label: string; bad?: boolean }[] = [
     { n: String(dayCount), label: 'Days into term 2' },
   ];
+  if (tally?.openFronts != null && tally.openFronts > 0) {
+    tallyTiles.push({ n: String(tally.openFronts), label: 'Open fronts' });
+  }
   if (tally?.developments != null) {
     tallyTiles.push({ n: tally.developments.toLocaleString('en-US'), label: 'Developments logged' });
   }
@@ -188,15 +205,15 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
 
   // ── Controls ──
   const seg = (
-    <span role="group" aria-label="Alarm level filter" style={{ display: 'inline-flex', border: `1px solid ${theme.line}` }}>
-      {ALARM_STOPS.map(({ label, min }) => {
-        const on = minAlarm === min;
+    <span role="group" aria-label="Timeline view filter" style={{ display: 'inline-flex', border: `1px solid ${theme.line}` }}>
+      {VIEW_STOPS.map(({ label, view: v }) => {
+        const on = view === v;
         return (
           <button
-            key={min}
+            key={String(v)}
             type="button"
             aria-pressed={on}
-            onClick={() => changeAlarm(min)}
+            onClick={() => changeView(v)}
             className="tt-ts-seg"
             style={{
               ...mono, fontSize: 10, padding: '8px 14px', background: on ? theme.bg2 : 'none',
@@ -326,12 +343,22 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
           display: 'flex', gap: 8, marginTop: 7, flexWrap: 'wrap', alignItems: 'center',
           justifyContent: narrow || right ? 'flex-start' : 'flex-end',
         }}>
-          <span style={{
-            ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
-            border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
-          }}>
-            {e.source === 'stories' ? 'Loose end' : SOURCE_LABELS[e.source]}
-          </span>
+          {e.front ? (
+            // Front tag — navigation to the front's own page arrives with ADO-548
+            <span style={{
+              ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.ink, fontWeight: 600,
+              border: `1px solid ${theme.dim}`, padding: '2px 8px', whiteSpace: 'nowrap',
+            }}>
+              {e.front.name}
+            </span>
+          ) : (
+            <span style={{
+              ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
+              border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
+            }}>
+              {e.source === 'stories' ? 'Loose end' : SOURCE_LABELS[e.source]}
+            </span>
+          )}
         </div>
       </div>,
     );
@@ -342,7 +369,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     : refreshing
       ? 'Updating…'
       : `${visible.length} development${visible.length === 1 ? '' : 's'}`
-        + (minAlarm > 0 ? ` at alarm ${minAlarm}+` : ' · the complete record');
+        + (view === 'main'
+          ? ' · the main line'
+          : view > 0 ? ` at alarm ${view}+` : ' · the complete record');
 
   return (
     <section aria-label="The Tracker timeline" style={{ padding: '8px 0 24px', borderBottom: `1px solid ${theme.line}` }}>
@@ -421,7 +450,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
             <div style={{ ...mono, position: 'relative', zIndex: 2, fontSize: 10.5, color: theme.dim, textAlign: narrow ? 'left' : 'center', padding: narrow ? '18px 0 18px 28px' : '18px 0', background: theme.bg }}>
               {query
                 ? 'Nothing on the record matches that search at this filter.'
-                : 'Nothing at this alarm level yet · try "All" for the complete record.'}
+                : view === 'main'
+                  ? 'Nothing on the main line yet · try "All" for the complete record.'
+                  : 'Nothing at this alarm level yet · try "All" for the complete record.'}
             </div>
           )}
         </div>

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -5,6 +5,7 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { ErrorState } from '@/edge-states/ErrorState';
 import { alarmPalette } from '@/tokens';
 import { fmtDate } from '@/lib/date-utils';
+import { track, toAnalyticsItemType } from '@/lib/analytics';
 import {
   fetchTrackerPage,
   fetchTrackerPins,
@@ -23,6 +24,9 @@ import {
   type TrackerTally,
   type TrackerView,
 } from '@/lib/timeline';
+
+/** Every Tracker event is tagged with this tab so it never blends into the News feed. */
+const TRACKER_TAB = 'tracker';
 
 // The Tracker (ADO-545): the homepage rap sheet as a vertical center-spine
 // timeline, replacing the W1.1 horizontal strip. The bar is the timeline;
@@ -161,6 +165,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   // scrolled deep, snap back to the controls so the change is legible instead
   // of the browser clamping scroll somewhere arbitrary.
   const changeView = (v: TrackerView) => {
+    track('filter_apply', { tab: TRACKER_TAB, filter_key: 'view', filter_value: String(v) });
     setView(v);
     const el = controlsRef.current;
     if (el && el.getBoundingClientRect().top < 0) {
@@ -169,6 +174,8 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   };
 
   const toggleSource = (s: TimelineSource) => {
+    // filter_value records the resulting state, not the click itself.
+    track('filter_apply', { tab: TRACKER_TAB, filter_key: `source_${s}`, filter_value: off.has(s) ? 'on' : 'off' });
     setOff(prev => {
       const next = new Set(prev);
       if (next.has(s)) next.delete(s); else next.add(s);
@@ -176,7 +183,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     });
   };
 
-  const open = (e: TimelineEntry) => {
+  const open = (e: TimelineEntry, position: number) => {
+    const item_type = toAnalyticsItemType(e.source);
+    if (item_type) track('card_open', { item_type, alarm_level: e.alarm, feed_position: position, tab: TRACKER_TAB });
     navigate(`/${SOURCE_ROUTES[e.source]}/${encodeURIComponent(String(e.id))}`);
     window.scrollTo({ top: 0, behavior: 'instant' });
   };
@@ -258,7 +267,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   const rows: React.ReactNode[] = [];
   let lastYM: string | null = null;
   let side = 0;
-  visible.forEach(e => {
+  visible.forEach((e, idx) => {
     const ym = e.date.slice(0, 7);
     if (ym !== lastYM) {
       rows.push(
@@ -329,7 +338,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
         </time>
         <a
           href={`/${SOURCE_ROUTES[e.source]}/${encodeURIComponent(String(e.id))}`}
-          onClick={ev => { ev.preventDefault(); open(e); }}
+          onClick={ev => { ev.preventDefault(); open(e, idx); }}
           className="tt-ts-hl"
           style={{
             display: 'block', marginTop: 5, textDecoration: 'none',

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'wouter';
 import type { TabFilterConfig } from '@/lib/filters';
+import { track } from '@/lib/analytics';
 
 export interface UseFiltersResult {
   activeFilters: Record<string, string>;
@@ -38,7 +39,13 @@ export function useFilters(config: TabFilterConfig): UseFiltersResult {
     if (localSearch !== urlSearch) setLocalSearch(urlSearch);
   }
 
+  // Analytics fire here, at the commit point, because every tab's filter bar,
+  // search box and pager funnels through this hook. Search sends length only
+  // (PRD section 4 property hygiene), and only once the debounce settles.
+  const tab = config.tabType;
+
   const setFilter = useCallback((key: string, value: string | null) => {
+    track('filter_apply', { tab, filter_key: key, filter_value: value ?? 'clear' });
     setParams(prev => {
       if (value) {
         prev.set(key, value);
@@ -48,9 +55,10 @@ export function useFilters(config: TabFilterConfig): UseFiltersResult {
       prev.delete('page');
       return prev;
     }, { replace: true });
-  }, [setParams]);
+  }, [setParams, tab]);
 
   const setPage = useCallback((n: number) => {
+    track('pagination', { tab, page: Math.max(1, n) });
     setParams(prev => {
       if (n <= 1) {
         prev.delete('page');
@@ -59,14 +67,15 @@ export function useFilters(config: TabFilterConfig): UseFiltersResult {
       }
       return prev;
     }, { replace: true });
-  }, [setParams]);
+  }, [setParams, tab]);
 
   const setSearch = useCallback((q: string) => {
     setLocalSearch(q);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
+      const trimmed = q.trim();
+      if (trimmed) track('search', { tab, query_length: trimmed.length });
       setParams(prev => {
-        const trimmed = q.trim();
         if (trimmed) {
           prev.set('q', trimmed);
         } else {
@@ -76,12 +85,13 @@ export function useFilters(config: TabFilterConfig): UseFiltersResult {
         return prev;
       }, { replace: true });
     }, 300);
-  }, [setParams]);
+  }, [setParams, tab]);
 
   const clearAll = useCallback(() => {
+    track('filter_apply', { tab, filter_key: 'all', filter_value: 'clear' });
     setParams({}, { replace: true });
     setLocalSearch('');
-  }, [setParams]);
+  }, [setParams, tab]);
 
   useEffect(() => {
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -9,7 +9,8 @@ export interface UseFiltersResult {
   searchQuery: string;
   committedSearch: string;
   setFilter: (key: string, value: string | null) => void;
-  setPage: (n: number) => void;
+  /** `silent` = automatic correction (e.g. out-of-range clamp), not a visitor action: no `pagination` event. */
+  setPage: (n: number, opts?: { silent?: boolean }) => void;
   setSearch: (q: string) => void;
   clearAll: () => void;
   hasActiveFilters: boolean;
@@ -57,8 +58,10 @@ export function useFilters(config: TabFilterConfig): UseFiltersResult {
     }, { replace: true });
   }, [setParams, tab]);
 
-  const setPage = useCallback((n: number) => {
-    track('pagination', { tab, page: Math.max(1, n) });
+  const setPage = useCallback((n: number, opts?: { silent?: boolean }) => {
+    // Only visitor-initiated page changes count toward the pagination KPI;
+    // App.tsx's out-of-range clamp passes { silent: true } (Codex P2, PR #131).
+    if (!opts?.silent) track('pagination', { tab, page: Math.max(1, n) });
     setParams(prev => {
       if (n <= 1) {
         prev.delete('page');

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -220,10 +220,7 @@ export function track<E extends EventName>(event: E, props: EventProps[E]): void
     return;
   }
 
-  if (!isAnalyticsEnabled()) {
-    console.log('[analytics:off-prod]', event, safe);
-    return;
-  }
+  if (!isAnalyticsEnabled()) return; // silent off PROD (no console.log in shipped code)
 
   // PostHog is the analysis layer.
   try {
@@ -249,10 +246,7 @@ export function track<E extends EventName>(event: E, props: EventProps[E]): void
  * (see `public/analytics-gate.js`), so this is GA4-only on purpose.
  */
 export function trackPageView(path: string): void {
-  if (!isAnalyticsEnabled()) {
-    console.log('[analytics:off-prod] page_view', path);
-    return;
-  }
+  if (!isAnalyticsEnabled()) return; // silent off PROD
   try {
     window.gtag?.('config', GA4_MEASUREMENT_ID, { page_path: path });
   } catch {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,62 @@
+/**
+ * Analytics gate for the React app (ADO-558).
+ *
+ * Same single rule as `public/analytics-gate.js`: analytics only run on the
+ * production hostname. Everywhere else (localhost, the Netlify TEST site,
+ * branch/deploy previews) we log to the console and make zero network calls.
+ *
+ * `public/analytics-gate.js` is a plain classic script shared with the legacy
+ * HTML pages, so it cannot import from `src/`. The two constants below are
+ * mirrored there on purpose -- change one, change both.
+ *
+ * Note for tests: nothing here touches `window` at module scope. Vitest runs in
+ * a node environment with no jsdom, so import-time DOM access would crash the
+ * whole test file (see `src/lib/supabase.ts` gotcha).
+ */
+
+/** Canonical production hostname. */
+export const ANALYTICS_HOSTNAME = 'trumpytracker.com';
+
+/**
+ * Hosts that count as production. Exact matches only, never a suffix test --
+ * a suffix test would let `trumpytracker.com.example.org` through.
+ *
+ * `www` currently 301s to the apex, so only the apex is reachable today. The
+ * alias is here so that flipping Netlify's primary domain can't silently
+ * switch analytics off.
+ */
+export const ANALYTICS_HOSTNAMES: readonly string[] = [
+  ANALYTICS_HOSTNAME,
+  `www.${ANALYTICS_HOSTNAME}`,
+];
+
+export const GA4_MEASUREMENT_ID = 'G-5MDT4HFMNB';
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    TT_ANALYTICS_ENABLED?: boolean;
+  }
+}
+
+/** True only on the production hostname. */
+export function isAnalyticsEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return ANALYTICS_HOSTNAMES.includes((window.location.hostname || '').toLowerCase());
+}
+
+/**
+ * Report an SPA route change to GA4. No-op (console only) off PROD.
+ * Never throws -- an analytics failure must not break navigation.
+ */
+export function trackPageView(path: string): void {
+  if (!isAnalyticsEnabled()) {
+    console.log('[analytics:off-prod] page_view', path);
+    return;
+  }
+  try {
+    window.gtag?.('config', GA4_MEASUREMENT_ID, { page_path: path });
+  } catch {
+    /* analytics must never break the UI */
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,17 +1,22 @@
 /**
- * Analytics gate for the React app (ADO-558).
+ * Analytics for the React app (ADO-558 gate, ADO-559 typed wrapper).
  *
- * Same single rule as `public/analytics-gate.js`: analytics only run on the
- * production hostname. Everywhere else (localhost, the Netlify TEST site,
- * branch/deploy previews) we log to the console and make zero network calls.
+ * Same single environment rule as `public/analytics-gate.js`: analytics only
+ * run on the production hostname. Everywhere else (localhost, the Netlify TEST
+ * site, branch/deploy previews) we log to the console and make zero network
+ * calls.
  *
  * `public/analytics-gate.js` is a plain classic script shared with the legacy
- * HTML pages, so it cannot import from `src/`. The two constants below are
- * mirrored there on purpose -- change one, change both.
+ * HTML pages, so it cannot import from `src/`. The constants below are mirrored
+ * there on purpose -- change one, change both.
+ *
+ * Scope: React app ONLY. `public/shared.js` is not bundled by Vite and keeps
+ * its own `trackEvent` + `ALLOWED_PARAMS` path for GA4, mirroring to PostHog
+ * through the same `window.TTAnalytics.capture` façade this module uses.
  *
  * Note for tests: nothing here touches `window` at module scope. Vitest runs in
  * a node environment with no jsdom, so import-time DOM access would crash the
- * whole test file (see `src/lib/supabase.ts` gotcha).
+ * whole test file (see the `src/lib/supabase.ts` gotcha).
  */
 
 /** Canonical production hostname. */
@@ -32,12 +37,119 @@ export const ANALYTICS_HOSTNAMES: readonly string[] = [
 
 export const GA4_MEASUREMENT_ID = 'G-5MDT4HFMNB';
 
+/**
+ * Bump whenever the shape of any event's properties changes, so GA4 raw events
+ * stay interpretable. Mirrors `schema_v` in `public/shared.js`.
+ */
+export const SCHEMA_VERSION = 2;
+
 declare global {
   interface Window {
     gtag?: (...args: unknown[]) => void;
     TT_ANALYTICS_ENABLED?: boolean;
+    TTAnalytics?: { capture: (name: string, props: Record<string, unknown>) => void };
   }
 }
+
+/* ------------------------------------------------------------------ *
+ * Event taxonomy (PRD section 4)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Analytics-local item type. `DisplayItem.type` is a plain `string` in
+ * `src/types.ts`; we deliberately do not widen the shared types for analytics.
+ */
+export type AnalyticsItemType = 'story' | 'eo' | 'scotus' | 'pardon';
+
+/** Where a card sat in the feed when it was opened. */
+export type FeedPosition = number | 'hero' | 'featured';
+
+/**
+ * The property contract for every named event.
+ *
+ * Property keys and their types are compile-time enforced: a caller physically
+ * cannot pass free text to `search`, because the only key it accepts is
+ * `query_length: number`. No PII, no free-text user input, no email addresses
+ * anywhere in here (PRD section 4 "Property hygiene").
+ */
+export interface EventProps {
+  card_open: {
+    item_type: AnalyticsItemType;
+    alarm_level: number;
+    feed_position: FeedPosition;
+    tab: string;
+  };
+  source_click: {
+    item_type: AnalyticsItemType;
+    outlet_domain: string;
+    source_position: number;
+  };
+  share_click: { channel: string; item_type: AnalyticsItemType };
+  correction_click: { item_type: AnalyticsItemType };
+  filter_apply: { tab: string; filter_key: string; filter_value: string };
+  /** Never the query text -- length only. */
+  search: { tab: string; query_length: number };
+  pagination: { tab: string; page: number };
+  newsletter_view: { surface: string };
+  newsletter_submit: { surface: string };
+  newsletter_success: { surface: string };
+  newsletter_error: { surface: string; error_category: string };
+  feedback_open: { page_path: string };
+  /** The feedback MESSAGE goes to Supabase only, never to an analytics vendor. */
+  feedback_submit: { page_path: string };
+}
+
+export type EventName = keyof EventProps;
+
+/**
+ * Runtime allowlist of property keys per event.
+ *
+ * This is the React-side equivalent of `ALLOWED_PARAMS` in `public/shared.js`,
+ * and it exists because the type system disappears at runtime: an `as any` cast
+ * or an untyped JS caller could otherwise smuggle a raw search string into a
+ * vendor payload. Undeclared keys are dropped, not sent.
+ *
+ * `_schemaMatchesTypes` below makes this list drift-proof -- if it disagrees
+ * with `EventProps` in either direction, the build fails.
+ */
+const EVENT_PROP_KEYS = {
+  card_open: ['item_type', 'alarm_level', 'feed_position', 'tab'],
+  source_click: ['item_type', 'outlet_domain', 'source_position'],
+  share_click: ['channel', 'item_type'],
+  correction_click: ['item_type'],
+  filter_apply: ['tab', 'filter_key', 'filter_value'],
+  search: ['tab', 'query_length'],
+  pagination: ['tab', 'page'],
+  newsletter_view: ['surface'],
+  newsletter_submit: ['surface'],
+  newsletter_success: ['surface'],
+  newsletter_error: ['surface', 'error_category'],
+  feedback_open: ['page_path'],
+  feedback_submit: ['page_path'],
+} as const satisfies Record<EventName, readonly string[]>;
+
+/* --- compile-time guard: EVENT_PROP_KEYS must match EventProps exactly --- */
+
+type KeyDrift<Declared extends string, Listed extends string> =
+  [Exclude<Declared, Listed> | Exclude<Listed, Declared>] extends [never]
+    ? true
+    : ['ANALYTICS SCHEMA DRIFT', Exclude<Declared, Listed> | Exclude<Listed, Declared>];
+
+type SchemaCheck = {
+  [E in EventName]: KeyDrift<
+    keyof EventProps[E] & string,
+    (typeof EVENT_PROP_KEYS)[E][number]
+  >;
+};
+
+// If a property is added to EventProps but not to EVENT_PROP_KEYS (or vice
+// versa), this assignment fails to compile and names the offending event.
+const _schemaMatchesTypes: Record<EventName, true> = {} as SchemaCheck;
+void _schemaMatchesTypes;
+
+/* ------------------------------------------------------------------ *
+ * Environment gate
+ * ------------------------------------------------------------------ */
 
 /** True only on the production hostname. */
 export function isAnalyticsEnabled(): boolean {
@@ -46,8 +158,91 @@ export function isAnalyticsEnabled(): boolean {
 }
 
 /**
+ * Map a `DisplayItem.type` (a plain string) onto the analytics vocabulary.
+ * Returns null for anything unrecognised so callers drop the event rather than
+ * inventing a category.
+ */
+export function toAnalyticsItemType(type: string | null | undefined): AnalyticsItemType | null {
+  switch (type) {
+    case 'story':
+    case 'stories':
+      return 'story';
+    case 'eo':
+    case 'eos':
+    case 'executive_order':
+      return 'eo';
+    case 'scotus':
+      return 'scotus';
+    case 'pardon':
+    case 'pardons':
+      return 'pardon';
+    default:
+      return null;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Dispatch
+ * ------------------------------------------------------------------ */
+
+/** Drop any key not declared for this event, and any null/undefined value. */
+function pickAllowed<E extends EventName>(event: E, props: EventProps[E]): Record<string, unknown> {
+  const allowed: readonly string[] = EVENT_PROP_KEYS[event];
+  const safe: Record<string, unknown> = {};
+  if (!props || typeof props !== 'object') return safe;
+
+  for (const [key, value] of Object.entries(props as Record<string, unknown>)) {
+    if (value === undefined || value === null) continue;
+    if (!allowed.includes(key)) {
+      console.warn(`[analytics] Blocked param: ${event}.${key}`);
+      continue;
+    }
+    safe[key] = value;
+  }
+  return safe;
+}
+
+/**
+ * Fire a named KPI event to PostHog and GA4.
+ *
+ * Fire-and-forget: never throws, never blocks navigation. An analytics failure
+ * (ad blocker, offline, SDK missing) must not break the UI.
+ */
+export function track<E extends EventName>(event: E, props: EventProps[E]): void {
+  let safe: Record<string, unknown>;
+  try {
+    safe = pickAllowed(event, props);
+  } catch {
+    return;
+  }
+
+  if (!isAnalyticsEnabled()) {
+    console.log('[analytics:off-prod]', event, safe);
+    return;
+  }
+
+  // PostHog is the analysis layer.
+  try {
+    window.TTAnalytics?.capture(event, safe);
+  } catch {
+    /* ignored */
+  }
+
+  // GA4 stays a traffic report plus a raw-event backup. Custom dimensions are
+  // deliberately NOT pre-registered (PRD section 10) -- the props still land in
+  // raw events, they just aren't sliceable in GA4 reports until someone needs it.
+  try {
+    window.gtag?.('event', event, { ...safe, schema_v: SCHEMA_VERSION });
+  } catch {
+    /* ignored */
+  }
+}
+
+/**
  * Report an SPA route change to GA4. No-op (console only) off PROD.
- * Never throws -- an analytics failure must not break navigation.
+ *
+ * PostHog captures SPA pageviews itself via `capture_pageview: 'history_change'`
+ * (see `public/analytics-gate.js`), so this is GA4-only on purpose.
  */
 export function trackPageView(path: string): void {
   if (!isAnalyticsEnabled()) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -61,8 +61,12 @@ declare global {
  */
 export type AnalyticsItemType = 'story' | 'eo' | 'scotus' | 'pardon';
 
-/** Where a card sat in the feed when it was opened. */
-export type FeedPosition = number | 'hero' | 'featured';
+/**
+ * Where a card sat when it was opened: a 0-based index in a grid/spine, or one
+ * of the named slots that bypass the grid (Home hero + featured, Detail's
+ * "Keep Reading" strip).
+ */
+export type FeedPosition = number | 'hero' | 'featured' | 'related';
 
 /**
  * The property contract for every named event.

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -221,8 +221,10 @@ const quoted = (v: string | number) => `"${String(v).replace(/"/g, '')}"`;
  * with `:`/`+` survive, and the whole logic tree is URL-encoded.
  *
  * In the 'main' view (ADO-554) stories filter on the server-computed
- * main_line column; the other sources keep the alarm-4+ predicate (they are
- * all loose ends until fronts can contain them) with pins applied client-side.
+ * main_line column; the other sources get the loose-end bar — alarm 5 only
+ * (rule v1.1: they are all loose ends until fronts can contain them, and the
+ * 4+ bar drowned the line in severity-saturated rows) — with pins applied
+ * client-side.
  */
 export function buildSourcePath(
   source: TimelineSource,
@@ -232,7 +234,7 @@ export function buildSourcePath(
   const s = SPECS[source];
   const conditions: string[] = [];
   const alarmFrag = view === 'main'
-    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(4))
+    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(5))
     : s.alarm(view);
   if (alarmFrag) conditions.push(alarmFrag);
   if (cursor) {
@@ -308,9 +310,15 @@ export function forceShowIdsBySource(pins: TrackerPins): Partial<Record<Timeline
  *
  * In the 'main' view, pins adjust the non-stories sources client-side:
  * force_hide entries are dropped from every page, and on the FIRST page
- * (state === null) force_show rows below the alarm-4 stream are fetched by id
+ * (state === null) force_show rows below the alarm-5 stream are fetched by id
  * and merged in at their chronological position. Stories pins are already
  * applied by v_tracker_stories on the server.
+ *
+ * Pinned rows surface AT THEIR DATE, deliberately: the Tracker is a
+ * chronological record, not a pinboard (pin-to-top is the ADO-552 hero
+ * carousel), so an injected old pin stays buffered by the coverage frontier
+ * until paging reaches its date — exempting it would fake completeness of a
+ * range that hasn't loaded. Covered by the frontier test in the pins suite.
  */
 export async function fetchTrackerPage(
   view: TrackerView,
@@ -365,7 +373,7 @@ export async function fetchTrackerPage(
   );
 
   // First page of the main line: surface force_show pins on non-stories
-  // sources. Only rows below the alarm-4 stream are merged — anything at 4+
+  // sources. Only rows below the alarm-5 stream are merged — anything at 5
   // arrives (or already arrived) through normal paging, so injecting it again
   // would duplicate the entry.
   if (isMain && state === null && pins?.size) {
@@ -381,7 +389,7 @@ export async function fetchTrackerPage(
           );
           if (!res.ok) return [];
           const rows: Raw[] = await res.json();
-          return rows.map(spec.adapter).filter(e => e.alarm < 4);
+          return rows.map(spec.adapter).filter(e => e.alarm < 5);
         } catch (err) {
           if ((err as Error).name === 'AbortError') throw err;
           return []; // pins are additive — a failed fetch must not break the page

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -14,6 +14,13 @@ export const TERM_START = '2025-01-20';
 /** The alarm segmented filter's positions: All / 3+ / 4+ / Only 5 */
 export type AlarmMin = 0 | 3 | 4 | 5;
 
+/**
+ * The Tracker's view selector (ADO-554): 'main' is the curated main line
+ * (PRD §12 anchor principle — the default), the numbers are raw alarm floors
+ * that recover the complete record.
+ */
+export type TrackerView = AlarmMin | 'main';
+
 export interface TimelineEntry {
   id: string | number;
   source: TimelineSource;
@@ -21,6 +28,8 @@ export interface TimelineEntry {
   date: string;
   headline: string;
   alarm: number;
+  /** Published front this entry belongs to (stories only, via v_tracker_stories) */
+  front?: { name: string; slug: string };
 }
 
 export const SOURCE_LABELS: Record<TimelineSource, string> = {
@@ -60,6 +69,9 @@ export function storyRowToEntry(raw: Raw): TimelineEntry {
     date: (raw.first_seen_at as string) || '',
     headline: (raw.primary_headline as string) || '',
     alarm,
+    front: raw.front_name
+      ? { name: raw.front_name as string, slug: (raw.front_slug as string) || '' }
+      : undefined,
   };
 }
 
@@ -126,9 +138,11 @@ interface SourceSpec {
 // Key order is the chip display order (mockup rev 6).
 const SPECS: Record<TimelineSource, SourceSpec> = {
   stories: {
-    table: 'stories',
-    select: 'id,primary_headline,first_seen_at,alarm_level,severity',
-    base: `status=eq.active&summary_neutral=not.is.null&first_seen_at=gte.${TERM_START}`,
+    // v_tracker_stories (migration 112) bakes in status=active + enriched and
+    // adds front membership + the server-computed main_line column (ADO-554).
+    table: 'v_tracker_stories',
+    select: 'id,primary_headline,first_seen_at,alarm_level,severity,front_name,front_slug',
+    base: `first_seen_at=gte.${TERM_START}`,
     dateCol: 'first_seen_at',
     limit: 60,
     adapter: storyRowToEntry,
@@ -205,15 +219,21 @@ const quoted = (v: string | number) => `"${String(v).replace(/"/g, '')}"`;
  * Keyset pagination: order date desc, id desc; the next page is
  * (date < D) OR (date = D AND id < I). Values are quoted so timestamps
  * with `:`/`+` survive, and the whole logic tree is URL-encoded.
+ *
+ * In the 'main' view (ADO-554) stories filter on the server-computed
+ * main_line column; the other sources keep the alarm-4+ predicate (they are
+ * all loose ends until fronts can contain them) with pins applied client-side.
  */
 export function buildSourcePath(
   source: TimelineSource,
-  min: AlarmMin,
+  view: TrackerView,
   cursor: SourceCursor | null,
 ): string {
   const s = SPECS[source];
   const conditions: string[] = [];
-  const alarmFrag = s.alarm(min);
+  const alarmFrag = view === 'main'
+    ? (source === 'stories' ? 'main_line.is.true' : s.alarm(4))
+    : s.alarm(view);
   if (alarmFrag) conditions.push(alarmFrag);
   if (cursor) {
     conditions.push(
@@ -234,14 +254,69 @@ export function initialTrackerState(): TrackerState {
   return state;
 }
 
+// ── Tracker pins (ADO-554) ──
+
+/** Map keyed `${source}:${entity_id}` → pin. Tiny table, fetched whole. */
+export type TrackerPins = Map<string, 'force_show' | 'force_hide'>;
+
+export const pinKey = (source: TimelineSource, id: string | number) => `${source}:${id}`;
+
+/**
+ * Fetch every pin. Failure (including the table not existing yet — code can
+ * deploy ahead of migration 112 while the flag is off) degrades to no pins.
+ */
+export async function fetchTrackerPins(signal?: AbortSignal): Promise<TrackerPins> {
+  const pins: TrackerPins = new Map();
+  try {
+    const { url, anonKey } = await import('./supabase');
+    // Newest-first so if curation ever outgrows the cap, the truncation is
+    // deterministic and the most recent pins win (review note on PR #127).
+    const res = await fetch(
+      `${url}/rest/v1/tracker_pin?select=source,entity_id,pin&order=updated_at.desc&limit=1000`,
+      { headers: { 'apikey': anonKey, 'Authorization': `Bearer ${anonKey}` }, signal },
+    );
+    if (!res.ok) return pins;
+    const rows: Raw[] = await res.json();
+    for (const r of rows) {
+      pins.set(pinKey(r.source as TimelineSource, r.entity_id as string), r.pin as 'force_show' | 'force_hide');
+    }
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') throw err;
+  }
+  return pins;
+}
+
+/**
+ * The force_show pins for non-stories sources, grouped per source. Stories
+ * pins are resolved server-side in v_tracker_stories, so they are excluded.
+ */
+export function forceShowIdsBySource(pins: TrackerPins): Partial<Record<TimelineSource, string[]>> {
+  const out: Partial<Record<TimelineSource, string[]>> = {};
+  for (const [key, pin] of pins) {
+    if (pin !== 'force_show') continue;
+    const sep = key.indexOf(':');
+    const source = key.slice(0, sep) as TimelineSource;
+    if (source === 'stories' || !TIMELINE_SOURCES.includes(source)) continue;
+    (out[source] ??= []).push(key.slice(sep + 1));
+  }
+  return out;
+}
+
 /**
  * Fetch the next page for every non-exhausted source and advance its cursor.
  * Returns only the NEW entries (ascending); callers merge with what they hold.
+ *
+ * In the 'main' view, pins adjust the non-stories sources client-side:
+ * force_hide entries are dropped from every page, and on the FIRST page
+ * (state === null) force_show rows below the alarm-4 stream are fetched by id
+ * and merged in at their chronological position. Stories pins are already
+ * applied by v_tracker_stories on the server.
  */
 export async function fetchTrackerPage(
-  min: AlarmMin,
+  view: TrackerView,
   state: TrackerState | null,
   signal?: AbortSignal,
+  pins?: TrackerPins,
 ): Promise<{ entries: TimelineEntry[]; state: TrackerState }> {
   // Lazy import: lib/supabase reads window.location at module load, which would
   // break node-env unit tests that import this module's pure functions.
@@ -253,6 +328,7 @@ export async function fetchTrackerPage(
 
   const prev = state ?? initialTrackerState();
   const next: TrackerState = { ...prev };
+  const isMain = view === 'main';
 
   const groups = await Promise.all(
     TIMELINE_SOURCES.map(async source => {
@@ -260,7 +336,7 @@ export async function fetchTrackerPage(
       if (st.exhausted) return [];
       const spec = SPECS[source];
       try {
-        const res = await fetch(`${url}/rest/v1/${buildSourcePath(source, min, st.cursor)}`, { headers, signal });
+        const res = await fetch(`${url}/rest/v1/${buildSourcePath(source, view, st.cursor)}`, { headers, signal });
         if (!res.ok) {
           next[source] = { ...st, exhausted: true, errored: true };
           return [];
@@ -274,7 +350,11 @@ export async function fetchTrackerPage(
           exhausted: rows.length < spec.limit,
           errored: false,
         };
-        return rows.map(spec.adapter);
+        let entries = rows.map(spec.adapter);
+        if (isMain && source !== 'stories' && pins?.size) {
+          entries = entries.filter(e => pins.get(pinKey(source, e.id)) !== 'force_hide');
+        }
+        return entries;
       } catch (err) {
         if ((err as Error).name === 'AbortError') throw err;
         // One source failing must not blank the whole Tracker
@@ -283,6 +363,33 @@ export async function fetchTrackerPage(
       }
     }),
   );
+
+  // First page of the main line: surface force_show pins on non-stories
+  // sources. Only rows below the alarm-4 stream are merged — anything at 4+
+  // arrives (or already arrived) through normal paging, so injecting it again
+  // would duplicate the entry.
+  if (isMain && state === null && pins?.size) {
+    const bySource = forceShowIdsBySource(pins);
+    const injected = await Promise.all(
+      (Object.keys(bySource) as TimelineSource[]).map(async source => {
+        const spec = SPECS[source];
+        const ids = bySource[source]!.map(id => quoted(id)).join(',');
+        try {
+          const res = await fetch(
+            `${url}/rest/v1/${spec.table}?select=${spec.select}&${spec.base}&id=in.(${ids})`,
+            { headers, signal },
+          );
+          if (!res.ok) return [];
+          const rows: Raw[] = await res.json();
+          return rows.map(spec.adapter).filter(e => e.alarm < 4);
+        } catch (err) {
+          if ((err as Error).name === 'AbortError') throw err;
+          return []; // pins are additive — a failed fetch must not break the page
+        }
+      }),
+    );
+    groups.push(...injected);
+  }
 
   return { entries: mergeEntries(groups), state: next };
 }
@@ -331,6 +438,8 @@ export interface TrackerTally {
   developments: number | null;
   /** Alarm-5 developments in the last 30 days */
   alarm5Last30: number | null;
+  /** Published, unresolved fronts (ADO-554); null before migration 112 or on error */
+  openFronts: number | null;
 }
 
 async function countRows(
@@ -365,6 +474,12 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
 
   const since = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
 
+  const openFrontsPromise = countRows(
+    url, headers,
+    'events?select=id&publish_state=eq.published&lifecycle=neq.resolved',
+    signal,
+  );
+
   const perSource = await Promise.all(
     TIMELINE_SOURCES.map(async source => {
       const s = SPECS[source];
@@ -388,5 +503,6 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
   return {
     developments: sum(perSource.map(p => p.total)),
     alarm5Last30: sum(perSource.map(p => p.worst)),
+    openFronts: await openFrontsPromise,
   };
 }

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -482,14 +482,17 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
 
   const since = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
 
-  const openFrontsPromise = countRows(
-    url, headers,
-    'events?select=id&publish_state=eq.published&lifecycle=neq.resolved',
-    signal,
-  );
-
-  const perSource = await Promise.all(
-    TIMELINE_SOURCES.map(async source => {
+  // Both branches awaited in ONE Promise.all so a rejection (AbortError on
+  // navigation) from either side is observed by the caller -- Codex P1 on
+  // PR #131: the front count could otherwise reject unhandled while the
+  // per-source batch rejected first.
+  const [openFronts, perSource] = await Promise.all([
+    countRows(
+      url, headers,
+      'events?select=id&publish_state=eq.published&lifecycle=neq.resolved',
+      signal,
+    ),
+    Promise.all(TIMELINE_SOURCES.map(async source => {
       const s = SPECS[source];
       const alarm5 = s.alarm(5)!;
       const [total, worst] = await Promise.all([
@@ -502,8 +505,8 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
         ),
       ]);
       return { total, worst };
-    }),
-  );
+    })),
+  ]);
 
   const sum = (vals: (number | null)[]) =>
     vals.every(v => v !== null) ? vals.reduce((a: number, b) => a + (b as number), 0) : null;
@@ -511,6 +514,6 @@ export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTa
   return {
     developments: sum(perSource.map(p => p.total)),
     alarm5Last30: sum(perSource.map(p => p.worst)),
-    openFronts: await openFrontsPromise,
+    openFronts,
   };
 }

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -9,6 +9,16 @@ import { pickHeadline } from '@/lib/pick-headline';
 import type { DisplayItem, TimelineEvent } from '@/types';
 import type { ThemePalette } from '@/tokens/themes';
 import { Link } from 'wouter';
+import { track, toAnalyticsItemType } from '@/lib/analytics';
+
+/** Hostname only, so an outbound URL never lands in an analytics payload. */
+function outletDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return 'unknown';
+  }
+}
 
 interface DetailProps {
   item: DisplayItem | null;
@@ -49,7 +59,19 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
   const correctionBody = `Story ID: ${item.id}\n\nWhich claim is incorrect:\n\nCorrect information:\n\nSource URL:`;
   const mailtoHref = `mailto:corrections@trumpytracker.com?subject=${encodeURIComponent(correctionSubject)}&body=${encodeURIComponent(correctionBody)}`;
 
+  // Analytics: every share/source/correction event carries the item type only
+  // (never the URL or headline). A null type means an unmapped DisplayItem.type,
+  // and the event is dropped rather than tagged with a made-up category.
+  const item_type = toAnalyticsItemType(item.type);
+  const trackShare = (channel: string) => {
+    if (item_type) track('share_click', { channel, item_type });
+  };
+  const trackSource = (url: string, position: number) => {
+    if (item_type) track('source_click', { item_type, outlet_domain: outletDomain(url), source_position: position });
+  };
+
   async function handleCopyLink() {
+    trackShare('copy_link');
     try {
       await navigator.clipboard.writeText(window.location.href);
       setCopied(true);
@@ -59,29 +81,34 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
   }
 
   function shareToX() {
+    trackShare('x');
     const text = encodeURIComponent(pickHeadline(story, hmode));
     const url = encodeURIComponent(window.location.href);
     window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, '_blank', 'noopener,noreferrer');
   }
 
   function shareToThreads() {
+    trackShare('threads');
     const content = encodeURIComponent(pickHeadline(story, hmode) + ' ' + window.location.href);
     window.open(`https://threads.net/intent/post?text=${content}`, '_blank', 'noopener,noreferrer');
   }
 
   function shareToFacebook() {
+    trackShare('facebook');
     const url = encodeURIComponent(window.location.href);
     const text = encodeURIComponent(pickHeadline(story, hmode));
     window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}&quote=${text}`, '_blank', 'noopener,noreferrer');
   }
 
   function shareToReddit() {
+    trackShare('reddit');
     const url = encodeURIComponent(window.location.href);
     const title = encodeURIComponent(pickHeadline(story, hmode));
     window.open(`https://reddit.com/submit?url=${url}&title=${title}`, '_blank', 'noopener,noreferrer');
   }
 
   function handleNativeShare() {
+    trackShare('native');
     if (navigator.share) {
       navigator.share({
         title: pickHeadline(story, hmode),
@@ -178,7 +205,7 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
                       }}>
                         {s.heading}
                       </h3>
-                      <ReceiptsTimeline events={item.timelineEvents} theme={theme} type={type} />
+                      <ReceiptsTimeline events={item.timelineEvents} theme={theme} type={type} onSourceClick={trackSource} />
                     </section>
                   );
                 }
@@ -224,6 +251,7 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
             </button>
             <a
               href={mailtoHref}
+              onClick={() => { if (item_type) track('correction_click', { item_type }); }}
               style={{ textDecoration: 'none', fontFamily: type.mono, fontSize: 11, letterSpacing: '0.14em', padding: '10px 16px', border: `1px solid ${theme.line}`, background: 'transparent', color: theme.ink, cursor: 'pointer', borderRadius: 2, textTransform: 'uppercase', display: 'inline-block' }}>
               Report Correction
             </a>
@@ -237,7 +265,7 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                 {item.sources.map((src, i) => (
-                  <a key={i} href={src.url} target="_blank" rel="noopener noreferrer" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', background: theme.bg, border: `1px solid ${theme.line}`, borderRadius: 2, color: theme.ink, textDecoration: 'none', fontFamily: type.mono, fontSize: 12 }}>
+                  <a key={i} href={src.url} target="_blank" rel="noopener noreferrer" onClick={() => trackSource(src.url, i)} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', background: theme.bg, border: `1px solid ${theme.line}`, borderRadius: 2, color: theme.ink, textDecoration: 'none', fontFamily: type.mono, fontSize: 12 }}>
                     <span style={{ color: c.accent, fontWeight: 700 }}>[{(i + 1).toString().padStart(2, '0')}]</span>
                     <span style={{ flex: 1 }}>{src.label}</span>
                     <span style={{ color: theme.dim }}>↗</span>
@@ -266,7 +294,11 @@ export function Detail({ item, loading, onOpenItem, relatedItems }: DetailProps)
                 {relatedItems.map(r => {
                   const rc = alarmPalette(r.alarm, 'restrained', mode, 'midnight');
                   return (
-                    <div key={r.id} onClick={() => onOpenItem(r.id)} style={{ cursor: 'pointer', padding: '16px 0', borderTop: `2px solid ${rc.accent}` }}>
+                    <div key={r.id} onClick={() => {
+                      const rt = toAnalyticsItemType(r.type);
+                      if (rt) track('card_open', { item_type: rt, alarm_level: r.alarm, feed_position: 'related', tab: 'detail' });
+                      onOpenItem(r.id);
+                    }} style={{ cursor: 'pointer', padding: '16px 0', borderTop: `2px solid ${rc.accent}` }}>
                       <div style={{ fontFamily: type.mono, fontSize: 10, color: rc.accent, letterSpacing: '0.14em', fontWeight: 700, marginBottom: 8 }}>{TONE_SYSTEM.typeLabels[r.type]}</div>
                       <div style={{ fontFamily: type.display, fontWeight: 600, fontSize: 16, lineHeight: 1.2, color: theme.ink, textWrap: 'balance' }}>{pickHeadline(r, hmode)}</div>
                     </div>
@@ -314,7 +346,13 @@ const TIMELINE_LABELS: Record<string, string> = {
   other: 'Other',
 };
 
-function ReceiptsTimeline({ events, theme, type }: { events: TimelineEvent[]; theme: ThemePalette; type: { mono: string; display: string; sans: string } }) {
+function ReceiptsTimeline({ events, theme, type, onSourceClick }: {
+  events: TimelineEvent[];
+  theme: ThemePalette;
+  type: { mono: string; display: string; sans: string };
+  /** Second source_click render site (PRD section 4); position = timeline index. */
+  onSourceClick: (url: string, position: number) => void;
+}) {
   return (
     <div style={{ position: 'relative', paddingLeft: 28 }}>
       {events.map((evt, i) => {
@@ -365,6 +403,7 @@ function ReceiptsTimeline({ events, theme, type }: { events: TimelineEvent[]; th
               )}
               {evt.source_url && (
                 <a href={evt.source_url} target="_blank" rel="noopener noreferrer"
+                  onClick={() => onSourceClick(evt.source_url!, i)}
                   style={{ fontFamily: type.mono, fontSize: 12, color: '#3b82f6', marginTop: 4, display: 'inline-block' }}>
                   Source ↗
                 </a>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import { fmtDate, relDate } from '@/lib/date-utils';
 import { pickHeadline } from '@/lib/pick-headline';
 import type { DisplayItem, DisplayStats } from '@/types';
 import type { TabFilterConfig } from '@/lib/filters';
+import { track, toAnalyticsItemType, type FeedPosition } from '@/lib/analytics';
 
 interface HomeProps {
   items: DisplayItem[];
@@ -49,6 +50,16 @@ export function Home({
   const showFiltered = hasActiveFilters || false;
   // When the Tracker owns "/", the story feed is the News tab
   const trackerHome = useFeatureFlag('rap_sheet');
+
+  // card_open lives here, not in Card: Card doesn't know its position or tab,
+  // and the hero <h1> + featured card open items without going through Card.
+  // Card's interface is unchanged; it just receives a closure per slot.
+  const tab = filterConfig?.tabType ?? 'stories';
+  const openWithTracking = (item: DisplayItem, position: FeedPosition) => {
+    const item_type = toAnalyticsItemType(item.type);
+    if (item_type) track('card_open', { item_type, alarm_level: item.alarm, feed_position: position, tab });
+    onOpenItem(item.id);
+  };
 
   const navLabel = filterConfig?.tabType === 'eos' ? 'Executive Orders'
     : filterConfig?.tabType === 'scotus' ? 'Supreme Court'
@@ -105,8 +116,8 @@ export function Home({
           gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))',
           gap: 20, padding: '24px 0 0',
         }}>
-          {items.map(it => (
-            <Card key={it.id} item={it} headlineMode={headlineMode} onOpen={onOpenItem} />
+          {items.map((it, i) => (
+            <Card key={it.id} item={it} headlineMode={headlineMode} onOpen={() => openWithTracking(it, i)} />
           ))}
         </div>
       </>
@@ -128,7 +139,7 @@ export function Home({
       <section aria-label="Lead story" style={{ padding: '44px 0 36px', borderBottom: `1px solid ${theme.line}`, position: 'relative' }}>
         <div style={{ maxWidth: 920 }}>
           <Kicker theme={theme} type={headType} item={lead} accent={cLead.accent} />
-          <h1 onClick={() => onOpenItem(lead.id)} style={{
+          <h1 onClick={() => openWithTracking(lead, 'hero')} style={{
             fontFamily: headType.display, fontWeight: 600,
             fontSize: 'clamp(32px, 4.0vw, 52px)', lineHeight: 1.04,
             letterSpacing: '-0.02em', textWrap: 'balance',
@@ -154,14 +165,14 @@ export function Home({
       {/* FEATURED CARD */}
       {featuredSecond && (
         <div style={{ padding: '28px 0 0' }}>
-          <Card item={featuredSecond} headlineMode={headlineMode} onOpen={onOpenItem} featured />
+          <Card item={featuredSecond} headlineMode={headlineMode} onOpen={() => openWithTracking(featuredSecond, 'featured')} featured />
         </div>
       )}
 
       {/* GRID */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(340px, 100%), 1fr))', gap: 20, padding: '24px 0 0' }}>
-        {rest.map(it => (
-          <Card key={it.id} item={it} headlineMode={headlineMode} onOpen={onOpenItem} />
+        {rest.map((it, i) => (
+          <Card key={it.id} item={it} headlineMode={headlineMode} onOpen={() => openWithTracking(it, i)} />
         ))}
       </div>
     </>


### PR DESCRIPTION
## What ships
Cherry-picks from `test` (no merges):
- `877c0bf` ADO-558: GA4 gated at script level on the PROD hostname (fixes TEST/localhost pollution)
- `ed39e72` ADO-559: PostHog bootstrap + typed analytics wrapper (client-side key, free tier, no card on file)
- `70f6a92` ADO-560: named KPI events (`card_open`, `source_click`, `share_click`, `filter_apply`, `search`, `pagination`)
- `b984b1f` + `4c91566` ADO-554: The Tracker main line (tracker_pin, v_tracker_stories, rule v1.1)
- flag flip: `rap_sheet: true` in `flags-prod.json` (Josh: "just send it", August 24, 2026)

## PROD prerequisites (done BEFORE this PR merges)
- Migration 112 applied on PROD via SQL Editor (August 24, 2026)
- 8 fronts seeded + published on PROD (7 from TEST + new `election-suppression`)

## Deployment checklist
- No edge functions, no new secrets, no workflow changes
- PostHog project 572949: Free plan, no payment method (pre-gate confirmed)
- tsc clean, vitest 168/168, vite build clean on this branch

## Rollback
Flip `rap_sheet` back to `false` in `flags-prod.json` (analytics pieces are additive and gated to the PROD hostname).

Refs: ADO-563, ADO-554, ADO-558, ADO-559, ADO-560

🤖 Generated with [Claude Code](https://claude.com/claude-code)