### PR TITLE
chore(flags): share_cards ON in PROD (ADO-571)

### DIFF
--- a/public/shared/flags-prod.json
+++ b/public/shared/flags-prod.json
@@ -7,5 +7,5 @@
   "executive_orders": true,
   "tone_v2": false,
   "rap_sheet": true,
-  "share_cards": false
+  "share_cards": true
 }


### PR DESCRIPTION
Flips `share_cards` to true in `flags-prod.json`. Renderer verified on PROD in PR #135 (flag-off default, `?ff_share_cards=true` override, card endpoint). Josh wants to start sharing to Facebook with cards now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P66geg1HRwB2597xV5UxMu