### PR TITLE
perf(tracker): precompute main line + tally, spine UX fixes (ADO-570)

### DIFF
--- a/.github/workflows/executive-orders-tracker.yml
+++ b/.github/workflows/executive-orders-tracker.yml
@@ -69,6 +69,15 @@ jobs:
         EO_LOOKBACK_DAYS: ${{ inputs.lookback_days || '3' }}
       run: node scripts/executive-orders-tracker-supabase.js
 
+    # ADO-570: new EOs count toward the homepage tally only after this refresh.
+    - name: Refresh Tracker main line + tally
+      if: always()
+      env:
+        SUPABASE_URL: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_URL || secrets.SUPABASE_URL }}
+        SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env_detect.outputs.environment == 'test' && secrets.SUPABASE_TEST_SERVICE_KEY || secrets.SUPABASE_SERVICE_KEY }}
+      run: node scripts/maintenance/refresh-tracker.js
+      timeout-minutes: 2
+
     - name: Commit any changes (minimal, since data is in Supabase)
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/pardons-tracker.yml
+++ b/.github/workflows/pardons-tracker.yml
@@ -47,6 +47,13 @@ jobs:
           set -euo pipefail
           node scripts/ingest/doj-pardons-scraper.js 2>&1 | tee logs/01-ingest.log
 
+      # ADO-570: new pardons count toward the homepage tally only after this refresh.
+      # Uses the job-level SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY env (prod|test by branch).
+      - name: Refresh Tracker main line + tally
+        if: always()
+        run: node scripts/maintenance/refresh-tracker.js
+        timeout-minutes: 2
+
       - name: Upload logs on failure
         if: failure() || cancelled()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rss-tracker-prod.yml
+++ b/.github/workflows/rss-tracker-prod.yml
@@ -41,6 +41,16 @@ jobs:
         run: node scripts/rss-tracker-supabase.js
         timeout-minutes: 5
 
+      # ADO-570: the homepage reads precomputed main_line + tally; refresh after
+      # every run (always(): a partial run still changed data). Never fails.
+      - name: Refresh Tracker main line + tally
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: node scripts/maintenance/refresh-tracker.js
+        timeout-minutes: 2
+
       - name: Upload run logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rss-tracker-test.yml
+++ b/.github/workflows/rss-tracker-test.yml
@@ -40,6 +40,16 @@ jobs:
         run: node scripts/rss-tracker-supabase.js
         timeout-minutes: 5
 
+      # ADO-570: the homepage reads precomputed main_line + tally; refresh after
+      # every run (always(): a partial run still changed data). Never fails.
+      - name: Refresh Tracker main line + tally
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_TEST_SERVICE_KEY }}
+        run: node scripts/maintenance/refresh-tracker.js
+        timeout-minutes: 2
+
       - name: Upload run logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scotus-tracker.yml
+++ b/.github/workflows/scotus-tracker.yml
@@ -62,6 +62,15 @@ jobs:
           set -euo pipefail
           node scripts/scotus/fetch-cases.js --resume 2>&1 | tee logs/fetch.log
 
+      # ADO-570: new rulings count toward the homepage tally only after this refresh.
+      - name: Refresh Tracker main line + tally
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: node scripts/maintenance/refresh-tracker.js
+        timeout-minutes: 2
+
       - name: Upload logs on failure/cancel
         if: failure() || cancelled()
         uses: actions/upload-artifact@v4

--- a/migrations/113_tracker_precompute.sql
+++ b/migrations/113_tracker_precompute.sql
@@ -1,0 +1,300 @@
+-- ============================================================================
+-- Migration 113: Precompute the Tracker main line + tally (ADO-570)
+-- ============================================================================
+-- WHY: the homepage computed "is this story on the main line?" for every
+-- active story on every page load (window function + lateral join inside
+-- v_tracker_stories, migration 112), three times per visit (spine page + two
+-- tally counts). Postgres cannot index a CASE inside a view, so each request
+-- was a full scan of ~14K rows: 2.2s cold / 0.2s warm on PROD's nano instance,
+-- whose buffer cache evicts on its own between pipeline runs. Measured
+-- August 29, 2026; plan: docs/features/events-tracker/plan-tracker-precompute.md
+--
+-- DESIGN: one rule, one place, one refresh.
+--   A) stories.main_line       stored flag + partial index (INCLUDE columns so
+--                              the 60-row spine page is an index-only scan)
+--   B) tracker_stats           one-row table the masthead tally reads
+--   C) v_tracker_main_line_rule the ONLY place rule v1.1 exists (moved verbatim
+--                              from the 112 view). service_role-only.
+--   D) refresh_tracker_derived() applies C to A and recomputes B. A dumb
+--                              applier — no rule logic of its own. Called as the
+--                              last step of every pipeline workflow and after
+--                              admin front/pin edits (scripts/maintenance/refresh-tracker.js).
+--   E) v_tracker_stories       same name, reads the stored column, plain front
+--                              join, no window function. Frontend spine unchanged.
+--
+-- RLS: the refresh runs as SECURITY DEFINER and therefore BYPASSES the
+-- migration-111 publish gates that anon reads inherit through security_invoker
+-- views. The rule view filters events.publish_state = 'published' explicitly
+-- so members of a draft front stay loose ends — exactly what anon saw before.
+-- Never rely on RLS inside the rule view.
+--
+-- Apply manually via the Supabase SQL Editor (NOT apply-migrations.js).
+-- Idempotent: safe to re-run. First run rewrites main_line for every row.
+-- PROD ORDER: apply between pipeline runs, then IMMEDIATELY run
+--   SELECT * FROM public.refresh_tracker_derived();
+--   ANALYZE public.stories;   -- new column has no stats until this
+-- (the column defaults false — until the refresh runs the spine is empty),
+-- THEN cherry-pick the code. The old frontend keeps working throughout.
+-- DEPENDENCIES: migrations 111 (events/story_event), 112 (tracker_pin).
+-- ROLLBACK: re-run the migration-112 v_tracker_stories block (it recreates the
+-- computed CASE); the column, stats table and function can stay.
+-- ============================================================================
+
+-- ============================================================================
+-- PART A: stored flag + index
+-- ============================================================================
+
+ALTER TABLE public.stories
+  ADD COLUMN IF NOT EXISTS main_line BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.stories.main_line IS
+  'ADO-570: precomputed Tracker main-line flag. Written ONLY by refresh_tracker_derived() from v_tracker_main_line_rule — never by hand, never by the pipeline directly. Stale until the next refresh (end of every pipeline run).';
+
+-- INCLUDE makes the spine page an index-only scan: the 60 newest main-line
+-- rows come straight from the index with zero heap reads, cold or warm.
+-- Predicate mirrors v_tracker_stories' WHERE so the planner can use it.
+-- `main_line IS TRUE` (not bare `main_line`) on purpose: PostgREST's
+-- `main_line=is.true` emits `IS TRUE`, and the planner would NOT prove that
+-- against a bare-boolean partial predicate (verified on TEST with
+-- enable_seqscan=off: the index was never chosen). Any hand-written query
+-- must use `main_line IS TRUE` too.
+DROP INDEX IF EXISTS public.idx_stories_tracker_main_line;  -- converge older predicate forms
+CREATE INDEX IF NOT EXISTS idx_stories_tracker_main_line
+  ON public.stories (first_seen_at DESC, id DESC)
+  INCLUDE (primary_headline, alarm_level, severity)
+  WHERE main_line IS TRUE AND status = 'active' AND summary_neutral IS NOT NULL;
+
+-- ============================================================================
+-- PART B: tracker_stats — the masthead tally, one row
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tracker_stats (
+  id             SMALLINT PRIMARY KEY CONSTRAINT tracker_stats_single_row CHECK (id = 1),
+  developments   INTEGER,          -- published developments across all four sources since TERM_START
+  alarm5_last30  INTEGER,          -- alarm-5 developments in the 30 days before refreshed_at
+  open_fronts    INTEGER,          -- published fronts not resolved
+  refreshed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.tracker_stats IS
+  'ADO-570: one-row masthead tally for The Tracker, recomputed by refresh_tracker_derived(). Replaces 9 HEAD count=exact requests per page load. Predicates mirror SPECS in src/lib/timeline.ts (see the function body).';
+
+ALTER TABLE public.tracker_stats ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "tracker_stats_anon_select" ON public.tracker_stats;
+CREATE POLICY "tracker_stats_anon_select" ON public.tracker_stats
+  FOR SELECT TO anon
+  USING (true);
+
+-- Migration 046 auto-revokes anon on new tables — explicit grant required.
+GRANT SELECT ON public.tracker_stats TO anon;
+GRANT ALL ON public.tracker_stats TO service_role;
+
+-- ============================================================================
+-- PART C: v_tracker_main_line_rule — rule v1.1, the single source of truth
+-- ============================================================================
+-- Moved verbatim from migration 112's v_tracker_stories:
+--   pin override            → force_show in, force_hide out
+--   no published front      → effective alarm 5 (loose end)
+--   front member            → front opening (earliest member) OR alarm 5
+--                             OR alarm >= 4 setting a new front peak
+-- Runs as the view owner (NOT security_invoker) because the refresh function
+-- reads it as service_role; hence the EXPLICIT publish gate on events.
+
+DROP VIEW IF EXISTS public.v_tracker_main_line_rule;
+CREATE VIEW public.v_tracker_main_line_rule AS
+WITH front_members AS (
+  SELECT
+    se.story_id,
+    ROW_NUMBER() OVER w AS member_seq,
+    MAX(
+      COALESCE(
+        s.alarm_level,
+        CASE s.severity
+          WHEN 'critical' THEN 5
+          WHEN 'severe'   THEN 4
+          WHEN 'moderate' THEN 3
+          WHEN 'minor'    THEN 2
+        END,
+        2
+      )
+    ) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS front_prior_peak
+  FROM public.story_event se
+  JOIN public.events  e ON e.id = se.event_id
+                       AND e.publish_state = 'published'   -- explicit: NOT inherited from RLS
+  JOIN public.stories s ON s.id = se.story_id
+                       AND s.status = 'active'
+                       AND s.summary_neutral IS NOT NULL
+  WINDOW w AS (PARTITION BY se.event_id ORDER BY s.first_seen_at, s.id)
+)
+SELECT
+  s.id,
+  CASE
+    WHEN p.pin = 'force_show' THEN TRUE
+    WHEN p.pin = 'force_hide' THEN FALSE
+    WHEN fm.story_id IS NULL THEN a.alarm_eff >= 5
+    ELSE fm.member_seq = 1
+      OR a.alarm_eff = 5
+      OR (a.alarm_eff >= 4 AND a.alarm_eff > COALESCE(fm.front_prior_peak, 0))
+  END AS main_line
+FROM public.stories s
+CROSS JOIN LATERAL (
+  SELECT COALESCE(
+    s.alarm_level,
+    CASE s.severity
+      WHEN 'critical' THEN 5
+      WHEN 'severe'   THEN 4
+      WHEN 'moderate' THEN 3
+      WHEN 'minor'    THEN 2
+    END,
+    2
+  )::smallint AS alarm_eff
+) a
+LEFT JOIN front_members fm ON fm.story_id = s.id
+LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::text
+WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
+
+COMMENT ON VIEW public.v_tracker_main_line_rule IS
+  'ADO-570: THE definition of the Tracker main-line rule (v1.1, PRD section 12). Edit the rule here and only here; refresh_tracker_derived() applies it to stories.main_line. Not public — anon reads the stored column through v_tracker_stories.';
+
+REVOKE ALL ON public.v_tracker_main_line_rule FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public.v_tracker_main_line_rule TO service_role;
+
+-- ============================================================================
+-- PART D: refresh_tracker_derived() — apply the rule, recompute the tally
+-- ============================================================================
+-- Stats predicates MIRROR SPECS in src/lib/timeline.ts (base + alarm(5)):
+--   stories : status active, enriched, first_seen_at >= term; alarm 5 =
+--             alarm_level >= 5 OR (alarm_level IS NULL AND severity = 'critical')
+--   scotus  : is_public, decided_at not null, >= term; alarm 5 = ruling_impact_level >= 5
+--   eos     : is_public, date >= term;                 alarm 5 = alarm_level >= 5
+--   pardons : is_public, pardon_date >= term;          alarm 5 = corruption_level >= 5
+--   fronts  : events published AND lifecycle <> 'resolved'
+-- If SPECS changes, change this function in the same commit.
+
+CREATE OR REPLACE FUNCTION public.refresh_tracker_derived()
+RETURNS TABLE (rows_changed INTEGER, took_ms INTEGER)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  -- v_ prefix: plain names collided with table columns (42702 on first TEST apply)
+  t0        TIMESTAMPTZ := clock_timestamp();
+  v_term      DATE := DATE '2025-01-20';                 -- TERM_START in src/lib/timeline.ts
+  v_since     DATE := (NOW() - INTERVAL '30 days')::date;
+  n_apply   INTEGER;
+  n_drop    INTEGER;
+BEGIN
+  -- 1. Apply the rule. Only rows whose flag actually changes are written,
+  --    so steady-state runs touch a handful of rows (no bloat).
+  UPDATE public.stories s
+     SET main_line = r.main_line
+    FROM public.v_tracker_main_line_rule r
+   WHERE r.id = s.id
+     AND s.main_line IS DISTINCT FROM r.main_line;
+  GET DIAGNOSTICS n_apply = ROW_COUNT;
+
+  -- 2. Rows that left the rule's scope (closed, merged, unenriched) drop off.
+  UPDATE public.stories s
+     SET main_line = false
+   WHERE s.main_line
+     AND NOT (s.status = 'active' AND s.summary_neutral IS NOT NULL);
+  GET DIAGNOSTICS n_drop = ROW_COUNT;
+
+  -- 3. Tally.
+  INSERT INTO public.tracker_stats (id, developments, alarm5_last30, open_fronts, refreshed_at)
+  SELECT
+    1,
+    (SELECT COUNT(*) FROM public.stories
+      WHERE status = 'active' AND summary_neutral IS NOT NULL AND first_seen_at >= v_term)
+    + (SELECT COUNT(*) FROM public.scotus_cases
+        WHERE is_public = true AND decided_at IS NOT NULL AND decided_at >= v_term)
+    + (SELECT COUNT(*) FROM public.executive_orders
+        WHERE is_public = true AND date >= v_term)
+    + (SELECT COUNT(*) FROM public.pardons
+        WHERE is_public = true AND pardon_date >= v_term),
+    (SELECT COUNT(*) FROM public.stories
+      WHERE status = 'active' AND summary_neutral IS NOT NULL AND first_seen_at >= v_term
+        AND first_seen_at >= v_since
+        AND (alarm_level >= 5 OR (alarm_level IS NULL AND severity = 'critical')))
+    + (SELECT COUNT(*) FROM public.scotus_cases
+        WHERE is_public = true AND decided_at IS NOT NULL AND decided_at >= v_term
+          AND decided_at >= v_since AND ruling_impact_level >= 5)
+    + (SELECT COUNT(*) FROM public.executive_orders
+        WHERE is_public = true AND date >= v_term
+          AND date >= v_since AND alarm_level >= 5)
+    + (SELECT COUNT(*) FROM public.pardons
+        WHERE is_public = true AND pardon_date >= v_term
+          AND pardon_date >= v_since AND corruption_level >= 5),
+    (SELECT COUNT(*) FROM public.events
+      WHERE publish_state = 'published' AND lifecycle <> 'resolved'),
+    NOW()
+  ON CONFLICT (id) DO UPDATE
+    SET developments  = EXCLUDED.developments,
+        alarm5_last30 = EXCLUDED.alarm5_last30,
+        open_fronts   = EXCLUDED.open_fronts,
+        refreshed_at  = EXCLUDED.refreshed_at;
+
+  rows_changed := n_apply + n_drop;
+  took_ms      := (EXTRACT(EPOCH FROM (clock_timestamp() - t0)) * 1000)::integer;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.refresh_tracker_derived() IS
+  'ADO-570: applies v_tracker_main_line_rule to stories.main_line (changed rows only) and recomputes tracker_stats. Call after every pipeline run and after admin front/pin edits: scripts/maintenance/refresh-tracker.js. service_role only.';
+
+REVOKE ALL ON FUNCTION public.refresh_tracker_derived() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_tracker_derived() TO service_role;
+
+-- ============================================================================
+-- PART E: v_tracker_stories — same name, reads the stored flag
+-- ============================================================================
+-- DROP + CREATE (not OR REPLACE): the 112 view exposed front_opening and
+-- alarm_eff, which only the window function could compute; nothing reads them
+-- (frontend selects id,primary_headline,first_seen_at,alarm_level,severity,
+-- front_name,front_slug). Grants are re-issued below because DROP loses them.
+
+DROP VIEW IF EXISTS public.v_tracker_stories;
+CREATE VIEW public.v_tracker_stories
+WITH (security_invoker = true) AS
+SELECT
+  s.id,
+  s.primary_headline,
+  s.first_seen_at,
+  s.alarm_level,
+  s.severity,
+  e.id    AS front_id,
+  e.name  AS front_name,
+  e.slug  AS front_slug,
+  p.pin   AS tracker_pin,
+  s.main_line
+FROM public.stories s
+LEFT JOIN public.story_event se ON se.story_id = s.id
+LEFT JOIN public.events e ON e.id = se.event_id
+                         AND e.publish_state = 'published'
+LEFT JOIN public.tracker_pin p ON p.source = 'stories' AND p.entity_id = s.id::text
+WHERE s.status = 'active' AND s.summary_neutral IS NOT NULL;
+
+COMMENT ON VIEW public.v_tracker_stories IS
+  'ADO-570: the Tracker spine''s stories read path. main_line is the STORED flag (refresh_tracker_derived), so main_line=is.true hits idx_stories_tracker_main_line as an index-only scan. Rule lives in v_tracker_main_line_rule. Tight columns on purpose — never widen to content/embedding (egress rule).';
+
+GRANT SELECT ON public.v_tracker_stories TO anon;
+GRANT SELECT ON public.v_tracker_stories TO service_role;
+
+-- ============================================================================
+-- Verification (run after applying; see plan section 5)
+-- ============================================================================
+-- SELECT * FROM public.refresh_tracker_derived();
+--   -- first run on PROD: rows_changed ~1400, took_ms < 5000
+-- SELECT count(*) FROM public.stories WHERE main_line;
+-- SELECT * FROM public.tracker_stats;
+-- EXPLAIN (ANALYZE, BUFFERS)
+--   SELECT id, primary_headline, first_seen_at, alarm_level, severity, front_name, front_slug
+--     FROM public.v_tracker_stories
+--    WHERE main_line IS TRUE AND first_seen_at >= '2025-01-20'
+--    ORDER BY first_seen_at DESC, id DESC LIMIT 60;
+--   -- expect: Index Only Scan using idx_stories_tracker_main_line, no Sort node,
+--   --         rows=60. Heap Fetches drops to ~0 once autovacuum sets the visibility
+--   --         map (or run VACUUM public.stories after the first refresh).

--- a/scripts/lib/skip-reasons.js
+++ b/scripts/lib/skip-reasons.js
@@ -31,6 +31,7 @@ export const PIPELINES = Object.freeze({
   PARDONS_INGEST:     'pardons_ingest',     // scripts/ingest/doj-pardons-scraper.js — staleness tripwire, header parse drift
   FRONT_ASSIGNMENT:   'front_assignment',   // fronts assignment agent (ADO-546/Wave 2) — declined to assign a story to a front
   FRONT_UPDATE_DRAFT: 'front_update_draft', // fronts update drafter (ADO-546/Wave 2) — declined to draft an update
+  TRACKER_REFRESH:    'tracker_refresh',    // scripts/maintenance/refresh-tracker.js — main_line/tally refresh failed (ADO-570)
 });
 
 export const REASONS = Object.freeze({
@@ -43,6 +44,7 @@ export const REASONS = Object.freeze({
   PARSE_ERROR:           'parse_error',           // JSON/response parse failed
   API_ERROR:             'api_error',             // external API call errored
   STALENESS_TRIPWIRE:    'staleness_tripwire',    // source has newer data than DB but run inserted nothing
+  REFRESH_FAILED:        'refresh_failed',        // refresh_tracker_derived() RPC errored; previous flags left in place (ADO-570)
 });
 
 /**

--- a/scripts/maintenance/refresh-tracker.js
+++ b/scripts/maintenance/refresh-tracker.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Refresh the Tracker's precomputed data (ADO-570).
+ *
+ * Calls public.refresh_tracker_derived() (migration 113), which applies the
+ * main-line rule to stories.main_line and recomputes tracker_stats. The
+ * homepage reads only those precomputed values, so anything that changes
+ * stories / fronts / pins / EOs / SCOTUS / pardons must be followed by this.
+ *
+ * Call sites — ONE function, every pipeline:
+ *   - last step of rss-tracker-{prod,test}.yml, scotus-tracker.yml,
+ *     pardons-tracker.yml, executive-orders-tracker.yml (if: always())
+ *   - after admin front/pin edits (ADO-547 editor; the fronts seed SQL calls
+ *     the function directly)
+ *
+ * NEVER fails the caller: a refresh error leaves the previous flags in place
+ * (stale-but-present beats missing) and writes a pipeline_skips row so it is
+ * visible in the admin Skips tab. Exit code is always 0.
+ *
+ * Env: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (or the SUPABASE_TEST_* names
+ * the SCOTUS workflow uses). Service role is required — anon cannot execute it.
+ *
+ * Usage: node scripts/maintenance/refresh-tracker.js
+ */
+
+import 'dotenv/config';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { recordSkip, PIPELINES, REASONS } from '../lib/skip-reasons.js';
+
+export async function refreshTracker(supabase) {
+  const { data, error } = await supabase.rpc('refresh_tracker_derived');
+  if (error) throw new Error(error.message);
+  const row = Array.isArray(data) ? data[0] : data;
+  return { rows_changed: row?.rows_changed ?? null, took_ms: row?.took_ms ?? null };
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.SUPABASE_TEST_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_TEST_SERVICE_KEY;
+  if (!url || !key) {
+    console.error('refresh-tracker: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — skipping');
+    return;
+  }
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+  try {
+    const r = await refreshTracker(supabase);
+    console.log(`refresh_tracker_derived rows_changed=${r.rows_changed} took_ms=${r.took_ms}`);
+  } catch (err) {
+    console.error(`refresh-tracker: FAILED (previous flags remain): ${err.message}`);
+    await recordSkip(supabase, {
+      pipeline: PIPELINES.TRACKER_REFRESH,
+      reason: REASONS.REFRESH_FAILED,
+      entity_type: 'tracker',
+      entity_id: null,
+      metadata: { error: String(err.message).slice(0, 500) },
+    });
+  }
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(`refresh-tracker: unexpected error: ${err.message}`);
+  });
+}

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -8,6 +8,7 @@ import {
   buildSourcePath,
   initialTrackerState,
   fetchTrackerPage,
+  fetchTrackerTally,
   fetchTrackerPins,
   forceShowIdsBySource,
   pinKey,
@@ -485,5 +486,45 @@ describe('tracker pins (ADO-554)', () => {
     calls = [];
     await fetchTrackerPage('main', state, undefined, pins);
     expect(calls.some(c => c.includes('id=in.'))).toBe(false);
+  });
+});
+
+describe('fetchTrackerTally (ADO-570: one GET on tracker_stats)', () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+    vi.stubGlobal('window', { location: { hostname: 'localhost', search: '' } });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  it('reads the precomputed row with a single request', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string) => {
+      calls.push(input);
+      return { ok: true, json: async () => [{ developments: 1234, alarm5_last30: 7, open_fronts: 8 }] };
+    }));
+    const t = await fetchTrackerTally();
+    expect(t).toEqual({ developments: 1234, alarm5Last30: 7, openFronts: 8 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('/rest/v1/tracker_stats?');
+    expect(calls[0]).not.toContain('v_tracker_stories');
+  });
+
+  it('yields nulls (tiles hidden, no crash) when the row is missing or the request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => [] })));
+    expect(await fetchTrackerTally()).toEqual({ developments: null, alarm5Last30: null, openFronts: null });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => [] })));
+    expect(await fetchTrackerTally()).toEqual({ developments: null, alarm5Last30: null, openFronts: null });
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    expect(await fetchTrackerTally()).toEqual({ developments: null, alarm5Last30: null, openFronts: null });
+  });
+
+  it('rethrows AbortError so navigation cancels cleanly', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; }));
+    await expect(fetchTrackerTally()).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -213,9 +213,12 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
   if (tally?.openFronts != null && tally.openFronts > 0) {
     tallyTiles.push({ n: String(tally.openFronts), label: 'Open fronts' });
   }
-  if (tally?.developments != null) {
-    tallyTiles.push({ n: tally.developments.toLocaleString('en-US'), label: 'Developments logged' });
-  }
+  // "Developments logged" hidden for now (Josh, August 31, 2026) — may return
+  // later to show the breadth of the tracked record. tracker_stats still
+  // computes it; re-enable by uncommenting.
+  // if (tally?.developments != null) {
+  //   tallyTiles.push({ n: tally.developments.toLocaleString('en-US'), label: 'Developments logged' });
+  // }
   if (tally?.alarm5Last30 != null) {
     tallyTiles.push({ n: String(tally.alarm5Last30), label: 'At alarm 5 · last 30 days', bad: true });
   }
@@ -286,7 +289,7 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
           textAlign: narrow ? 'left' : 'center',
         }}>
           <span style={{
-            ...mono, fontSize: 11, fontWeight: 600, letterSpacing: '0.14em', color: theme.ink,
+            ...mono, fontSize: 12, fontWeight: 600, letterSpacing: '0.14em', color: theme.ink,
             background: theme.bg2, border: `1px solid ${theme.dim}`, padding: '5px 14px',
           }}>
             {monthLabel(ym)}
@@ -381,16 +384,11 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
             }}>
               {e.front.name}
             </span>
-          ) : e.source === 'stories' ? (
-            // Only stories carry a loose-end tag; the other sources' type now
-            // sits in the date line, so a second source tag here was redundant
-            <span style={{
-              ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
-              border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
-            }}>
-              Loose end
-            </span>
           ) : null}
+          {/* Stories with no front get NO tag: the public "Loose end" label
+              confused readers (Josh, August 31, 2026) — "loose end" stays
+              admin/PRD vocabulary only. The real fix for mis-tagged rows is
+              front assignment, not a label. */}
         </div>
       </div>,
     );

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -14,6 +14,7 @@ import {
   visibleEntries,
   mergeEntries,
   SOURCE_LABELS,
+  ENTRY_TYPE_LABELS,
   SOURCE_ROUTES,
   TERM_START,
   TIMELINE_SOURCES,
@@ -332,6 +333,10 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
         }} />
         <time style={{ ...mono, display: 'block', fontSize: 10, color: accent }}>
           {fmtDate(e.date)}
+          {/* Entry type always visible: the front tag below replaces the source
+              tag on front members, so without this a reader can't tell a story
+              from an EO or a ruling at a glance (Josh, August 29, 2026) */}
+          <span style={{ color: theme.ink, fontWeight: 600 }}> · {ENTRY_TYPE_LABELS[e.source]}</span>
           {e.alarm >= 5 ? (
             <span style={{
               background: accent, color: theme.bg, fontWeight: 600,
@@ -367,14 +372,16 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
             }}>
               {e.front.name}
             </span>
-          ) : (
+          ) : e.source === 'stories' ? (
+            // Only stories carry a loose-end tag; the other sources' type now
+            // sits in the date line, so a second source tag here was redundant
             <span style={{
               ...mono, fontSize: 9, letterSpacing: '0.08em', color: theme.dim,
               border: `1px solid ${theme.line}`, padding: '2px 8px', whiteSpace: 'nowrap',
             }}>
-              {e.source === 'stories' ? 'Loose end' : SOURCE_LABELS[e.source]}
+              Loose end
             </span>
-          )}
+          ) : null}
         </div>
       </div>,
     );

--- a/src/components/TrackerSpine.tsx
+++ b/src/components/TrackerSpine.tsx
@@ -279,14 +279,15 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
     const ym = e.date.slice(0, 7);
     if (ym !== lastYM) {
       rows.push(
+        // The month chip sits ON the spine (interrupting the line) so it reads
+        // as a segment boundary of the timeline, not a floating label.
         <div key={`m-${ym}`} aria-hidden="true" style={{
-          position: 'relative', zIndex: 2, padding: '16px 0',
+          position: 'relative', zIndex: 2, padding: '18px 0',
           textAlign: narrow ? 'left' : 'center',
-          ...(narrow ? { paddingLeft: 28 } : {}),
         }}>
           <span style={{
-            ...mono, fontSize: 10, letterSpacing: '0.12em', color: theme.ink,
-            background: theme.bg, border: `1px solid ${theme.line}`, padding: '4px 12px',
+            ...mono, fontSize: 11, fontWeight: 600, letterSpacing: '0.14em', color: theme.ink,
+            background: theme.bg2, border: `1px solid ${theme.dim}`, padding: '5px 14px',
           }}>
             {monthLabel(ym)}
           </span>
@@ -315,6 +316,14 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
             ? { position: 'relative', width: '50%', marginLeft: '50%', padding: '12px 0 12px 34px', textAlign: 'left' }
             : { position: 'relative', width: '50%', padding: '12px 34px 12px 0', textAlign: 'right' }}
       >
+        {/* Narrow: a short tick from the spine to the entry, so each row reads
+            as attached to the timeline instead of a plain left-padded list */}
+        {narrow && (
+          <span aria-hidden="true" style={{
+            position: 'absolute', left: 8, top: e.alarm >= 5 ? 18 + dotSize / 2 - 1 : 20 + dotSize / 2 - 1,
+            width: 18, height: 2, background: theme.line, zIndex: 1,
+          }} />
+        )}
         <span aria-hidden="true" style={{
           position: 'absolute', top: e.alarm >= 5 ? 18 : 20, zIndex: 3,
           width: dotSize, height: dotSize, borderRadius: '50%',
@@ -466,7 +475,9 @@ export function TrackerSpine({ standalone = false }: TrackerSpineProps) {
         <div style={{ position: 'relative', padding: '18px 0 34px' }}>
           <span aria-hidden="true" style={{
             position: 'absolute', top: 0, bottom: 0, width: 2, background: theme.line,
-            ...(narrow ? { left: 8 } : { left: '50%', transform: 'translateX(-50%)' }),
+            // translateX(-50%) in BOTH layouts: the dots center on x=8 (narrow)
+            // / 50% (wide), and without it the 2px line sat 1px off-center
+            ...(narrow ? { left: 8, transform: 'translateX(-50%)' } : { left: '50%', transform: 'translateX(-50%)' }),
           }} />
           {rows}
           {loaded && !refreshing && visible.length === 0 && (

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -39,6 +39,14 @@ export const SOURCE_LABELS: Record<TimelineSource, string> = {
   pardons: 'Pardons',
 };
 
+/** Per-entry type label on the spine (what a row IS: story, EO, ruling, pardon) */
+export const ENTRY_TYPE_LABELS: Record<TimelineSource, string> = {
+  stories: 'Story',
+  scotus: 'Decision',
+  eos: 'EO',
+  pardons: 'Pardon',
+};
+
 /** Route prefix for each source's detail page */
 export const SOURCE_ROUTES: Record<TimelineSource, string> = {
   stories: 'detail',

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -146,8 +146,9 @@ interface SourceSpec {
 // Key order is the chip display order (mockup rev 6).
 const SPECS: Record<TimelineSource, SourceSpec> = {
   stories: {
-    // v_tracker_stories (migration 112) bakes in status=active + enriched and
-    // adds front membership + the server-computed main_line column (ADO-554).
+    // v_tracker_stories (migration 112, rewritten in 113) bakes in status=active
+    // + enriched and adds front membership + the main_line column (ADO-554) —
+    // a STORED flag since ADO-570, so main_line=is.true is an index-only scan.
     table: 'v_tracker_stories',
     select: 'id,primary_headline,first_seen_at,alarm_level,severity,front_name,front_slug',
     base: `first_seen_at=gte.${TERM_START}`,
@@ -466,70 +467,34 @@ export interface TrackerTally {
   openFronts: number | null;
 }
 
-async function countRows(
-  url: string,
-  headers: Record<string, string>,
-  path: string,
-  signal?: AbortSignal,
-): Promise<number | null> {
+/**
+ * One GET on the precomputed tracker_stats row (migration 113, ADO-570).
+ * Replaces 9 HEAD count=exact requests, two of which scanned every active
+ * story on PROD (2s cold) and hid the tile until all of them resolved.
+ * The counts are as of refreshed_at (end of the last pipeline run). Any
+ * failure or a missing row yields nulls, which hides the tiles - never throws
+ * except on abort.
+ */
+export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTally> {
+  const empty: TrackerTally = { developments: null, alarm5Last30: null, openFronts: null };
+  const { url, anonKey } = await import('./supabase');
   try {
-    // HEAD + count=exact: the total arrives in Content-Range with zero body egress
-    const res = await fetch(`${url}/rest/v1/${path}`, {
-      method: 'HEAD',
-      headers: { ...headers, 'Prefer': 'count=exact' },
-      signal,
-    });
-    if (!res.ok) return null;
-    const range = res.headers.get('content-range') || '';
-    const total = Number(range.split('/')[1]);
-    return Number.isFinite(total) ? total : null;
+    const res = await fetch(
+      `${url}/rest/v1/tracker_stats?select=developments,alarm5_last30,open_fronts&id=eq.1&limit=1`,
+      { headers: { 'apikey': anonKey, 'Authorization': `Bearer ${anonKey}` }, signal },
+    );
+    if (!res.ok) return empty;
+    const rows: Raw[] = await res.json();
+    const row = rows[0];
+    if (!row) return empty;
+    const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+    return {
+      developments: num(row.developments),
+      alarm5Last30: num(row.alarm5_last30),
+      openFronts: num(row.open_fronts),
+    };
   } catch (err) {
     if ((err as Error).name === 'AbortError') throw err;
-    return null;
+    return empty;
   }
-}
-
-export async function fetchTrackerTally(signal?: AbortSignal): Promise<TrackerTally> {
-  const { url, anonKey } = await import('./supabase');
-  const headers = {
-    'apikey': anonKey,
-    'Authorization': `Bearer ${anonKey}`,
-  };
-
-  const since = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
-
-  // Both branches awaited in ONE Promise.all so a rejection (AbortError on
-  // navigation) from either side is observed by the caller -- Codex P1 on
-  // PR #131: the front count could otherwise reject unhandled while the
-  // per-source batch rejected first.
-  const [openFronts, perSource] = await Promise.all([
-    countRows(
-      url, headers,
-      'events?select=id&publish_state=eq.published&lifecycle=neq.resolved',
-      signal,
-    ),
-    Promise.all(TIMELINE_SOURCES.map(async source => {
-      const s = SPECS[source];
-      const alarm5 = s.alarm(5)!;
-      const [total, worst] = await Promise.all([
-        countRows(url, headers, `${s.table}?select=id&${s.base}`, signal),
-        countRows(
-          url, headers,
-          `${s.table}?select=id&${s.base}&${s.dateCol}=gte.${since}`
-          + `&and=${encodeURIComponent(`(${alarm5})`)}`,
-          signal,
-        ),
-      ]);
-      return { total, worst };
-    })),
-  ]);
-
-  const sum = (vals: (number | null)[]) =>
-    vals.every(v => v !== null) ? vals.reduce((a: number, b) => a + (b as number), 0) : null;
-
-  return {
-    developments: sum(perSource.map(p => p.total)),
-    alarm5Last30: sum(perSource.map(p => p.worst)),
-    openFronts,
-  };
 }


### PR DESCRIPTION
## Summary
- Migration 113 (already applied on PROD, refresh verified: 14,799 developments / 8 open fronts): stories.main_line stored flag + partial index, one-row tracker_stats tally, rule v1.1 isolated in v_tracker_main_line_rule, refresh_tracker_derived() applier
- Every pipeline workflow now ends with scripts/maintenance/refresh-tracker.js
- Frontend: tally reads one tracker_stats row instead of 9 HEAD count requests; spine stories filter on the stored main_line column (index-only scan)
- Spine rows show entry type (Story/EO/Decision/Pardon) in the date line
- UX (Josh-approved on TEST): month markers bolder + on-the-spine, mobile timeline alignment + connector ticks, "Developments logged" tile hidden, "Loose end" tag removed

## Deploy order (followed)
1. Migration 113 applied on PROD SQL Editor ✅ (September 1, 2026 02:30 UTC)
2. refresh_tracker_derived() + ANALYZE ✅ (tracker_stats verified)
3. This PR = the code cherry-picks (9da2ae5, 78d0329, 528a27b, 7263a2d from test)

## Verification
- tsc clean, vitest 174/174 on this branch
- TEST homepage eyeballed and approved by Josh (August 31, 2026)

ADO-570 (Testing -> closing after PROD verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UY1dVHRYnouLBEVfbsRPqz