### PR TITLE
docs: sync Aug 23-24 handoffs + growth kickoff (PROD redeploy for OG env fix)

### DIFF
--- a/docs/features/growth/kickoff-social-and-monetization.md
+++ b/docs/features/growth/kickoff-social-and-monetization.md
@@ -1,0 +1,82 @@
+# Growth kickoff: social automation + monetization
+
+**Written:** August 24, 2026 (end of the ADO-563 analytics rollout session)
+**Status:** kickoff only. Each track gets its own deep planning session that produces a PRD + plan in this folder. Nothing here is decided except where marked.
+**Owner:** Josh. **Budget ceiling for everything below:** stays inside the $50/month hard cap until revenue exists.
+
+## 0. Open Decisions (Josh)
+
+Answer these before or during the planning sessions; each names the item it blocks.
+
+- [ ] **D1 - Which platform first?** (blocks social Phase B). Recommendation: Bluesky + X free tier, decided by the "Shares by channel" tile on the Content Engagement dashboard after 2 weeks - whichever channel readers already share to wins.
+- [ ] **D2 - Human-in-the-loop or full auto?** (blocks social Phase B). Recommendation: draft-then-approve for the first month (the Discord webhook already exists for alerts; approval = a reaction), full auto only for alarm-5 items once the voice is trusted.
+- [ ] **D3 - Image style.** (blocks visuals). Recommendation: deterministic branded cards rendered from our own data (headline, alarm level, front tag, source count) - $0, no AI-image weirdness, always on-brand. AI-generated imagery only for the weekly "by the numbers" post, if ever.
+- [ ] **D4 - First money move.** (blocks monetization Phase A). Recommendation: a "Support the receipts" button (Ko-fi or Stripe Payment Link, $0 setup, 0-5% fees) BEFORE any ads. Ads on political content pay badly and AdSense may reject or demonetize the category.
+- [ ] **D5 - Where does the first dollar go?** Recommendation: Supabase Pro ($25/mo) - PROD DB has been over the 500MB free cap since May (see active-work memory). Revenue target #1 is simply "the site pays its own hosting".
+- [ ] **D6 - Retire the overlapping cards?** ADO-131, 149, 236, 249 all describe pieces of 515 / 299. Recommendation: close them as duplicates when the social PRD lands.
+
+## 1. What already exists (do not re-plan)
+
+| Item | State | What it is |
+|---|---|---|
+| Epic **ADO-299** Social Media & Marketing Automation | New (January 2026) | Full tools landscape (Buffer / Postiz / direct APIs), 5-phase plan, cost table. Still the reference for platform costs: X free tier = 500 posts/month (enough), X Basic $200/mo only for engagement features (NOT in budget). |
+| Story **ADO-515** Social share infrastructure Phase 1 | New, blocked | Dynamic OG tags per story/EO/SCOTUS/pardon via Netlify Edge Function + refactored share panel. Spec: `docs/superpowers/specs/2026-05-23-social-share-infrastructure-design.md`. **Blocker:** Netlify PROD env vars (SUPABASE_URL + ANON_KEY) still point at TEST values (memory, May 30). |
+| Share panel on detail pages | Live | X / Reddit / Copy Link buttons, instrumented (`share_click` by channel) since ADO-560. |
+| `og-default.png` | Broken reference | Fixed as part of 515. |
+| Claude cloud agents (Stories / EO / SCOTUS / Pardons) | Live | Every item already has editorial copy in the T2 voice + an alarm level. Social copy is a derivative of this, not new AI spend. |
+| The Tracker + 8 fronts | Live on PROD since August 24, 2026 | Fronts are natural social series ("Iran, day 137") - a front page (ADO-548) is the ideal share target. |
+| Canva MCP | Connected in Claude Code | Can create/edit/export designs programmatically - candidate for card templates without paying for Canva AI. |
+| PostHog Content Engagement dashboard | Live | `share_click` by channel, `source_click` by outlet, opens by type / alarm. This is the data that decides D1 and what to post. |
+
+## 2. What changed since Epic 299 was written (January)
+
+1. **Editorial copy is free now.** 299 assumed GPT writes "smart-ass commentary" per post. The Claude agents already produce it per item at $0 marginal (subscription). Social copy = a short-form template over existing fields (headline, spicy summary first sentence, alarm label, front) - no new model calls for v1.
+2. **We have alarm levels and fronts.** Posting rules can be mechanical: alarm 5 = post immediately; front opening / new front peak = post; everything else = daily digest. This is the same rule the Tracker main line uses (migration 112) - reuse `v_tracker_stories.main_line` as the "worth posting" predicate.
+3. **We can measure it.** `share_click` by channel tells us where readers already go; UTM-tagged links on our own posts show up in GA4 acquisition as a distinct source. Add `utm_source=<platform>&utm_medium=social&utm_campaign=auto` to every automated link so social-driven sessions are separable in both dashboards.
+4. **Visuals do not need image AI.** A branded card rendered from data (Satori / `@vercel/og` on a Netlify Edge Function, or a Canva template filled via MCP) is deterministic, $0, and never misspells a name. This also IS the 515 Phase 2 "dynamic OG image" - one renderer serves both link previews and social posts.
+
+## 3. Social automation - proposed shape (for the planning session)
+
+**Goal:** every alarm-5 development and every front opening gets posted with a branded card and a UTM link within ~15 minutes, with zero manual work after approval rules are set.
+
+- **Phase A - cards + previews ($0):** unblock 515 (Josh sets the two Netlify env vars), ship OG tags, then the card renderer (headline, alarm badge, front tag, "N sources", date, T2 wordmark). Platform-sized variants: 1200x630 (link preview / X), 1080x1080 (IG / Threads), 1080x1920 (stories) - same renderer, three sizes.
+- **Phase B - poster ($0):** a scheduled GitHub Action (same pattern as `rss-tracker-prod.yml`) or a Claude cloud agent that reads new `main_line = true` rows since last run, builds copy from existing fields, attaches the card, posts via Bluesky AT Protocol (free) + X free tier (500/mo). Record every post in a `social_posts` table (platform, entity, post id, url, posted_at) so it is idempotent and measurable. Human gate per D2.
+- **Phase C - digest + series ($0):** daily "today on the main line" thread; weekly "by the numbers" card (developments logged, alarm-5 count - the Tracker tally numbers already exist in `fetchTrackerTally`); front series posts when a front hits a new peak.
+- **Phase D - engagement:** requires X Basic ($200/mo). Out of budget; revisit only once monetization covers it.
+
+**Cost:** Phases A-C $0/month on current infrastructure. Optional: Buffer $5/channel/mo if we want IG/Facebook without Meta app review.
+
+**Success metrics (from the dashboards):** GA4 sessions with `utm_medium=social` per week; `share_click` growth; retention of social-acquired visitors vs direct.
+
+## 4. Monetization - proposed shape (for the planning session)
+
+**Goal #1:** the site pays its own hosting (~$25-45/month: Supabase Pro + domain; PostHog stays $0). **Goal #2:** fund the X Basic tier if engagement automation proves worth it.
+
+| Option | Setup cost | Fit | Notes |
+|---|---|---|---|
+| **Donation / "Support the receipts"** (Ko-fi, Buy Me a Coffee, Stripe Payment Link) | $0, 0-5% fees | Best first move | One button in the header + a line under every detail page. Zero design risk, no content-policy exposure. Instrument as `support_click`. |
+| **Newsletter sponsorship** | $0 | Good, later | Needs the newsletter to exist with real subscribers (Phase 5b ships the funnel). Sponsor slot in the weekly digest. Rate follows list size. |
+| **Membership** (Patreon / Ko-fi memberships) | $0, 5-8% fees | Medium | Perk ideas: early access to front pages, monthly "receipts" PDF, name in a supporters list. Only after there is a habit (retention tile > 10%). |
+| **Display ads** (AdSense, Ezoic, Mediavine) | $0 but traffic minimums (Mediavine 50k sessions/mo) | Poor fit now | Political content is often limited-ads or rejected; RPM on politics is low; ads fight the design. Park it. |
+| **Affiliate / merch** | $0-low | Weak | Off-brand unless it is books/receipts-themed. Park it. |
+
+**Instrumentation first:** add `support_click` (and later `member_click`) to the analytics allowlist so the Content Engagement dashboard shows conversion by page and by alarm level of the item being read. Decision rule: if support clicks per 1,000 pageviews < 2 after a month, the ask is invisible - move it, do not add another.
+
+**Cost:** $0 to start. Fees only on money that arrives.
+
+## 5. Sequencing (recommendation)
+
+1. **Now (no session needed):** Josh sets Netlify PROD env vars (unblocks 515) and answers D1-D5 above.
+2. **Session 1 - Social PRD + plan** (deep): resolves 299 vs 515 overlap, specifies the card renderer, poster, `social_posts` table, UTM scheme, approval flow. Output: `docs/features/growth/prd-social-automation.md` + plan. Close duplicate cards (D6).
+3. **Session 2 - Monetization PRD + plan** (medium): support button + instrumentation + copy; newsletter sponsorship placeholder. Output: `docs/features/growth/prd-monetization.md`.
+4. **Build order:** 515 -> card renderer -> support button (one afternoon, ships with the renderer PR) -> poster Phase B -> digest.
+5. **Read the dashboard at each step** (ADO-564 rules): shares-by-channel picks the platform; source-click rate decides whether posts link to us or to the outlet; retention decides when membership is worth offering.
+
+## 6. Related cards
+
+- Epic ADO-299 (social automation) - keep as the parent; this doc supersedes its phase list.
+- Epic ADO-565 (monetization) - created August 24, 2026.
+- ADO-515 (OG tags + share UI) - first build.
+- ADO-548 (front pages) - best share target; sequence before Phase C.
+- ADO-564 (north-star numbers) - the data gate for every decision above.
+- ADO-131 / 149 / 236 / 249 - overlapping legacy cards, close on D6.

--- a/docs/handoffs/2026-08-24-ado-563-analytics-prod-rollout.md
+++ b/docs/handoffs/2026-08-24-ado-563-analytics-prod-rollout.md
@@ -1,0 +1,61 @@
+# Handoff - ADO-563: Analytics Phase 5a PROD rollout + The Tracker debut (ADO-554)
+
+**Date:** August 24, 2026 (supervised session with Josh)
+**Tickets closed:** ADO-563, ADO-558, ADO-559, ADO-560, ADO-554. **Created:** ADO-564 (north-star check, due September 7, 2026).
+**PR:** #131 `deploy/ado-563-analytics-tracker` -> `main`, squash `3b37ad5`. Branch deleted.
+
+## What shipped to trumpytracker.com
+
+1. **Analytics Phases 1-2** (cherry-picks `877c0bf` 558, `ed39e72` 559, `70f6a92` 560): GA4 gated to the PROD hostname, PostHog bootstrap + typed wrapper, six named KPI events.
+2. **The Tracker debut** (cherry-picks `b984b1f` + `4c91566` 554): Josh's in-session call was "just send it" - AC7 (TEST eyeball) waived in favour of live PROD review; he expects to want changes later.
+   - Migration 112 applied on PROD via SQL Editor (claude-in-chrome + raw.githubusercontent fetch, the migration-111 pattern).
+   - 8 fronts seeded + published on PROD: the 7 TEST fronts plus a NEW **Election Suppression** front (Josh: "election fraud" is the pretext, suppression is the front). Assignments by keyword sweep (one front per story, most-specific first): Iran 1510, Epstein 235, Ballroom 120, Election ~67, Crypto 40, Kushner 14, Courts 10, Qatar 7. No pins. Script kept at `scripts/maintenance/2026-08-24-ado-554-prod-fronts-seed.sql` (test-only path; already applied).
+   - `rap_sheet: true` in `flags-prod.json` (same PR, after migration + seed).
+3. `docs/ARCHITECTURE.md`: new "Analytics vendors" table + `rap_sheet` row in kill switches.
+
+## Review + fixes (Codex on PR #131, all addressed and synced to `test`)
+
+- P1 `src/lib/timeline.ts`: front-count promise now inside the same `Promise.all` as the per-source tally (no unobserved AbortError).
+- P1 console logging: off-PROD gtag / TTAnalytics / track / trackPageView / shared.js trackEvent are now SILENT no-ops (repo rule: no console.log in shipped code). Tests updated to assert no console output. **Consequence:** on TEST/localhost you can no longer see "would-fire" analytics in the console - watch `window.TTAnalytics.capture` in DevTools instead.
+- P2 `useFilters.setPage(n, { silent: true })`: App.tsx's out-of-range page clamp no longer emits `pagination`.
+- The GitHub "review" check (GPT-4o reviewer) FAILS because the OpenAI key has no credits. Not a blocker (Codex is the review of record) but Josh should top up or retire it.
+
+## Verification done on trumpytracker.com
+
+- PostHog pre + post deploy: Free plan, "Add your credit card" prompt = no payment method, billing limit = free tier 1M.
+- GA4 real-time: PROD pageviews arriving (`/`, `/detail/14111`, `/news`); deploy previews / TEST / localhost blocked by the exact-hostname gate.
+- PostHog Activity: `$pageview`, autocapture, and every named event from real clicks: `card_open` (tracker tab, pos 0, alarm 5), `source_click` (fortune.com), `share_click` (copy_link), `pagination` (stories p2), `search` (len 7), `filter_apply` (Dumpster Fire pill).
+- Replay: recording, 50% sampling (project setting), `maskAllInputs: true` in code (project masking is "passwords only" - the code assertion is what protects inputs).
+- PROD Tracker: 8 open fronts, main line renders with front tags.
+
+## Content Engagement dashboard
+
+https://us.posthog.com/project/572949/dashboard/2029138 - 12 insights created through the logged-in session API (see conventions memory for the fetch pattern): card open rate (`card_open / $pageview`) and source click rate (`source_click / card_open`) as bold numbers; card opens by item type / tab / feed position / alarm level; source clicks by outlet; shares by channel; filters / searches / pagination by tab; daily pageviews. Newsletter + Feedback dashboards stay in Phase 5b.
+
+## Gotchas learned
+
+- PROD headlines != TEST headlines: copying TEST's curated headline list matched almost nothing on PROD. Keyword sweeps + `DISTINCT ON (story_id)` is the reusable pattern (`story_event.story_id` is the PK).
+- The first election sweep grabbed 175 rows because `redistrict|gerrymander` are their own topic - keep those OUT of Election Suppression.
+- Auto-mode classifier blocked write SQL runs in the Supabase editor (ctrl+Enter and Run button) but allowed read-only previews - Josh presses the key for writes. Supabase's "creates a table without RLS" popup on `WITH ... INSERT` is a false positive.
+- Screenshots on the trumpytracker.com tab timed out repeatedly (heavy renderer); `find` + ref clicks and `javascript_tool` worked fine. Refs churn on every React re-render - re-`find` before each click.
+
+## Next
+
+- ADO-561 (feedback popup, Phase 3) -> 562 -> Phase 5b deploy (feedback-submit function + migration 113).
+- ADO-557 fronts automation planning (reuse the seed regexes); ADO-548 front pages; ADO-547 admin pin editor. Josh will want Tracker changes after seeing it live - expect a curation pass.
+- ADO-564: read the two north-star numbers off dashboard 2029138 on/after September 7, 2026.
+
+## Addendum (same night)
+
+- **GPT API PR-review workflow removed** (PR #132, `e4aaf8c` on main, also on test). It was draining the OpenAI balance Josh had just topped up, and that balance also feeds RSS entity extraction - RSS Tracker PROD failed 5 runs in a row (18:27-02:51) with `429 You have no credits remaining` on embeddings. Codex (ChatGPT subscription) is the only PR reviewer now. If the next 2h RSS run still fails, that is a new session's problem.
+- Dashboard 2029138 grew to 16 tiles: weekly retention, card-open + source-click rates split by `$device_type`, and Tracker view/source toggle use (`filter_apply` on tab=tracker).
+- **Decision rules** (threshold -> action) are a comment on ADO-564. Gaps acknowledged: front-tag clicks are not instrumented until ADO-548 (add `front_open`); Newsletter + Feedback dashboards wait for Phase 5b. Looker Studio was never really used - not maintained.
+- **Owner traffic excluded** (same night): GA4 internal-traffic rule "Josh home" (`129.228.58.76/32`) + the property's "Internal Traffic" data filter flipped Testing -> Active; PostHog project filter `$ip is_not 129.228.58.76` set default-on and applied to every dashboard tile. Not retroactive; update both if the home IP changes (`curl -s https://api.ipify.org`). GA4 gets NO new events - it stays the traffic report; PostHog is the behaviour layer. Pre-August-24 GA4 history is inflated by TEST/preview traffic - baseline starts today.
+
+## Growth track opened (end of session)
+
+Josh: social automation with visuals + monetization are the must-do next tracks, driven by the new analytics. Kickoff doc: `docs/features/growth/kickoff-social-and-monetization.md` (section 0 = six open decisions for Josh). Cards: Epic 299 re-kicked with a comment + child ADO-566 (social planning session); new Epic 565 (monetization) + child ADO-567 (monetization planning session). First unblock is not code: Josh sets the Netlify PROD env vars so ADO-515 (OG tags + share UI) can ship.
+
+## Next session starts here (Josh, end of night)
+
+**Investigate + plan the OG link-preview fix before anything else.** Verified live tonight: `curl -A "Twitterbot/1.0" https://trumpytracker.com/detail/14111` returns `og:title="TrumpyTracker"` and `og:image="/og-default.png"` - every shared link shows a generic card. `netlify/edge-functions/og-tags.ts` is deployed on main and reads `SUPABASE_URL` + `SUPABASE_ANON_KEY` from Netlify env; the May 30 note (ADO-515) says those still hold TEST values. Josh had not heard of this blocker - walk him through it, confirm the actual env values (Netlify MCP / dashboard), then with his explicit OK set PROD values, redeploy, and re-run the curl until the headline appears. This is the first domino for the social track (Epic 299 / ADO-566). Alerts discussion (pipeline-failure email, PostHog spike/drop alerts) also parked for tomorrow.

--- a/docs/handoffs/2026-08-24-prod-openai-quota-outage.md
+++ b/docs/handoffs/2026-08-24-prod-openai-quota-outage.md
@@ -1,0 +1,36 @@
+# 2026-08-24 — PROD RSS pipeline outage: OpenAI out of credits
+
+**Type:** Ops incident / diagnosis only — no code changes, no ADO ticket.
+
+## What happened
+- 5 consecutive `RSS Tracker - PROD` runs failed 18:27 → 02:51 UTC (last green 16:25 UTC).
+- Every run died at the article-embedding step: `429 insufficient_quota — You have no credits remaining`
+  → `FATAL: OpenAI auth/payment error (429). Aborting embeddings.` → exit 1.
+- Embeddings (`text-embedding-3-small`) are the only OpenAI call left in the PROD pipeline
+  (editorial enrichment is Claude agents; legacy GPT story enrichment is OFF).
+
+## Diagnosis steps (repeatable)
+```bash
+gh run list --workflow "RSS Tracker - PROD" --limit 15 --json conclusion,createdAt
+gh run view <id> --log-failed | grep -iE "429|quota|FATAL"
+gh secret list | grep -i openai   # OPENAI_API_KEY last set 2025-06-29
+```
+
+## Gotcha
+Josh's first credit top-up did NOT fix it — a manual re-run (`32807382009`) still 429'd.
+Credits must land on the OpenAI org/project that the GitHub-secret key belongs to.
+Second top-up ("payment cleared") worked: run `32808567473` → 41 embeddings, 0 failures.
+
+## Recovery: self-healing, no manual steps
+- Feeds/articles were still ingested during the outage; only embed → cluster → enrich were skipped.
+- Each run selects `articles WHERE embedding_v1 IS NULL` (100/run) and `get_unclustered_articles`.
+- First recovery run hit the 4-min runtime guard during clustering → `partial_success`
+  (10 of 41 clustered). Expected; cron (every 2h) drains the rest.
+- All failures were logged to `pipeline_skips` (reason `API_ERROR`) — admin → Skips tab.
+
+## Watch item
+Hybrid-clustering ANN candidate block took 7–9s/article (target <100ms) on the recovery run.
+Check the 06:00/08:00 UTC runs on 2026-08-25; if it persists on normal-size runs, open an ADO story.
+
+## Cost
+Negligible — backlog is embeddings only (~$0.0001/article).


### PR DESCRIPTION
## Summary
- Docs-only: syncs the ADO-563 handoff, PROD OpenAI-quota outage note, and growth-track kickoff from `test` to `main`.
- Merging triggers a PROD redeploy so `netlify/edge-functions/og-tags.ts` picks up the Netlify **production-context** `SUPABASE_URL` / `SUPABASE_ANON_KEY` (set to PROD on August 26, 2026; other contexts stay TEST). Unblocks ADO-515 / Epic 299.

## Verification
- After deploy: `curl -A "Twitterbot/1.0" https://trumpytracker.com/detail/14111` should return `og:title` = story headline instead of "TrumpyTracker".

🤖 Generated with [Claude Code](https://claude.com/claude-code)