### PR TITLE
OG share polish + homepage first-paint fix (ADO-515, ADO-568)

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,28 +69,31 @@
     ::selection { background: #2d6a8a; color: #ffffff; }
     /* Boot skeleton: paints at HTML parse, replaced when React mounts into
        #root. Named tt-boot-* so it can never collide with the app's own
-       tt-shimmer styles. */
+       tt-shimmer styles. The header bar MIRRORS Header.tsx geometry (1440px
+       container, 14px/20px padding, 20px/700 brand) so the wordmark does not
+       jump when the real header takes over. Content bars are centered to
+       match the tally/spine layout. */
     @keyframes tt-boot-pulse { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
-    .tt-boot { max-width: 1400px; margin: 0 auto; padding: 28px 20px; }
-    .tt-boot-brand { font-weight: 900; letter-spacing: 0.04em; font-size: 22px; padding-bottom: 16px; }
-    .tt-boot-bar { border-radius: 2px; height: 16px; margin-top: 12px; background: #121214; animation: tt-boot-pulse 1.6s ease-in-out infinite; }
+    .tt-boot-hd { border-bottom: 1px solid #2a2a2d; }
+    html[data-mode="light"] .tt-boot-hd { border-bottom-color: #dfe1e6; }
+    .tt-boot-hd-in { max-width: 1440px; margin: 0 auto; padding: 14px 20px; font-weight: 700; font-size: 20px; letter-spacing: 0.02em; }
+    .tt-boot-main { max-width: 1400px; margin: 0 auto; padding: 44px 20px 0; display: flex; flex-direction: column; align-items: center; }
+    .tt-boot-bar { border-radius: 2px; height: 16px; margin-top: 14px; background: #121214; animation: tt-boot-pulse 1.6s ease-in-out infinite; }
     html[data-mode="light"] .tt-boot-bar { background: #ecedf0; }
-    .tt-boot-rule { height: 1px; margin: 20px 0 8px; background: #2a2a2d; }
-    html[data-mode="light"] .tt-boot-rule { background: #dfe1e6; }
   </style>
 </head>
 <body>
   <div id="root">
     <div class="tt-boot" role="status" aria-label="Loading TrumpyTracker">
-      <div class="tt-boot-brand">TRUMPY/TRACKER</div>
-      <div class="tt-boot-rule"></div>
-      <div class="tt-boot-bar" style="width: 58%"></div>
-      <div class="tt-boot-bar" style="width: 90%; height: 34px"></div>
-      <div class="tt-boot-bar" style="width: 78%; height: 34px"></div>
-      <div class="tt-boot-bar" style="width: 46%"></div>
-      <div class="tt-boot-rule"></div>
-      <div class="tt-boot-bar" style="width: 68%"></div>
-      <div class="tt-boot-bar" style="width: 84%"></div>
+      <div class="tt-boot-hd"><div class="tt-boot-hd-in">TRUMPY / TRACKER</div></div>
+      <div class="tt-boot-main">
+        <div class="tt-boot-bar" style="width: min(620px, 86%); height: 64px"></div>
+        <div class="tt-boot-bar" style="width: min(230px, 48%); height: 30px; margin-top: 34px"></div>
+        <div class="tt-boot-bar" style="width: min(560px, 78%); height: 12px"></div>
+        <div class="tt-boot-bar" style="width: min(640px, 90%); margin-top: 30px"></div>
+        <div class="tt-boot-bar" style="width: min(480px, 68%)"></div>
+        <div class="tt-boot-bar" style="width: min(560px, 78%)"></div>
+      </div>
     </div>
   </div>
   <script type="module" src="/src/main.tsx"></script>

--- a/index.html
+++ b/index.html
@@ -4,20 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>TrumpyTracker — accountability log</title>
-  <meta name="description" content="A daily accountability log for the Trump administration. Sourced, cited, updated." />
+  <meta name="description" content="Keeping receipts on every scandal, pardon, and power grab. Sourced, cited, updated." />
 
   <link rel="icon" type="image/jpeg" href="/trumpytracker-logo.jpeg" />
   <meta property="og:title" content="TrumpyTracker" />
-  <meta property="og:description" content="A daily accountability log. Sourced, cited, updated." />
+  <meta property="og:description" content="Keeping receipts on every scandal, pardon, and power grab." />
   <meta property="og:image" content="https://trumpytracker.com/og-default.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="TrumpyTracker — a daily accountability log" />
+  <meta property="og:image:alt" content="TrumpyTracker: keeping receipts on every scandal, pardon, and power grab" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://trumpytracker.com" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="TrumpyTracker" />
-  <meta name="twitter:description" content="A daily accountability log. Sourced, cited, updated." />
+  <meta name="twitter:description" content="Keeping receipts on every scandal, pardon, and power grab." />
   <meta name="twitter:image" content="https://trumpytracker.com/og-default.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/index.html
+++ b/index.html
@@ -22,6 +22,13 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <!-- Supabase preconnects (ADO-568): DNS+TLS setup overlaps the JS download
+       instead of delaying the first data fetch. Both envs listed statically —
+       the env pick happens in JS, too late to start the handshake, and the
+       unused connection just idles out. PROD ref here is deliberate; root
+       index.html is outside lint-prod-refs scan dirs. -->
+  <link rel="preconnect" href="https://osjbulmltfpcoldydexg.supabase.co" crossorigin />
+  <link rel="preconnect" href="https://wnrjrywpcadwutfykflu.supabase.co" crossorigin />
   <!-- Fonts load async (media swap on load): the blocking form cost ~800ms of
        blank screen on mobile before anything painted. display=swap means text
        renders in fallbacks until each face arrives. -->

--- a/index.html
+++ b/index.html
@@ -9,13 +9,16 @@
   <link rel="icon" type="image/jpeg" href="/trumpytracker-logo.jpeg" />
   <meta property="og:title" content="TrumpyTracker" />
   <meta property="og:description" content="A daily accountability log. Sourced, cited, updated." />
-  <meta property="og:image" content="/og-default.png" />
+  <meta property="og:image" content="https://trumpytracker.com/og-default.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="TrumpyTracker — a daily accountability log" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://trumpytracker.com" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="TrumpyTracker" />
   <meta name="twitter:description" content="A daily accountability log. Sourced, cited, updated." />
-  <meta name="twitter:image" content="/og-default.png" />
+  <meta name="twitter:image" content="https://trumpytracker.com/og-default.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -22,13 +22,26 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <!-- Fonts load async (media swap on load): the blocking form cost ~800ms of
+       blank screen on mobile before anything painted. display=swap means text
+       renders in fallbacks until each face arrives. -->
   <link
     href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&family=JetBrains+Mono:wght@400;500;600;700&family=Archivo+Black&family=Archivo:wght@400;500;600;700;800&display=swap"
     rel="stylesheet"
+    media="print"
+    onload="this.media='all'"
   />
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&family=JetBrains+Mono:wght@400;500;600;700&family=Archivo+Black&family=Archivo:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+  </noscript>
 
-  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD. -->
-  <script src="/analytics-gate.js"></script>
+  <!-- Analytics: hostname-gated loader (ADO-558). Injects GA4 only on PROD.
+       Deferred: it only defines window.gtag/TTAnalytics stubs consumed after
+       mount, and deferred classic scripts still run before the module bundle. -->
+  <script src="/analytics-gate.js" defer></script>
 
   <!-- FOUC prevention: set mode before any CSS/React loads -->
   <script>
@@ -47,10 +60,32 @@
     html, body { margin: 0; padding: 0; }
     body { font-family: 'Inter Tight', system-ui, sans-serif; -webkit-font-smoothing: antialiased; }
     ::selection { background: #2d6a8a; color: #ffffff; }
+    /* Boot skeleton: paints at HTML parse, replaced when React mounts into
+       #root. Named tt-boot-* so it can never collide with the app's own
+       tt-shimmer styles. */
+    @keyframes tt-boot-pulse { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+    .tt-boot { max-width: 1400px; margin: 0 auto; padding: 28px 20px; }
+    .tt-boot-brand { font-weight: 900; letter-spacing: 0.04em; font-size: 22px; padding-bottom: 16px; }
+    .tt-boot-bar { border-radius: 2px; height: 16px; margin-top: 12px; background: #121214; animation: tt-boot-pulse 1.6s ease-in-out infinite; }
+    html[data-mode="light"] .tt-boot-bar { background: #ecedf0; }
+    .tt-boot-rule { height: 1px; margin: 20px 0 8px; background: #2a2a2d; }
+    html[data-mode="light"] .tt-boot-rule { background: #dfe1e6; }
   </style>
 </head>
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <div class="tt-boot" role="status" aria-label="Loading TrumpyTracker">
+      <div class="tt-boot-brand">TRUMPY/TRACKER</div>
+      <div class="tt-boot-rule"></div>
+      <div class="tt-boot-bar" style="width: 58%"></div>
+      <div class="tt-boot-bar" style="width: 90%; height: 34px"></div>
+      <div class="tt-boot-bar" style="width: 78%; height: 34px"></div>
+      <div class="tt-boot-bar" style="width: 46%"></div>
+      <div class="tt-boot-rule"></div>
+      <div class="tt-boot-bar" style="width: 68%"></div>
+      <div class="tt-boot-bar" style="width: 84%"></div>
+    </div>
+  </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Home } from '@/pages/Home';
 import { TrackerHome } from '@/pages/TrackerHome';
 import { useFeatureFlag, useFlagsReady } from '@/hooks/useFeatureFlag';
 import { LoadingSkeleton } from '@/edge-states/LoadingSkeleton';
+import { BootSkeleton } from '@/edge-states/BootSkeleton';
 import { fetchList, fetchStoryDetail, fetchEoDetail, fetchScotusDetail, fetchPardonDetail } from '@/lib/api';
 import { getFilterConfig } from '@/lib/filters';
 import { useFilters } from '@/hooks/useFilters';
@@ -78,7 +79,9 @@ function HomeRoute({ onOpenItem }: { onOpenItem: (id: string | number) => void }
   const ready = useFlagsReady();
   const trackerHome = useFeatureFlag('rap_sheet');
 
-  if (!ready) return <LoadingSkeleton />;
+  // BootSkeleton, not LoadingSkeleton: it is pixel-identical to the static
+  // skeleton in index.html, so the flag wait doesn't flash a different layout.
+  if (!ready) return <BootSkeleton />;
   if (trackerHome) return <TrackerHome />;
   return <TypePage tabType="stories" onOpenItem={onOpenItem} />;
 }

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -105,8 +105,15 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     setLoadingMore(false);
     setRefreshing(true);
     (async () => {
+      // Pins and source pages fetch CONCURRENTLY (the pins promise is only
+      // awaited inside fetchTrackerPage after every page response arrives) —
+      // serializing them added a full round-trip to first paint (ADO-568).
       const pins = view === 'main'
-        ? (pinsRef.current ??= await fetchTrackerPins(ac.signal))
+        ? (pinsRef.current
+            ? Promise.resolve(pinsRef.current)
+            : fetchTrackerPins(ac.signal)
+                .then(p => (pinsRef.current = p))
+                .catch(() => undefined))
         : undefined;
       const { entries: page, state } = await fetchTrackerPage(view, null, ac.signal, pins);
       if (ac.signal.aborted) return;

--- a/src/edge-states/BootSkeleton.tsx
+++ b/src/edge-states/BootSkeleton.tsx
@@ -1,0 +1,21 @@
+// React copy of the static boot skeleton in index.html — SAME markup, SAME
+// tt-boot-* classes (their styles live in index.html's inline <style>, which
+// stays in <head> for the page's lifetime). HomeRoute renders this while the
+// flag file resolves so the handoff static skeleton → React → TrackerHome is
+// pixel-identical; rendering anything else here flashes a mismatched layout
+// (ADO-568). If you change one copy, change the other.
+export function BootSkeleton() {
+  return (
+    <div className="tt-boot" role="status" aria-label="Loading TrumpyTracker">
+      <div className="tt-boot-hd"><div className="tt-boot-hd-in">TRUMPY / TRACKER</div></div>
+      <div className="tt-boot-main">
+        <div className="tt-boot-bar" style={{ width: 'min(620px, 86%)', height: 64 }} />
+        <div className="tt-boot-bar" style={{ width: 'min(230px, 48%)', height: 30, marginTop: 34 }} />
+        <div className="tt-boot-bar" style={{ width: 'min(560px, 78%)', height: 12 }} />
+        <div className="tt-boot-bar" style={{ width: 'min(640px, 90%)', marginTop: 30 }} />
+        <div className="tt-boot-bar" style={{ width: 'min(480px, 68%)' }} />
+        <div className="tt-boot-bar" style={{ width: 'min(560px, 78%)' }} />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -39,6 +39,15 @@ async function loadFlags(): Promise<Record<string, boolean>> {
 }
 
 /**
+ * Start the flag-file fetch immediately (called from main.tsx before React
+ * mounts). The homepage cannot route until flags resolve, so waiting for the
+ * first hook effect put a whole network round-trip after mount for nothing.
+ */
+export function prefetchFlags(): void {
+  void loadFlags();
+}
+
+/**
  * True once the flag file has loaded (or failed and defaulted). Lets routing
  * decisions wait instead of flashing the flag-off surface for a frame.
  */

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -324,7 +324,9 @@ export async function fetchTrackerPage(
   view: TrackerView,
   state: TrackerState | null,
   signal?: AbortSignal,
-  pins?: TrackerPins,
+  // May be a promise so callers can fetch pins CONCURRENTLY with the source
+  // pages (pins are only consumed after every page response has arrived).
+  pins?: TrackerPins | Promise<TrackerPins | undefined>,
 ): Promise<{ entries: TimelineEntry[]; state: TrackerState }> {
   // Lazy import: lib/supabase reads window.location at module load, which would
   // break node-env unit tests that import this module's pure functions.
@@ -358,11 +360,7 @@ export async function fetchTrackerPage(
           exhausted: rows.length < spec.limit,
           errored: false,
         };
-        let entries = rows.map(spec.adapter);
-        if (isMain && source !== 'stories' && pins?.size) {
-          entries = entries.filter(e => pins.get(pinKey(source, e.id)) !== 'force_hide');
-        }
-        return entries;
+        return rows.map(spec.adapter);
       } catch (err) {
         if ((err as Error).name === 'AbortError') throw err;
         // One source failing must not blank the whole Tracker
@@ -372,12 +370,22 @@ export async function fetchTrackerPage(
     }),
   );
 
+  // Pins are applied only now that every source page has arrived, so a
+  // promise-valued `pins` never delays the fetches themselves.
+  const resolvedPins = await pins;
+  if (isMain && resolvedPins?.size) {
+    TIMELINE_SOURCES.forEach((source, i) => {
+      if (source === 'stories') return;
+      groups[i] = groups[i].filter(e => resolvedPins.get(pinKey(source, e.id)) !== 'force_hide');
+    });
+  }
+
   // First page of the main line: surface force_show pins on non-stories
   // sources. Only rows below the alarm-5 stream are merged — anything at 5
   // arrives (or already arrived) through normal paging, so injecting it again
   // would duplicate the entry.
-  if (isMain && state === null && pins?.size) {
-    const bySource = forceShowIdsBySource(pins);
+  if (isMain && state === null && resolvedPins?.size) {
+    const bySource = forceShowIdsBySource(resolvedPins);
     const injected = await Promise.all(
       (Object.keys(bySource) as TimelineSource[]).map(async source => {
         const spec = SPECS[source];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,11 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { prefetchFlags } from './hooks/useFeatureFlag';
 import './styles/base.css';
+
+// Homepage routing blocks on the flag file — start that fetch now, in
+// parallel with React startup, instead of after the first mount effect.
+prefetchFlags();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,32 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import netlifyPlugin from '@netlify/vite-plugin';
 import { resolve } from 'path';
 
+// The app's entire stylesheet is ~1.3KB; as a <link> it is one extra
+// render-blocking round trip that delays first paint of the boot skeleton
+// (ADO-568). Inline it into index.html and drop the link.
+function inlineCss(): Plugin {
+  return {
+    name: 'tt-inline-css',
+    apply: 'build',
+    enforce: 'post',
+    transformIndexHtml(html, ctx) {
+      if (!ctx.bundle) return html;
+      for (const [name, asset] of Object.entries(ctx.bundle)) {
+        if (!name.endsWith('.css') || asset.type !== 'asset') continue;
+        const link = new RegExp(`<link[^>]+href="[^"]*${asset.fileName.split('/').pop()}"[^>]*>`);
+        if (!link.test(html)) continue;
+        html = html.replace(link, `<style>${asset.source}</style>`);
+        delete ctx.bundle[name];
+      }
+      return html;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), netlifyPlugin()],
+  plugins: [react(), netlifyPlugin(), inlineCss()],
   publicDir: 'public',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
Two tested-on-TEST changes, frontend-only (no migrations, edge functions, workflows, or secrets):

**OG / share metadata (ADO-515 follow-up)**
- Absolute og:image URLs (FB spec requires absolute; homepage was relative)
- og:image:width/height/alt so Facebook's first-ever scrape renders with the image
- New tagline in share + search descriptions: "Keeping receipts on every scandal, pardon, and power grab."

**Homepage first paint (ADO-568)** — Lighthouse mobile was 48, FCP 3.3s blank, LCP 7.0s:
- Static boot skeleton + wordmark inline in index.html (paints before any JS; mirrors Header geometry so nothing jumps; flag-wait renders the identical BootSkeleton)
- Google Fonts load async; analytics-gate.js deferred; 1.3KB app CSS inlined at build (was a render-blocking link)
- prefetchFlags() at bundle start; tracker pins fetch concurrent with source pages (fetchTrackerPage accepts a pins promise, applied after pages arrive)

## Testing
- Lighthouse mobile on TEST after: FCP 0.9s (was 3.4s), Speed Index 0.9s (was 3.4s), render-blocking audit clean
- vitest 174/174, qa:smoke passes
- Josh live-verified TEST: loading artifact gone, homepage renders correctly
- FB Sharing Debugger fresh scrape renders headline + description + image

🤖 Generated with [Claude Code](https://claude.com/claude-code)