### PR TITLE
fix(agents): SCOTUS impact level is valence, not magnitude; sync prompt files

### DIFF
--- a/docs/features/pardons-claude-agent/prompt-v1.md
+++ b/docs/features/pardons-claude-agent/prompt-v1.md
@@ -165,10 +165,6 @@ This ensures you have the latest prompt file for the branch this run is pinned t
 
 Read `public/shared/tone-system.json` from the repo. The `bannedOpenings`, `bannedPhrases`, `bannedPatterns`, and `writingRules` arrays are BINDING for all editorial output. Follow them alongside the Voice DOs/DON'Ts in this prompt.
 
-### Step A.2: Read Tone System Rules
-
-Read `public/shared/tone-system.json` from the repo. The `bannedOpenings`, `bannedPhrases`, `bannedPatterns`, and `writingRules` arrays are BINDING for all editorial output. Follow them alongside the Voice DOs/DON'Ts in this prompt.
-
 ### Step 1: Log Run Start
 
 Create a log entry to mark this run as started:

--- a/docs/features/scotus-claude-agent/prompt-v1.md
+++ b/docs/features/scotus-claude-agent/prompt-v1.md
@@ -233,7 +233,7 @@ For each case, read the opinion text and produce ALL of the following fields. Us
 
 | Field | Type | Constraints | How to determine |
 |-------|------|-------------|------------------|
-| `disposition` | text | Must be one of: `affirmed`, `reversed`, `vacated`, `remanded`, `reversed_and_remanded`, `vacated_and_remanded`, `affirmed_and_remanded`, `dismissed`, `granted`, `denied`, `GVR`, `other` | Read the judgment line (usually near the end of the syllabus or opinion) |
+| `disposition` | text | Must be one of: `affirmed`, `reversed`, `vacated`, `remanded`, `reversed_and_remanded`, `vacated_and_remanded`, `affirmed_and_remanded`, `dismissed`, `granted`, `denied`, `gvr`, `other` | Read the judgment line (usually near the end of the syllabus or opinion) |
 | `holding` | text | 1-3 sentences | The Court's central legal conclusion |
 | `vote_split` | text | Format: `N-N` (e.g., `9-0`, `5-4`) | Count majority vs dissenting justices |
 | `majority_author` | text or null | Last name only (e.g., `Jackson`, `Thomas`) | Listed at the top of the majority opinion. `null` for per curiam opinions. |
@@ -248,13 +248,13 @@ For each case, read the opinion text and produce ALL of the following fields. Us
 - "Reversed and remanded" → `reversed_and_remanded`
 - "Vacated and remanded" → `vacated_and_remanded`
 - "Affirmed in part, reversed in part, and remanded" → `affirmed_and_remanded`
-- "Granted, vacated, and remanded" (GVR) → `GVR`
+- "Granted, vacated, and remanded" (GVR) → `gvr`
 
 **Editorial fields** (quality matters  - these calibrate against gold set examples):
 
 | Field | Type | Guidance |
 |-------|------|----------|
-| `ruling_impact_level` | smallint 0-5 | 0=no impact, 1=minimal (narrow technical), 2=moderate (one area of law), 3=significant (changes practice), 4=major (landmark), 5=transformative (constitutional crisis, affects millions). Most cases are 2-3. Reserve 4-5 for genuinely landmark cases. |
+| `ruling_impact_level` | smallint 0-5 | **VALENCE, not magnitude.** Rate how much damage the ruling does to democratic norms, civil rights, checks on executive power, or ordinary people. Do NOT rate how landmark or historic the case is. A landmark ruling that blocks an abuse of power is a 0 (Democracy Wins) even if it is the biggest case of the term; a quiet ruling that hands the executive an unchecked power can be a 5. Scale: 0 = rights protected or an abuse blocked; 1 = a narrow or fragile win with limiting language; 2 = the Court punted, sidestepped, or trimmed a right at the margins; 3 = a real loss in one area of law or practice (institutional sabotage); 4 = major expansion of state or executive power, or a major loss of rights; 5 = constitutional crisis: precedent overruled to unlock executive power, rights stripped from millions. Most cases are 2-3. Reserve 4-5 for genuine damage, never for prominence. |
 | `ruling_label` | text | 3-8 word punchy label (e.g., "VA deference on benefit-of-the-doubt", "TikTok ban upheld as national security measure") |
 | `who_wins` | text | 1-2 sentences. Name the specific parties and explain what they gain. |
 | `who_loses` | text | 1-2 sentences. Name the specific parties and explain what they lose. |
@@ -276,6 +276,8 @@ For each case, read the opinion text and produce ALL of the following fields. Us
 This voice applies to `summary_spicy`, `why_it_matters`, `who_wins`, `who_loses`, `dissent_highlights`, and `ruling_label`. Factual fields (`disposition`, `vote_split`, `holding`, etc.) remain neutral and precise.
 
 **Tone calibration by `ruling_impact_level`:**
+
+The level is the valence of the outcome (how bad it is for democracy and rights), and the tone follows the level. A Level 0 is written as a win, whatever its historical weight.
 
 | Level | Label | Tone | Energy |
 |-------|-------|------|--------|
@@ -487,7 +489,7 @@ These 5 cases are fact-checked against SCOTUSblog, Wikipedia, and Oyez. Use them
 
 **Case:** Barrett v. United States, No. 24-5774 (Jan 14, 2026)
 **Type:** Compound disposition (`reversed_and_remanded`), unanimous 9-0, per Justice Jackson
-**Why selected:** Tests compound disposition detection and narrow-impact calibration
+**Why selected:** Tests compound disposition detection and Level 1 calibration (a narrow defendant win: credit where due, flag the asterisk)
 
 ```json
 {
@@ -497,7 +499,7 @@ These 5 cases are fact-checked against SCOTUSblog, Wikipedia, and Oyez. Use them
   "majority_author": "Jackson",
   "dissent_authors": [],
   "case_type": "merits",
-  "ruling_impact_level": 2,
+  "ruling_impact_level": 1,
   "ruling_label": "Double-conviction bar for single firearm act",
   "who_wins": "Dwayne Barrett, who faced dual convictions for a single act involving a firearm offense resulting in death",
   "who_loses": "Federal prosecutors, who lose the ability to stack convictions under both section 924(c)(1)(A)(i) and section 924(j) for the same conduct",
@@ -620,7 +622,7 @@ These 5 cases are fact-checked against SCOTUSblog, Wikipedia, and Oyez. Use them
 
 **Case:** Laboratory Corp. of America Holdings v. Davis, No. 24-304 (Jun 5, 2025)
 **Type:** Procedural case (certiorari dismissed), unusual 8-1 with Kavanaugh dissent
-**Why selected:** Tests handling of non-merits dispositions and low-confidence flagging
+**Why selected:** Tests handling of non-merits dispositions, low-confidence flagging, and Level 2 calibration (a punt is Judicial Sidestepping, not a win)
 
 ```json
 {
@@ -630,7 +632,7 @@ These 5 cases are fact-checked against SCOTUSblog, Wikipedia, and Oyez. Use them
   "majority_author": null,
   "dissent_authors": ["Kavanaugh"],
   "case_type": "procedural",
-  "ruling_impact_level": 1,
+  "ruling_impact_level": 2,
   "ruling_label": "Certiorari dismissed as improvidently granted",
   "who_wins": "No clear winner  - case dismissed without a merits ruling",
   "who_loses": "No clear loser  - the underlying circuit decision stands by default",


### PR DESCRIPTION
## What
- `docs/features/scotus-claude-agent/prompt-v1.md`: `ruling_impact_level` is now defined once as **valence** (how much damage the ruling does to democracy and rights), never magnitude. The old field table said landmark = 4-5 while the tone table said 0 = Democracy Wins, so the June run rated by magnitude and the September 1 re-run rated by valence. Josh ruled valence on August 31, 2026 (birthright citizenship win = 0 even though landmark). Gold examples recalibrated to match: Barrett (narrow defendant win) 2 to 1, LabCorp (DIG punt) 1 to 2.
- Also restores the `gvr` lowercase normalization (PR #115) that main had lost, and drops the duplicated Step A.2 in the pardons prompt.

## Why now
The SCOTUS enrichment routine reads main at run time (16:00 UTC weekdays). Until this merges the semantics can flip again on the next run.

## Verification
Docs-only prompt change. Diff reviewed line by line; both files now match the test branch byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSovCa5uDWjRwzL7TDmqDW